### PR TITLE
Add Linux/Avalonia version

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,14 @@ Session DPS = your damage ÷ time actually **in combat**, so downtime never dilu
 
 ## For developers
 
-- `src/EQBuddy` — WPF app (.NET 10, `net10.0-windows`). Build: `dotnet build -c Release`.
+- `src/EQBuddy` — WPF app (.NET 10, `net10.0-windows`). Build on Windows:
+  `dotnet build src/EQBuddy/EQBuddy.csproj -c Release`. From non-Windows machines,
+  add `-p:EnableWindowsTargeting=true`.
+- `src/EQBuddy.Avalonia` — cross-platform Avalonia app (.NET 10). Build:
+  `dotnet build src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj -c Release`.
+- `src/EQBuddy.Core` — shared parser, watcher, settings, update, and session-stat logic.
+  The existing Core source files still live under `src/EQBuddy/Core` so the diff stays
+  easy to review; both UI projects consume them through this project.
 - `src/EQBuddy/Core/LogParser.cs` — one regex per log-line type; add new patterns here.
 - `src/EQBuddy/Core/SessionStats.cs` — aggregation + DPS fight tracking + session rollover.
 - `src/EQBuddy/Core/LogWatcher.cs` — file tailing (500 ms polls, offset-based, truncation-safe).

--- a/src/EQBuddy.Avalonia/App.axaml
+++ b/src/EQBuddy.Avalonia/App.axaml
@@ -1,0 +1,7 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="EQBuddy.Avalonia.App">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/src/EQBuddy.Avalonia/App.cs
+++ b/src/EQBuddy.Avalonia/App.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace EQBuddy.Avalonia;
+
+public sealed class App : Application
+{
+    private static readonly string ErrorLog = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "EQBuddy", "error.log");
+
+    public static void LogError(object? ex)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(ErrorLog)!);
+            File.AppendAllText(ErrorLog, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {ex}\n\n");
+        }
+        catch { }
+    }
+
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        AppDomain.CurrentDomain.UnhandledException += (_, args) => LogError(args.ExceptionObject);
+        TaskScheduler.UnobservedTaskException += (_, args) =>
+        {
+            LogError(args.Exception);
+            args.SetObserved();
+        };
+
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            desktop.MainWindow = new MainWindow();
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/EQBuddy.Avalonia/AppTheme.cs
+++ b/src/EQBuddy.Avalonia/AppTheme.cs
@@ -1,0 +1,118 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace EQBuddy.Avalonia;
+
+internal static class AppTheme
+{
+    public static readonly IBrush PanelBrush = Brush("#26FFFFFF");
+    public static readonly IBrush PanelHoverBrush = Brush("#33FFD98C");
+    public static readonly IBrush BorderBrush = Brush("#66C9A227");
+    public static readonly IBrush TextBrush = Brush("#FFEDE4D3");
+    public static readonly IBrush DimBrush = Brush("#FF9C927F");
+    public static readonly IBrush AccentBrush = Brush("#FFE3B341");
+    public static readonly IBrush GoodBrush = Brush("#FF7FBF5F");
+    public static readonly IBrush BadBrush = Brush("#FFD9634F");
+    public static readonly IBrush WarnBrush = Brush("#FFE0A030");
+    public static readonly IBrush BgBrush = Brush("#F21C1917");
+
+    public static IBrush BgWithOpacity(double opacity) =>
+        new SolidColorBrush(Color.FromArgb((byte)(Math.Clamp(opacity, 0.15, 1.0) * 255), 0x1C, 0x19, 0x17));
+
+    public static Button IconButton(string text, string tip)
+    {
+        var button = new Button
+        {
+            Content = text,
+            Background = Brushes.Transparent,
+            Foreground = DimBrush,
+            BorderThickness = new Thickness(0),
+            Padding = new Thickness(6, 2),
+            FontSize = 13,
+            Cursor = new Cursor(StandardCursorType.Hand),
+            MinWidth = 26,
+            MinHeight = 24,
+        };
+        ToolTip.SetTip(button, tip);
+        return button;
+    }
+
+    public static ToggleButton IconToggle(string text, string tip)
+    {
+        var button = new ToggleButton
+        {
+            Content = text,
+            Background = Brushes.Transparent,
+            Foreground = AccentBrush,
+            BorderThickness = new Thickness(0),
+            Padding = new Thickness(6, 2),
+            FontSize = 13,
+            Cursor = new Cursor(StandardCursorType.Hand),
+            MinWidth = 26,
+            MinHeight = 24,
+        };
+        ToolTip.SetTip(button, tip);
+        return button;
+    }
+
+    public static ToggleButton StarToggle(string key, string tip)
+    {
+        var button = new ToggleButton
+        {
+            Tag = key,
+            Content = "☆",
+            Background = Brushes.Transparent,
+            Foreground = DimBrush,
+            BorderThickness = new Thickness(0),
+            FontSize = 12,
+            Margin = new Thickness(8, 0, 0, 0),
+            Cursor = new Cursor(StandardCursorType.Hand),
+        };
+        ToolTip.SetTip(button, tip);
+        return button;
+    }
+
+    public static TextBlock DimText(string text, Thickness? margin = null) => new()
+    {
+        Text = text,
+        FontSize = 11,
+        Foreground = DimBrush,
+        TextWrapping = TextWrapping.Wrap,
+        Margin = margin ?? default,
+    };
+
+    public static TextBlock StatValue(string text = "") => new()
+    {
+        Text = text,
+        FontWeight = FontWeight.SemiBold,
+        Foreground = AccentBrush,
+    };
+
+    public static Expander Section(Control header, Control content) => new()
+    {
+        Header = header,
+        Content = new Border
+        {
+            Padding = new Thickness(10, 0, 10, 8),
+            Child = content,
+        },
+        Background = PanelBrush,
+        Foreground = TextBrush,
+        Margin = new Thickness(0, 2, 0, 0),
+        Padding = new Thickness(10, 7),
+    };
+
+    public static TextBlock Heading(string text, IBrush? brush = null) => new()
+    {
+        Text = text,
+        FontSize = 11,
+        FontWeight = FontWeight.SemiBold,
+        Foreground = brush ?? AccentBrush,
+    };
+
+    public static IBrush Brush(string color) => new SolidColorBrush(Color.Parse(color));
+}

--- a/src/EQBuddy.Avalonia/AppTheme.cs
+++ b/src/EQBuddy.Avalonia/AppTheme.cs
@@ -92,19 +92,7 @@ internal static class AppTheme
         Foreground = AccentBrush,
     };
 
-    public static Expander Section(Control header, Control content) => new()
-    {
-        Header = header,
-        Content = new Border
-        {
-            Padding = new Thickness(10, 0, 10, 8),
-            Child = content,
-        },
-        Background = PanelBrush,
-        Foreground = TextBrush,
-        Margin = new Thickness(0, 2, 0, 0),
-        Padding = new Thickness(10, 7),
-    };
+    public static SectionPanel Section(Control header, Control content) => new(header, content);
 
     public static TextBlock Heading(string text, IBrush? brush = null) => new()
     {
@@ -115,4 +103,73 @@ internal static class AppTheme
     };
 
     public static IBrush Brush(string color) => new SolidColorBrush(Color.Parse(color));
+}
+
+internal sealed class SectionPanel : Border
+{
+    private readonly Border _body;
+    private readonly TextBlock _chevron;
+
+    public bool IsExpanded
+    {
+        get => _body.IsVisible;
+        set
+        {
+            _body.IsVisible = value;
+            _chevron.Text = value ? "v" : ">";
+        }
+    }
+
+    public SectionPanel(Control header, Control content)
+    {
+        Background = AppTheme.PanelBrush;
+        CornerRadius = new CornerRadius(6);
+        Margin = new Thickness(0, 2, 0, 0);
+
+        _chevron = new TextBlock
+        {
+            Text = ">",
+            Foreground = AppTheme.DimBrush,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(6, 0, 0, 0),
+        };
+
+        var headerGrid = new Grid();
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        headerGrid.Children.Add(header);
+        Grid.SetColumn(_chevron, 1);
+        headerGrid.Children.Add(_chevron);
+
+        var headerBorder = new Border
+        {
+            Background = Brushes.Transparent,
+            CornerRadius = new CornerRadius(6),
+            Padding = new Thickness(10, 7),
+            Cursor = new Cursor(StandardCursorType.Hand),
+            Child = headerGrid,
+        };
+        headerBorder.PointerPressed += (_, args) =>
+        {
+            if (args.Source is Button or ToggleButton) return;
+            IsExpanded = !IsExpanded;
+            args.Handled = true;
+        };
+
+        _body = new Border
+        {
+            Padding = new Thickness(10, 0, 10, 8),
+            Child = content,
+            IsVisible = false,
+        };
+
+        Child = new StackPanel
+        {
+            Children =
+            {
+                headerBorder,
+                _body,
+            },
+        };
+    }
 }

--- a/src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj
+++ b/src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>EQBuddy.Avalonia</AssemblyName>
+    <RootNamespace>EQBuddy.Avalonia</RootNamespace>
+    <Version>1.5.1</Version>
+    <ApplicationIcon>..\EQBuddy\Assets\EQBuddy.ico</ApplicationIcon>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EQBuddy.Core\EQBuddy.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -1,0 +1,921 @@
+using System.Diagnostics;
+using System.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using EQBuddy.Core;
+
+namespace EQBuddy.Avalonia;
+
+public sealed class MainWindow : Window
+{
+    private readonly AppSettings _settings = AppSettings.Load();
+    private readonly SessionStats _stats = new();
+    private readonly LogWatcher _watcher;
+    private readonly DispatcherTimer _uiTimer;
+    private readonly Border _root = new();
+    private readonly Grid _miniRoot = new();
+    private readonly StackPanel _miniChips = new() { Orientation = Orientation.Horizontal };
+    private readonly Ellipse _miniDot = Dot();
+    private readonly StackPanel _normalRoot = new() { Width = 320 };
+    private readonly Ellipse _statusDot = Dot();
+    private readonly TextBlock _charLabel = AppTheme.DimText("looking for a character...");
+    private readonly ScrollViewer _sectionScroll = new();
+    private readonly Border _logBanner = Banner(AppTheme.WarnBrush);
+    private readonly Border _updateBanner = Banner(AppTheme.GoodBrush);
+    private readonly TextBlock _updateText = new() { FontSize = 12, Foreground = AppTheme.GoodBrush, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap };
+    private readonly TextBlock _zoneText = AppTheme.DimText("-");
+    private readonly TextBlock _sessionText = AppTheme.DimText("session 0:00");
+    private readonly TextBlock _combatHeader = AppTheme.StatValue("0 dps");
+    private readonly TextBlock _healingHeader = AppTheme.StatValue("0 hps");
+    private readonly TextBlock _killsHeader = AppTheme.StatValue("0");
+    private readonly TextBlock _lootHeader = AppTheme.StatValue("0 items");
+    private readonly TextBlock _moneyHeader = AppTheme.StatValue("0c");
+    private readonly TextBlock _progressHeader = AppTheme.StatValue("0% xp");
+    private readonly TextBlock _factionHeader = AppTheme.StatValue("-");
+    private readonly TextBlock _miscHeader = AppTheme.StatValue("0 deaths");
+    private readonly TextBlock _combatSummary = AppTheme.DimText("");
+    private readonly TextBlock _healingSummary = AppTheme.DimText("");
+    private readonly TextBlock _killsSummary = AppTheme.DimText("");
+    private readonly TextBlock _moneySummary = AppTheme.DimText("");
+    private readonly TextBlock _progressSummary = AppTheme.DimText("");
+    private readonly ItemsControl _damageSourceList = new();
+    private readonly ItemsControl _damageTakenList = new();
+    private readonly ItemsControl _healSpellList = new();
+    private readonly ItemsControl _healerList = new();
+    private readonly ItemsControl _killList = new();
+    private readonly ItemsControl _partyKillList = new();
+    private readonly ItemsControl _lootList = new();
+    private readonly ItemsControl _craftedList = new();
+    private readonly ItemsControl _soldList = new();
+    private readonly ItemsControl _skillList = new();
+    private readonly ItemsControl _factionList = new();
+    private readonly ItemsControl _deathList = new();
+    private readonly ItemsControl _zoneList = new();
+    private readonly TextBlock _healSpellsLabel = AppTheme.Heading("Heals cast", AppTheme.GoodBrush);
+    private readonly StackPanel _healSortBar = new() { Orientation = Orientation.Horizontal };
+    private readonly TextBlock _healersLabel = AppTheme.Heading("Healed by", AppTheme.GoodBrush);
+    private readonly TextBlock _partyKillsLabel = AppTheme.Heading("Group kills");
+    private readonly TextBlock _craftedLabel = AppTheme.Heading("Created by merging");
+    private readonly TextBlock _soldLabel = AppTheme.Heading("Sold to merchants");
+    private readonly ToggleButton _pinBtn = AppTheme.IconToggle("P", "Always on top");
+    private readonly Button _gearBtn = AppTheme.IconButton("...", "Settings");
+    private readonly Dictionary<string, ToggleButton> _stars = new();
+    private readonly List<Expander> _sections = new();
+    private TextBlock _dmgOutSortTotal = null!;
+    private TextBlock _dmgOutSortHits = null!;
+    private TextBlock _dmgOutSortAvg = null!;
+    private TextBlock _dmgInSortTotal = null!;
+    private TextBlock _dmgInSortHits = null!;
+    private TextBlock _dmgInSortAvg = null!;
+    private TextBlock _healSortTotal = null!;
+    private TextBlock _healSortHits = null!;
+    private TextBlock _healSortAvg = null!;
+    private DateTime _lastCharScan = DateTime.MinValue;
+    private DateTime _lastJanitorRun = DateTime.MinValue;
+    private DateTime _lastUpdateCheck = DateTime.MinValue;
+    private UpdateInfo? _pendingUpdate;
+    private DateTime _upToDateNoticeUntil = DateTime.MinValue;
+    private bool _installingUpdate;
+    private OptionsWindow? _optionsWindow;
+    private StatSort _dmgOutSort = StatSort.Total;
+    private StatSort _dmgInSort = StatSort.Total;
+    private StatSort _healSort = StatSort.Total;
+
+    private static readonly string[] MiniStatOrder = ["kills", "dps", "hps", "loot", "money", "xp", "deaths"];
+
+    private enum StatSort { Total, Hits, Avg }
+
+    public MainWindow()
+    {
+        _watcher = new LogWatcher(_stats);
+        Title = "EQBuddy";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        WindowDecorations = global::Avalonia.Controls.WindowDecorations.None;
+        TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
+        Background = Brushes.Transparent;
+        Topmost = _settings.AlwaysOnTop;
+        ShowInTaskbar = true;
+        CanResize = false;
+        Opacity = _settings.Opacity;
+        Content = BuildRoot();
+
+        if (_settings.LogFolder is { } saved && !Directory.Exists(saved))
+            _settings.LogFolder = null;
+        _settings.LogFolder ??= LogWatcher.FindDefaultLogFolder();
+        RestorePosition();
+        ApplyUiScale(_settings.UiScale);
+        ApplyBackgroundOpacity(_settings.BackgroundOpacity);
+        _pinBtn.IsChecked = _settings.AlwaysOnTop;
+        foreach (var (key, star) in _stars)
+            star.IsChecked = _settings.MiniStats.Contains(key);
+        UpdateStarVisuals();
+        SetMode(_settings.Minimized);
+        FollowActiveCharacter();
+
+        if (_settings.LogFolder is { } lf)
+            Task.Run(() =>
+            {
+                EqConfig.EnsureLoggingEnabled(lf);
+                EqConfig.TruncateStaleLogs(lf, SessionStats.SessionGap);
+            });
+
+        _uiTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _uiTimer.Tick += (_, _) => RefreshUi();
+        _uiTimer.Start();
+    }
+
+    public double UiScale => _settings.UiScale;
+    public double WidgetOpacity => Opacity;
+    public double BackgroundOpacityValue => _settings.BackgroundOpacity;
+
+    public void SetUiScale(double scale)
+    {
+        _settings.UiScale = Math.Clamp(scale, 0.5, 2.0);
+        ApplyUiScale(_settings.UiScale);
+        _settings.Save();
+    }
+
+    public void SetWindowOpacity(double opacity)
+    {
+        _settings.Opacity = Math.Clamp(opacity, 0.3, 1.0);
+        Opacity = _settings.Opacity;
+        _settings.Save();
+    }
+
+    public void SetBackgroundOpacity(double opacity)
+    {
+        _settings.BackgroundOpacity = Math.Clamp(opacity, 0.15, 1.0);
+        ApplyBackgroundOpacity(_settings.BackgroundOpacity);
+        _settings.Save();
+    }
+
+    private Control BuildRoot()
+    {
+        _root.CornerRadius = new CornerRadius(10);
+        _root.BorderBrush = AppTheme.BorderBrush;
+        _root.BorderThickness = new Thickness(1);
+        _root.ContextMenu = BuildContextMenu();
+        _root.PointerPressed += OnDrag;
+        _root.Child = new StackPanel
+        {
+            Margin = new Thickness(10),
+            Children =
+            {
+                BuildMiniRoot(),
+                BuildNormalRoot(),
+            },
+        };
+        return _root;
+    }
+
+    private Control BuildMiniRoot()
+    {
+        _miniRoot.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        _miniRoot.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        _miniRoot.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        _miniRoot.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        _miniDot.Margin = new Thickness(2, 0, 8, 0);
+        _miniRoot.Children.Add(_miniDot);
+        Grid.SetColumn(_miniChips, 1);
+        _miniRoot.Children.Add(_miniChips);
+        var restore = AppTheme.IconButton("[]", "Expand");
+        restore.Click += (_, _) => SetMode(false);
+        restore.Margin = new Thickness(8, 0, 0, 0);
+        Grid.SetColumn(restore, 2);
+        _miniRoot.Children.Add(restore);
+        var close = AppTheme.IconButton("x", "Close");
+        close.Click += (_, _) => Close();
+        Grid.SetColumn(close, 3);
+        _miniRoot.Children.Add(close);
+        return _miniRoot;
+    }
+
+    private Control BuildNormalRoot()
+    {
+        _normalRoot.Children.Add(BuildTitleBar());
+        _logBanner.Child = new TextBlock
+        {
+            Text = "Logging looks off. Type /log in the game's chat window. EQBuddy enables it automatically for future game launches.",
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 12,
+            Foreground = AppTheme.WarnBrush,
+        };
+        _logBanner.Margin = new Thickness(0, 8, 0, 0);
+        _normalRoot.Children.Add(_logBanner);
+        _updateBanner.Child = _updateText;
+        _updateBanner.Margin = new Thickness(0, 8, 0, 0);
+        _updateBanner.Cursor = new Cursor(StandardCursorType.Hand);
+        _updateBanner.PointerPressed += OnUpdateBannerClick;
+        _normalRoot.Children.Add(_updateBanner);
+        _normalRoot.Children.Add(BuildSessionLine());
+        _sectionScroll.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
+        _sectionScroll.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+        _sectionScroll.Content = BuildSections();
+        _normalRoot.Children.Add(_sectionScroll);
+        return _normalRoot;
+    }
+
+    private Control BuildTitleBar()
+    {
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+        for (var i = 0; i < 5; i++) grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        var title = new StackPanel { Orientation = Orientation.Horizontal, VerticalAlignment = VerticalAlignment.Center };
+        _statusDot.Margin = new Thickness(2, 0, 7, 0);
+        title.Children.Add(_statusDot);
+        title.Children.Add(new TextBlock { Text = "EQBuddy", FontWeight = FontWeight.Bold, FontSize = 14, Foreground = AppTheme.AccentBrush });
+        grid.Children.Add(title);
+        _charLabel.Margin = new Thickness(10, 0, 6, 0);
+        _charLabel.TextTrimming = TextTrimming.CharacterEllipsis;
+        Grid.SetColumn(_charLabel, 1);
+        grid.Children.Add(_charLabel);
+        _gearBtn.Click += OnGear;
+        Grid.SetColumn(_gearBtn, 2);
+        grid.Children.Add(_gearBtn);
+        _pinBtn.Click += OnPinChanged;
+        Grid.SetColumn(_pinBtn, 3);
+        grid.Children.Add(_pinBtn);
+        var reset = AppTheme.IconButton("R", "Reset session stats");
+        reset.Click += (_, _) => _stats.Reset();
+        Grid.SetColumn(reset, 4);
+        grid.Children.Add(reset);
+        var mini = AppTheme.IconButton("-", "Minimize to dashboard");
+        mini.Click += (_, _) => SetMode(true);
+        Grid.SetColumn(mini, 5);
+        grid.Children.Add(mini);
+        var close = AppTheme.IconButton("x", "Close");
+        close.Click += (_, _) => Close();
+        Grid.SetColumn(close, 6);
+        grid.Children.Add(close);
+        return grid;
+    }
+
+    private Control BuildSessionLine()
+    {
+        var grid = new Grid { Margin = new Thickness(2, 8, 2, 4) };
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        grid.Children.Add(_zoneText);
+        Grid.SetColumn(_sessionText, 1);
+        grid.Children.Add(_sessionText);
+        return grid;
+    }
+
+    private Control BuildSections()
+    {
+        var panel = new StackPanel();
+        AddSection(panel, "dps", "Combat", _combatHeader, BuildCombatSection(), "Show DPS in mini dashboard");
+        AddSection(panel, "hps", "Healing", _healingHeader, BuildHealingSection(), "Show HPS in mini dashboard");
+        AddSection(panel, "kills", "Kills", _killsHeader, BuildKillsSection(), "Show kills in mini dashboard");
+        AddSection(panel, "loot", "Loot", _lootHeader, BuildLootSection(), "Show loot count in mini dashboard");
+        AddSection(panel, "money", "Money", _moneyHeader, BuildMoneySection(), "Show money in mini dashboard");
+        AddSection(panel, "xp", "Progress", _progressHeader, BuildProgressSection(), "Show XP in mini dashboard");
+        panel.Children.Add(TrackSection(AppTheme.Section(Header("Faction", _factionHeader), _factionList)));
+        AddSection(panel, "deaths", "Travels & Deaths", _miscHeader, BuildMiscSection(), "Show deaths in mini dashboard");
+        return panel;
+    }
+
+    private void AddSection(Panel panel, string starKey, string title, TextBlock value, Control content, string tip)
+    {
+        var star = AppTheme.StarToggle(starKey, tip);
+        star.Click += OnStarChanged;
+        _stars[starKey] = star;
+        panel.Children.Add(TrackSection(AppTheme.Section(Header(title, value, star), content)));
+    }
+
+    private Expander TrackSection(Expander section)
+    {
+        _sections.Add(section);
+        return section;
+    }
+
+    private static Grid Header(string title, TextBlock value, ToggleButton? star = null)
+    {
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        if (star is not null) grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        grid.Children.Add(new TextBlock { Text = title, FontSize = 13, Foreground = AppTheme.TextBrush });
+        Grid.SetColumn(value, 1);
+        grid.Children.Add(value);
+        if (star is not null)
+        {
+            Grid.SetColumn(star, 2);
+            grid.Children.Add(star);
+        }
+        return grid;
+    }
+
+    private Control BuildCombatSection()
+    {
+        var panel = new StackPanel();
+        _combatSummary.Margin = new Thickness(0, 2, 0, 4);
+        panel.Children.Add(_combatSummary);
+        panel.Children.Add(SortHeader("Damage by attack", out _dmgOutSortTotal, out _dmgOutSortHits, out _dmgOutSortAvg, OnSortDmgOut));
+        panel.Children.Add(_damageSourceList);
+        panel.Children.Add(SortHeader("Damage taken from", out _dmgInSortTotal, out _dmgInSortHits, out _dmgInSortAvg, OnSortDmgIn));
+        panel.Children.Add(_damageTakenList);
+        return panel;
+    }
+
+    private Control BuildHealingSection()
+    {
+        var panel = new StackPanel();
+        _healingSummary.Margin = new Thickness(0, 2, 0, 4);
+        panel.Children.Add(_healingSummary);
+        var sort = SortHeader("Heals cast", out _healSortTotal, out _healSortHits, out _healSortAvg, OnSortHeal, _healSpellsLabel, _healSortBar);
+        panel.Children.Add(sort);
+        panel.Children.Add(_healSpellList);
+        panel.Children.Add(_healersLabel);
+        panel.Children.Add(_healerList);
+        return panel;
+    }
+
+    private Control BuildKillsSection()
+    {
+        var panel = new StackPanel();
+        _killsSummary.Margin = new Thickness(0, 2, 0, 4);
+        panel.Children.Add(_killsSummary);
+        panel.Children.Add(_killList);
+        _partyKillsLabel.Margin = new Thickness(0, 6, 0, 0);
+        panel.Children.Add(_partyKillsLabel);
+        panel.Children.Add(_partyKillList);
+        return panel;
+    }
+
+    private Control BuildLootSection()
+    {
+        var panel = new StackPanel();
+        panel.Children.Add(_lootList);
+        _craftedLabel.Margin = new Thickness(0, 6, 0, 0);
+        panel.Children.Add(_craftedLabel);
+        panel.Children.Add(_craftedList);
+        return panel;
+    }
+
+    private Control BuildMoneySection()
+    {
+        var panel = new StackPanel();
+        panel.Children.Add(_moneySummary);
+        _soldLabel.Margin = new Thickness(0, 6, 0, 0);
+        panel.Children.Add(_soldLabel);
+        panel.Children.Add(_soldList);
+        return panel;
+    }
+
+    private Control BuildProgressSection()
+    {
+        var panel = new StackPanel();
+        _progressSummary.Margin = new Thickness(0, 2, 0, 4);
+        panel.Children.Add(_progressSummary);
+        panel.Children.Add(AppTheme.Heading("Skill-ups"));
+        panel.Children.Add(_skillList);
+        return panel;
+    }
+
+    private Control BuildMiscSection()
+    {
+        var panel = new StackPanel();
+        panel.Children.Add(AppTheme.Heading("Deaths", AppTheme.BadBrush));
+        panel.Children.Add(_deathList);
+        panel.Children.Add(AppTheme.Heading("Zones visited"));
+        panel.Children.Add(_zoneList);
+        return panel;
+    }
+
+    private static Control SortHeader(string title, out TextBlock total, out TextBlock hits, out TextBlock avg,
+        EventHandler<PointerPressedEventArgs> handler, TextBlock? titleBlock = null, StackPanel? sortBar = null)
+    {
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        grid.Children.Add(titleBlock ?? AppTheme.Heading(title));
+        sortBar ??= new StackPanel { Orientation = Orientation.Horizontal };
+        sortBar.HorizontalAlignment = HorizontalAlignment.Right;
+        sortBar.Children.Add(AppTheme.DimText("sort:", new Thickness(0, 0, 4, 0)));
+        total = SortLink("total", "total", handler, selected: true);
+        hits = SortLink(title.Contains("Heal", StringComparison.OrdinalIgnoreCase) ? "casts" : "hits", "hits", handler);
+        avg = SortLink("avg", "avg", handler);
+        sortBar.Children.Add(total);
+        sortBar.Children.Add(hits);
+        sortBar.Children.Add(avg);
+        Grid.SetColumn(sortBar, 1);
+        grid.Children.Add(sortBar);
+        return grid;
+    }
+
+    private static TextBlock SortLink(string text, string tag, EventHandler<PointerPressedEventArgs> handler, bool selected = false)
+    {
+        var link = new TextBlock
+        {
+            Text = text,
+            Tag = tag,
+            FontSize = 10,
+            Foreground = selected ? AppTheme.AccentBrush : AppTheme.DimBrush,
+            Cursor = new Cursor(StandardCursorType.Hand),
+            Margin = new Thickness(text == "total" ? 0 : 6, 0, 0, 0),
+        };
+        link.PointerPressed += handler;
+        return link;
+    }
+
+    private ContextMenu BuildContextMenu()
+    {
+        var menu = new ContextMenu();
+        var version = new MenuItem { Header = $"EQBuddy v{UpdateChecker.CurrentVersion}", IsEnabled = false };
+        var check = new MenuItem { Header = "Check for updates" };
+        check.Click += (_, _) => { _lastUpdateCheck = DateTime.Now; CheckForUpdates(manual: true); };
+        var options = new MenuItem { Header = "Options... (size, opacity)" };
+        options.Click += OnOptions;
+        var choose = new MenuItem { Header = "Choose log folder..." };
+        choose.Click += OnChooseLogFolder;
+        var detect = new MenuItem { Header = "Auto-detect log folder" };
+        detect.Click += (_, _) =>
+        {
+            _settings.LogFolder = LogWatcher.FindDefaultLogFolder();
+            _settings.Save();
+            _lastCharScan = DateTime.MinValue;
+            FollowActiveCharacter();
+        };
+        menu.Items.Add(version);
+        menu.Items.Add(check);
+        menu.Items.Add(options);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(choose);
+        menu.Items.Add(detect);
+        return menu;
+    }
+
+    private void RestorePosition()
+    {
+        if (!double.IsNaN(_settings.WindowLeft))
+            Position = new PixelPoint((int)_settings.WindowLeft, (int)_settings.WindowTop);
+    }
+
+    private void ApplyUiScale(double scale) =>
+        _root.RenderTransform = Math.Abs(scale - 1.0) < 0.001 ? null : new ScaleTransform(scale, scale);
+
+    private void ApplyBackgroundOpacity(double opacity) => _root.Background = AppTheme.BgWithOpacity(opacity);
+
+    private async void OnChooseLogFolder(object? sender, EventArgs e)
+    {
+        var folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Pick the EverQuest Legends Logs folder",
+            AllowMultiple = false,
+        });
+        var picked = folders.FirstOrDefault()?.TryGetLocalPath();
+        if (picked is null) return;
+        var logsSub = System.IO.Path.Combine(picked, "Logs");
+        if (!Directory.EnumerateFiles(picked, "eqlog_*.txt").Any() && Directory.Exists(logsSub))
+            picked = logsSub;
+        _settings.LogFolder = picked;
+        _settings.Save();
+        _lastCharScan = DateTime.MinValue;
+        FollowActiveCharacter();
+    }
+
+    private void FollowActiveCharacter()
+    {
+        if (_settings.LogFolder is null)
+        {
+            _charLabel.Text = "logs not found - right-click, Choose log folder";
+            return;
+        }
+        var active = LogWatcher.MostRecentlyActive(_settings.LogFolder);
+        if (active is null)
+        {
+            _charLabel.Text = "waiting for a character to log in...";
+            return;
+        }
+        if (!string.Equals(active.FilePath, _watcher.CurrentPath, StringComparison.OrdinalIgnoreCase))
+        {
+            _watcher.Select(active.FilePath);
+            _charLabel.Text = active.Display;
+        }
+    }
+
+    private void RefreshUi()
+    {
+        if (DateTime.Now - _lastCharScan > TimeSpan.FromSeconds(5))
+        {
+            _lastCharScan = DateTime.Now;
+            FollowActiveCharacter();
+        }
+        if (DateTime.Now - _lastUpdateCheck > TimeSpan.FromHours(6))
+        {
+            _lastUpdateCheck = DateTime.Now;
+            CheckForUpdates(manual: false);
+        }
+        if (_settings.LogFolder is { } folder && DateTime.Now - _lastJanitorRun > TimeSpan.FromMinutes(10))
+        {
+            _lastJanitorRun = DateTime.Now;
+            Task.Run(() =>
+            {
+                EqConfig.EnsureLoggingEnabled(folder);
+                EqConfig.TruncateStaleLogs(folder, SessionStats.SessionGap);
+            });
+        }
+
+        UpdateLoggingStatus();
+        if (_upToDateNoticeUntil != DateTime.MinValue && DateTime.Now > _upToDateNoticeUntil && _pendingUpdate is null && !_installingUpdate)
+        {
+            _updateBanner.IsVisible = false;
+            _upToDateNoticeUntil = DateTime.MinValue;
+        }
+        if (_watcher.LastError is { } err) App.LogError(err);
+
+        var s = _stats.Snapshot();
+        if (_miniRoot.IsVisible) UpdateMiniChips(s);
+        _zoneText.Text = s.CurrentZone.Length > 0 ? s.CurrentZone : "-";
+        _sessionText.Text = s.SessionStart is { } start
+            ? $"session {(int)s.Elapsed.TotalHours}:{s.Elapsed.Minutes:D2} (since {start:h:mm tt})"
+            : "waiting for log activity...";
+        _combatHeader.Text = s.CurrentDps > 0 ? $"{s.SessionDps:0} dps (now {s.CurrentDps:0})" : $"{s.SessionDps:0} dps";
+        _killsHeader.Text = s.PartyKillCount > 0 ? $"{s.YourKillCount} (+{s.PartyKillCount})" : $"{s.YourKillCount}";
+        _lootHeader.Text = s.CraftedTotal > 0 ? $"{s.LootTotal} items (+{s.CraftedTotal} made)" : $"{s.LootTotal} item{(s.LootTotal == 1 ? "" : "s")}";
+        _moneyHeader.Text = StatsSnapshot.FormatCoin(s.Copper);
+        _progressHeader.Text = $"{s.XpPercent:0.0}% xp" + (s.Levels.Count > 0 ? $", +{s.Levels.Count} lvl" : "") + (s.AaGained > 0 ? $", +{s.AaGained} aa" : "");
+        _factionHeader.Text = s.Faction.Count > 0 ? $"{s.Faction.Count} factions" : "-";
+        _miscHeader.Text = $"{s.Deaths.Count} death{(s.Deaths.Count == 1 ? "" : "s")}";
+        RefreshExpandedSections(s);
+    }
+
+    private void RefreshExpandedSections(StatsSnapshot s)
+    {
+        if (_sections[0].IsExpanded)
+        {
+            var acc = s.HitCount + s.MissCount > 0 ? (double)s.HitCount / (s.HitCount + s.MissCount) * 100 : 0;
+            var critRate = s.HitCount > 0 ? (double)s.CritCount / s.HitCount * 100 : 0;
+            var incomingSwings = s.AvoidedIncoming + s.MeleeHitsTaken;
+            var avoidance = incomingSwings > 0 ? (double)s.AvoidedIncoming / incomingSwings * 100 : 0;
+            var combatTime = TimeSpan.FromSeconds(s.CombatSeconds);
+            _combatSummary.Text =
+                $"Dealt {s.DamageDealt:N0} ({s.MeleeDamage:N0} melee / {s.SpellDamage:N0} spell)\n" +
+                $"{s.CritCount} crits ({critRate:0.#}% rate) - {acc:0}% accuracy\n" +
+                $"In combat {(int)combatTime.TotalMinutes}m {combatTime.Seconds}s this session\n" +
+                $"Biggest hit: {s.MaxHit:N0} ({s.MaxHitDesc})\n" +
+                $"Taken {s.DamageTaken:N0} - avoided {s.AvoidedIncoming} of {incomingSwings} melee attacks ({avoidance:0}%)" +
+                (s.SpecialHits.Count > 0 ? "\n" + string.Join(" - ", s.SpecialHits.Select(x => $"{x.Name} {x.Count}")) : "") +
+                (s.Fizzles + s.Resists > 0 ? $"\nFizzles {s.Fizzles} - resists {s.Resists}" : "");
+            FillStatList(_damageSourceList, s.DamageBySource, _dmgOutSort, "hit");
+            FillStatList(_damageTakenList, s.DamageByAttacker, _dmgInSort, "hit");
+        }
+        _healingHeader.Text = s.Hps > 0 ? $"{s.Hps:0.#} hps" : $"{s.HealingDone:N0} healed";
+        if (_sections[1].IsExpanded)
+        {
+            _healingSummary.Text = $"Done {s.HealingDone:N0} - received {s.HealingReceived:N0}" +
+                (s.RegenTicks > 0 ? $"\n{s.RegenTicks} regen/hymn ticks (game logs no amounts for these)" : "");
+            var showSpells = s.HealsBySpell.Count > 0;
+            _healSpellsLabel.IsVisible = showSpells;
+            _healSortBar.IsVisible = showSpells;
+            FillStatList(_healSpellList, s.HealsBySpell, _healSort, "cast");
+            _healersLabel.IsVisible = s.HealsByHealer.Count > 0;
+            FillList(_healerList, s.HealsByHealer.Select(h => (h.Name, $"{h.Total:N0} - {h.Hits} heal{(h.Hits == 1 ? "" : "s")}")));
+        }
+        if (_sections[2].IsExpanded)
+        {
+            _killsSummary.Text = $"{s.KillsPerHour:0.0} kills/hr";
+            FillList(_killList, s.YourKills.Select(k => (k.Name, $"x{k.Count}")));
+            _partyKillsLabel.IsVisible = s.PartyKillsByKiller.Count > 0;
+            FillList(_partyKillList, s.PartyKillsByKiller.Select(k => (k.Name, $"x{k.Count}")));
+        }
+        if (_sections[3].IsExpanded)
+        {
+            FillList(_lootList, s.Loot.Select(l => (l.Item, $"x{l.Count}")));
+            _craftedLabel.IsVisible = s.Crafted.Count > 0;
+            FillList(_craftedList, s.Crafted.Select(c => (c.Name, $"x{c.Count}")));
+        }
+        if (_sections[4].IsExpanded)
+        {
+            _moneySummary.Text = $"Corpses {StatsSnapshot.FormatCoin(s.CorpseCopper)} ({s.CoinDrops} drops, biggest {StatsSnapshot.FormatCoin(s.BiggestDrop)})\n" +
+                $"Merchant sales {StatsSnapshot.FormatCoin(s.VendorCopper)} ({s.SalesCount} sales)\n" +
+                $"{StatsSnapshot.FormatCoin(s.CopperPerHour)} per hour";
+            _soldLabel.IsVisible = s.SoldItems.Count > 0;
+            FillList(_soldList, s.SoldItems.Select(i => ($"{i.Item}{(i.Count > 1 ? $" x{i.Count}" : "")}", StatsSnapshot.FormatCoin(i.Copper))));
+        }
+        if (_sections[5].IsExpanded)
+        {
+            _progressSummary.Text = $"{s.XpTicks} xp gains - {s.XpPerHour:0.0}%/hr - {s.SkillUpTotal} skill-ups" +
+                (s.AaGained > 0 ? $"\n{s.AaGained} AA point{(s.AaGained == 1 ? "" : "s")} - {s.AaPerHour:0.0} AA/hr (now {s.AaTotal} unspent)" : "") +
+                (s.HoursToLevel is { } eta ? $"\nNext level in {FormatEta(eta)} at this pace" : "") +
+                (s.Levels.Count > 0 ? "\n" + string.Join(", ", s.Levels.Select(l => $"{l.Text} at {l.Time:h:mm tt}")) : "");
+            FillList(_skillList, s.SkillUps.Select(k => (k.Skill, $"{k.Value} (+{k.Ups})")));
+        }
+        if (_sections[6].IsExpanded)
+            FillList(_factionList, s.Faction.Select(f => (f.Faction, $"{(f.Net >= 0 ? "+" : "")}{f.Net}")),
+                valueBrush: f => f.StartsWith('-') ? AppTheme.BadBrush : AppTheme.GoodBrush);
+        if (_sections[7].IsExpanded)
+        {
+            FillList(_deathList, s.Deaths.Select(d => (d.Text, d.Time.ToString("h:mm tt"))));
+            FillList(_zoneList, s.Zones.Select(z => (z.Text, z.Time.ToString("h:mm tt"))));
+        }
+    }
+
+    private void UpdateLoggingStatus()
+    {
+        DateTime? lastActivity = _watcher.LastGrowth;
+        if (lastActivity is null && _watcher.CurrentPath is { } p && File.Exists(p))
+            lastActivity = File.GetLastWriteTime(p);
+        var age = lastActivity is { } t ? DateTime.Now - t : TimeSpan.MaxValue;
+        var brush = age < TimeSpan.FromSeconds(30) ? AppTheme.GoodBrush : age < TimeSpan.FromMinutes(2) ? AppTheme.WarnBrush : AppTheme.BadBrush;
+        var tip = lastActivity is { } la ? $"Last log activity: {la:h:mm:ss tt}" : "No log file activity yet";
+        _statusDot.Fill = brush;
+        _miniDot.Fill = brush;
+        ToolTip.SetTip(_statusDot, tip);
+        ToolTip.SetTip(_miniDot, tip);
+        _logBanner.IsVisible = age > TimeSpan.FromMinutes(2);
+    }
+
+    private void SetMode(bool mini)
+    {
+        _settings.Minimized = mini;
+        _miniRoot.IsVisible = mini;
+        _normalRoot.IsVisible = !mini;
+        _settings.Save();
+        if (mini) UpdateMiniChips(_stats.Snapshot());
+    }
+
+    private void UpdateMiniChips(StatsSnapshot s)
+    {
+        _miniChips.Children.Clear();
+        var selected = MiniStatOrder.Where(_settings.MiniStats.Contains).ToList();
+        if (selected.Count == 0)
+        {
+            _miniChips.Children.Add(AppTheme.DimText("* star stats in full view"));
+            return;
+        }
+        foreach (var key in selected)
+        {
+            var text = key switch
+            {
+                "kills" => $"Kills {s.YourKillCount}",
+                "dps" => s.CurrentDps > 0 ? $"{s.CurrentDps:0} dps" : $"{s.SessionDps:0} dps",
+                "hps" => $"{s.Hps:0.#} hps",
+                "loot" => $"Loot {s.LootTotal}",
+                "money" => StatsSnapshot.FormatCoin(s.Copper),
+                "xp" => $"{s.XpPercent:0.0}%" + (s.HoursToLevel is { } eta ? $" - lvl {FormatEta(eta)}" : ""),
+                "deaths" => $"Deaths {s.Deaths.Count}",
+                _ => "",
+            };
+            _miniChips.Children.Add(new TextBlock
+            {
+                Text = text,
+                FontSize = 13,
+                FontWeight = FontWeight.SemiBold,
+                Foreground = AppTheme.AccentBrush,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 12, 0),
+            });
+        }
+    }
+
+    private static string FormatEta(double hours) => hours >= 1
+        ? $"~{(int)hours}h {(int)((hours - (int)hours) * 60)}m"
+        : $"~{Math.Max(1, (int)(hours * 60))}m";
+
+    private void OnOptions(object? sender, EventArgs e)
+    {
+        if (_optionsWindow is { IsVisible: true })
+        {
+            _optionsWindow.Activate();
+            return;
+        }
+        _optionsWindow = new OptionsWindow(this);
+        _optionsWindow.Show(this);
+    }
+
+    private void OnGear(object? sender, EventArgs e) => _root.ContextMenu?.Open(_root);
+
+    private void OnPinChanged(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Topmost = _pinBtn.IsChecked == true;
+        _settings.AlwaysOnTop = Topmost;
+        _settings.Save();
+    }
+
+    private void OnStarChanged(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var btn = (ToggleButton)sender!;
+        var key = (string)btn.Tag!;
+        if (btn.IsChecked == true)
+        {
+            if (!_settings.MiniStats.Contains(key)) _settings.MiniStats.Add(key);
+        }
+        else
+        {
+            _settings.MiniStats.Remove(key);
+        }
+        UpdateStarVisuals();
+        _settings.Save();
+    }
+
+    private void UpdateStarVisuals()
+    {
+        foreach (var star in _stars.Values)
+        {
+            star.Content = star.IsChecked == true ? "*" : "☆";
+            star.Foreground = star.IsChecked == true ? AppTheme.AccentBrush : AppTheme.DimBrush;
+        }
+    }
+
+    private void CheckForUpdates(bool manual)
+    {
+        Task.Run(async () =>
+        {
+            var folder = UpdateChecker.FindUpdateFolder(_settings.UpdateFolder);
+            var info = folder is null ? null : UpdateChecker.Check(folder);
+            if (info is null && await UpdateChecker.CheckGitHubAsync() is { } webLatest)
+                info = new UpdateInfo(webLatest, SetupPath: null);
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_installingUpdate) return;
+                if (info is not null && UpdateChecker.IsNewer(info))
+                {
+                    _pendingUpdate = info;
+                    _updateText.Text = info.SetupPath is not null
+                        ? $"Update v{info.Latest} is ready - click here to install."
+                        : $"Update v{info.Latest} is available - click to open the download page.";
+                    _updateBanner.IsVisible = true;
+                }
+                else if (manual)
+                {
+                    _pendingUpdate = null;
+                    _updateText.Text = info is null && folder is null
+                        ? "Couldn't check for updates (no update folder, GitHub unreachable)."
+                        : $"You're up to date (v{UpdateChecker.CurrentVersion}).";
+                    _updateBanner.IsVisible = true;
+                    _upToDateNoticeUntil = DateTime.Now.AddSeconds(6);
+                }
+            });
+        });
+    }
+
+    private void OnUpdateBannerClick(object? sender, PointerPressedEventArgs e)
+    {
+        e.Handled = true;
+        if (_pendingUpdate is not { } info || _installingUpdate) return;
+        if (info.SetupPath is null)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo(UpdateChecker.GitHubLatestPage) { UseShellExecute = true });
+                _pendingUpdate = null;
+                _updateText.Text = "Download page opened - run the new EQBuddySetup.exe to update.";
+                _upToDateNoticeUntil = DateTime.Now.AddSeconds(10);
+            }
+            catch (Exception ex)
+            {
+                App.LogError(ex);
+                _updateText.Text = $"Couldn't open browser - visit {UpdateChecker.GitHubLatestPage}";
+            }
+            return;
+        }
+        _installingUpdate = true;
+        _updateText.Text = "Installing update - EQBuddy will restart itself...";
+        Task.Run(() =>
+        {
+            try
+            {
+                var staged = UpdateChecker.StageForInstall(info);
+                Process.Start(staged, "/SILENT");
+                Dispatcher.UIThread.Post(Shutdown);
+            }
+            catch (Exception ex)
+            {
+                App.LogError(ex);
+                Dispatcher.UIThread.Post(() =>
+                {
+                    _installingUpdate = false;
+                    _updateText.Text = "Update failed to start - see error.log.";
+                });
+            }
+        });
+    }
+
+    private void FillStatList(ItemsControl list, IEnumerable<SourceDamage> stats, StatSort sort, string unit)
+    {
+        var sorted = sort switch
+        {
+            StatSort.Hits => stats.OrderByDescending(d => d.Hits),
+            StatSort.Avg => stats.OrderByDescending(d => (double)d.Total / d.Hits),
+            _ => stats.OrderByDescending(d => d.Total),
+        };
+        FillList(list, sorted.Select(d => (d.Name, $"{d.Total:N0} - {d.Hits} {unit}{(d.Hits == 1 ? "" : "s")} - avg {(double)d.Total / d.Hits:0.#}")));
+    }
+
+    private static StatSort ParseSort(object sender) => (string)((TextBlock)sender).Tag! switch
+    {
+        "hits" => StatSort.Hits,
+        "avg" => StatSort.Avg,
+        _ => StatSort.Total,
+    };
+
+    private static void SetSortVisual(StatSort mode, TextBlock total, TextBlock hits, TextBlock avg)
+    {
+        total.Foreground = mode == StatSort.Total ? AppTheme.AccentBrush : AppTheme.DimBrush;
+        hits.Foreground = mode == StatSort.Hits ? AppTheme.AccentBrush : AppTheme.DimBrush;
+        avg.Foreground = mode == StatSort.Avg ? AppTheme.AccentBrush : AppTheme.DimBrush;
+    }
+
+    private void OnSortDmgOut(object? sender, PointerPressedEventArgs e)
+    {
+        _dmgOutSort = ParseSort(sender!);
+        SetSortVisual(_dmgOutSort, _dmgOutSortTotal, _dmgOutSortHits, _dmgOutSortAvg);
+        RefreshUi();
+    }
+
+    private void OnSortDmgIn(object? sender, PointerPressedEventArgs e)
+    {
+        _dmgInSort = ParseSort(sender!);
+        SetSortVisual(_dmgInSort, _dmgInSortTotal, _dmgInSortHits, _dmgInSortAvg);
+        RefreshUi();
+    }
+
+    private void OnSortHeal(object? sender, PointerPressedEventArgs e)
+    {
+        _healSort = ParseSort(sender!);
+        SetSortVisual(_healSort, _healSortTotal, _healSortHits, _healSortAvg);
+        RefreshUi();
+    }
+
+    private static void FillList(ItemsControl list, IEnumerable<(string Name, string Value)> rows, Func<string, IBrush>? valueBrush = null)
+    {
+        list.ItemsSource = rows.Select(row =>
+        {
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            grid.Children.Add(new TextBlock
+            {
+                Text = row.Name,
+                FontSize = 12,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                Foreground = AppTheme.TextBrush,
+                Margin = new Thickness(0, 1, 8, 1),
+            });
+            var right = new TextBlock
+            {
+                Text = row.Value,
+                FontSize = 12,
+                Foreground = valueBrush?.Invoke(row.Value) ?? AppTheme.DimBrush,
+            };
+            Grid.SetColumn(right, 1);
+            grid.Children.Add(right);
+            return grid;
+        }).ToList();
+    }
+
+    private void OnDrag(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.ClickCount == 2 && _miniRoot.IsVisible)
+        {
+            SetMode(false);
+            return;
+        }
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(e);
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _uiTimer.Stop();
+        _settings.WindowLeft = Position.X;
+        _settings.WindowTop = Position.Y;
+        _settings.Save();
+        _watcher.Dispose();
+        base.OnClosed(e);
+        Shutdown();
+    }
+
+    private static void Shutdown()
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            desktop.Shutdown();
+    }
+
+    private static Ellipse Dot() => new()
+    {
+        Width = 9,
+        Height = 9,
+        Fill = AppTheme.BadBrush,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    private static Border Banner(IBrush brush) => new()
+    {
+        Background = new SolidColorBrush(((SolidColorBrush)brush).Color, 0.20),
+        CornerRadius = new CornerRadius(6),
+        Padding = new Thickness(8, 6),
+        IsVisible = false,
+    };
+}

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -68,7 +68,7 @@ public sealed class MainWindow : Window
     private readonly ToggleButton _pinBtn = AppTheme.IconToggle("P", "Always on top");
     private readonly Button _gearBtn = AppTheme.IconButton("...", "Settings");
     private readonly Dictionary<string, ToggleButton> _stars = new();
-    private readonly List<Expander> _sections = new();
+    private readonly List<SectionPanel> _sections = new();
     private TextBlock _dmgOutSortTotal = null!;
     private TextBlock _dmgOutSortHits = null!;
     private TextBlock _dmgOutSortAvg = null!;
@@ -292,7 +292,7 @@ public sealed class MainWindow : Window
         panel.Children.Add(TrackSection(AppTheme.Section(Header(title, value, star), content)));
     }
 
-    private Expander TrackSection(Expander section)
+    private SectionPanel TrackSection(SectionPanel section)
     {
         _sections.Add(section);
         return section;

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -1,0 +1,133 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace EQBuddy.Avalonia;
+
+public sealed class OptionsWindow : Window
+{
+    private readonly MainWindow _main;
+    private readonly TextBlock _scaleLabel = LabelValue();
+    private readonly TextBlock _bgOpacityLabel = LabelValue();
+    private readonly TextBlock _opacityLabel = LabelValue();
+    private readonly Slider _scaleSlider = Slider(0.8, 1.6, 0.05);
+    private readonly Slider _bgOpacitySlider = Slider(0.15, 1.0, 0.05);
+    private readonly Slider _opacitySlider = Slider(0.5, 1.0, 0.02);
+    private bool _ready;
+
+    public OptionsWindow(MainWindow main)
+    {
+        _main = main;
+        Title = "EQBuddy Options";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        WindowDecorations = global::Avalonia.Controls.WindowDecorations.None;
+        TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
+        Background = Brushes.Transparent;
+        Topmost = true;
+        ShowInTaskbar = false;
+        CanResize = false;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+
+        Content = new Border
+        {
+            Background = AppTheme.BgBrush,
+            CornerRadius = new CornerRadius(10),
+            BorderBrush = AppTheme.BorderBrush,
+            BorderThickness = new Thickness(1),
+            Child = BuildContent(),
+        };
+
+        PointerPressed += OnDrag;
+        _scaleSlider.Value = main.UiScale;
+        _opacitySlider.Value = main.WidgetOpacity;
+        _bgOpacitySlider.Value = main.BackgroundOpacityValue;
+        Subscribe(_scaleSlider, () => _main.SetUiScale(_scaleSlider.Value));
+        Subscribe(_bgOpacitySlider, () => _main.SetBackgroundOpacity(_bgOpacitySlider.Value));
+        Subscribe(_opacitySlider, () => _main.SetWindowOpacity(_opacitySlider.Value));
+        UpdateLabels();
+        _ready = true;
+    }
+
+    private Control BuildContent()
+    {
+        var panel = new StackPanel { Margin = new Thickness(16), Width = 240 };
+        var title = new Grid { Margin = new Thickness(0, 0, 0, 10) };
+        title.Children.Add(new TextBlock
+        {
+            Text = "Options",
+            FontWeight = FontWeight.Bold,
+            FontSize = 14,
+            Foreground = AppTheme.AccentBrush,
+        });
+        var close = AppTheme.IconButton("x", "Close");
+        close.HorizontalAlignment = HorizontalAlignment.Right;
+        close.Click += (_, _) => Close();
+        title.Children.Add(close);
+        panel.Children.Add(title);
+
+        AddSlider(panel, "Widget size", _scaleLabel, _scaleSlider);
+        AddSlider(panel, "Background see-through", _bgOpacityLabel, _bgOpacitySlider,
+            "Only the dark panel fades; text stays sharp.");
+        AddSlider(panel, "Whole-widget opacity", _opacityLabel, _opacitySlider,
+            "Fades everything, text included.");
+        panel.Children.Add(AppTheme.DimText("Size also scales all text. Changes apply instantly and are saved.",
+            margin: new Thickness(0, 8, 0, 0)));
+        return panel;
+    }
+
+    private static void AddSlider(Panel panel, string label, TextBlock value, Slider slider, string? hint = null)
+    {
+        var row = new Grid();
+        row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+        row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        row.Children.Add(new TextBlock { Text = label, FontSize = 12, Foreground = AppTheme.TextBrush });
+        Grid.SetColumn(value, 1);
+        row.Children.Add(value);
+        panel.Children.Add(row);
+        if (hint is not null)
+            panel.Children.Add(AppTheme.DimText(hint));
+        slider.Margin = new Thickness(0, 4, 0, 12);
+        panel.Children.Add(slider);
+    }
+
+    private void Subscribe(Slider slider, Action apply)
+    {
+        slider.PropertyChanged += (_, args) =>
+        {
+            if (args.Property != RangeBase.ValueProperty) return;
+            if (!_ready) return;
+            apply();
+            UpdateLabels();
+        };
+    }
+
+    private void UpdateLabels()
+    {
+        _scaleLabel.Text = $"{_scaleSlider.Value:P0}";
+        _opacityLabel.Text = $"{_opacitySlider.Value:P0}";
+        _bgOpacityLabel.Text = $"{_bgOpacitySlider.Value:P0}";
+    }
+
+    private void OnDrag(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(e);
+    }
+
+    private static TextBlock LabelValue() => new()
+    {
+        FontSize = 12,
+        Foreground = AppTheme.AccentBrush,
+    };
+
+    private static Slider Slider(double min, double max, double tick) => new()
+    {
+        Minimum = min,
+        Maximum = max,
+        TickFrequency = tick,
+        IsSnapToTickEnabled = true,
+    };
+}

--- a/src/EQBuddy.Avalonia/Program.cs
+++ b/src/EQBuddy.Avalonia/Program.cs
@@ -1,0 +1,15 @@
+using Avalonia;
+
+namespace EQBuddy.Avalonia;
+
+internal static class Program
+{
+    [STAThread]
+    public static void Main(string[] args) =>
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+}

--- a/src/EQBuddy.Core/EQBuddy.Core.csproj
+++ b/src/EQBuddy.Core/EQBuddy.Core.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>EQBuddy.Core</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\EQBuddy\Core\**\*.cs" Link="Core\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>

--- a/src/EQBuddy/Core/LogWatcher.cs
+++ b/src/EQBuddy/Core/LogWatcher.cs
@@ -47,31 +47,38 @@ public sealed class LogWatcher : IDisposable
     {
         // The Daybreak installer records the install location in the uninstall registry
         // key, so custom install paths are found without any user configuration.
-        foreach (var hive in new[] { Microsoft.Win32.Registry.CurrentUser, Microsoft.Win32.Registry.LocalMachine })
-        foreach (var subkey in new[]
+        if (OperatingSystem.IsWindows())
         {
-            @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\DGC-EverQuest Legends",
-            @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\DGC-EverQuest Legends",
-        })
-        {
-            try
+            foreach (var hive in new[] { Microsoft.Win32.Registry.CurrentUser, Microsoft.Win32.Registry.LocalMachine })
+            foreach (var subkey in new[]
             {
-                using var key = hive.OpenSubKey(subkey);
-                var marker = key?.GetValue("UninstallString") as string
-                             ?? key?.GetValue("DisplayIcon") as string;
-                if (marker is null) continue;
-                var root = Path.GetDirectoryName(marker.Trim('"'));
-                if (root is null) continue;
-                var logs = Path.Combine(root, "Logs");
-                if (Directory.Exists(logs)) return logs;
+                @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\DGC-EverQuest Legends",
+                @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\DGC-EverQuest Legends",
+            })
+            {
+                try
+                {
+                    using var key = hive.OpenSubKey(subkey);
+                    var marker = key?.GetValue("UninstallString") as string
+                                 ?? key?.GetValue("DisplayIcon") as string;
+                    if (marker is null) continue;
+                    var root = Path.GetDirectoryName(marker.Trim('"'));
+                    if (root is null) continue;
+                    var logs = Path.Combine(root, "Logs");
+                    if (Directory.Exists(logs)) return logs;
+                }
+                catch { /* registry access denied — fall through */ }
             }
-            catch { /* registry access denied — fall through */ }
         }
 
         string[] candidates =
         [
             @"C:\Users\Public\Daybreak Game Company\Installed Games\EverQuest Legends\Logs",
             @"C:\Users\Public\Daybreak Game Company\Installed Games\EverQuest\Logs",
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".local", "share", "Daybreak Game Company", "Installed Games",
+                "EverQuest Legends", "Logs"),
         ];
         return candidates.FirstOrDefault(Directory.Exists);
     }

--- a/src/EQBuddy/Core/UpdateChecker.cs
+++ b/src/EQBuddy/Core/UpdateChecker.cs
@@ -34,7 +34,8 @@ public static class UpdateChecker
     {
         get
         {
-            var v = Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0);
+            var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+            var v = assembly.GetName().Version ?? new Version(0, 0, 0);
             return Normalize(v);
         }
     }

--- a/src/EQBuddy/EQBuddy.csproj
+++ b/src/EQBuddy/EQBuddy.csproj
@@ -14,4 +14,12 @@
     <ApplicationIcon>Assets\EQBuddy.ico</ApplicationIcon>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Remove="Core\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EQBuddy.Core\EQBuddy.Core.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Hey there, I had Codex make a quick Avalonia port of your UI for use on Linux (I couldn't get your version to easily work via Wine).  I'm not sure if you're interested in supporting this or not, feel free to throw this out if not!  It's mildly tested, but I don't have a suite of tests to go through (all the fields seem to update as I played) and I didn't see any automated tests.
I'm happy to make tweaks or do some more testing if you have some testing docs available.

If you don't want to maintain this version, would you be open to moving the /Core/ logic into its own cross platform project?  That would make keeping a Linux fork up to date a little easier.


## Codex Summary

This adds an experimental cross-platform Avalonia UI for EQBuddy while keeping the existing WPF app intact.

The new Avalonia app is intended to replicate the current WPF widget behavior: live log watching, full/mini modes, starred mini-dashboard stats, expandable stat sections, sorting, options sliders, log folder selection, update banner, reset, pin, and close controls.

## Project Structure

This PR adds a new `EQBuddy.Core` project so the Avalonia app has a non-WPF/non-Windows project to reference.

Right now `EQBuddy.Core` compiles the existing files from `src/EQBuddy/Core` in place, rather than physically moving them. That keeps this PR less disruptive.

Longer term, the maintainer may want to move the existing `Core` folder into `src/EQBuddy.Core` directly for cleaner separation:

- `EQBuddy.Core` — parser, log watcher, session stats, settings, updater
- `EQBuddy` — WPF UI
- `EQBuddy.Avalonia` — Avalonia UI

## Avalonia UI

This includes an Avalonia replica of the current WPF UI, targeting `net10.0`, so it can run on Linux/macOS/Windows without WPF.

The maintainer could keep both UIs side-by-side, or eventually drop WPF and use Avalonia as the single UI across platforms.

## Compatibility Notes

The existing WPF app is preserved and now references `EQBuddy.Core`.

One small Core change was needed for cross-platform friendliness: Windows registry-based log folder detection is guarded behind `OperatingSystem.IsWindows()`.

The update checker now reads the version from the entry assembly rather than the Core assembly, so the Avalonia app reports its own version correctly.