### PR TITLE
Bring Avalonia version up to parity with 1.8.13

### DIFF
--- a/src/EQBuddy.Avalonia/AlertWindow.cs
+++ b/src/EQBuddy.Avalonia/AlertWindow.cs
@@ -1,0 +1,131 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using EQBuddy.Core;
+
+namespace EQBuddy.Avalonia;
+
+/// <summary>
+/// Floating tracked-rule alert tile. During play it never activates and its X11 input
+/// region is empty; while Options is open it becomes a draggable placement target.
+/// </summary>
+public sealed class AlertWindow : Window
+{
+    private readonly AppSettings _settings;
+    private readonly MainWindow _owner;
+    private readonly TextBlock _alertText;
+    private readonly DispatcherTimer _hide;
+    private bool _placement;
+
+    public AlertWindow(AppSettings settings, MainWindow owner)
+    {
+        _settings = settings;
+        _owner = owner;
+        Title = "EQBuddy Alert";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        WindowDecorations = global::Avalonia.Controls.WindowDecorations.None;
+        TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
+        Background = Brushes.Transparent;
+        Topmost = true;
+        ShowInTaskbar = false;
+        ShowActivated = false;
+        CanResize = false;
+
+        _alertText = new TextBlock
+        {
+            FontSize = 13,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = AppTheme.AccentBrush,
+            TextWrapping = TextWrapping.Wrap,
+        };
+        Content = new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0xF0, 0x1E, 0x1A, 0x14)),
+            BorderBrush = AppTheme.AccentBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(12, 8),
+            MaxWidth = 380,
+            Child = _alertText,
+        };
+
+        _hide = new DispatcherTimer { Interval = TimeSpan.FromSeconds(6) };
+        _hide.Tick += (_, _) =>
+        {
+            _hide.Stop();
+            if (!_placement) Hide();
+        };
+        Opened += (_, _) => ApplyClickThrough(!_placement);
+        PointerPressed += OnDrag;
+    }
+
+    public void ShowAlert(string text)
+    {
+        _alertText.Text = text;
+        PositionFromSettings();
+        ShowOwned();
+        Topmost = true;
+        _hide.Stop();
+        _hide.Start();
+    }
+
+    /// <summary>Show a draggable preview while Options is open.</summary>
+    public void EnterPlacement()
+    {
+        _placement = true;
+        _hide.Stop();
+        _alertText.Text = "★ Alert banner — drag me to where alerts should appear";
+        PositionFromSettings();
+        ShowOwned();
+        ApplyClickThrough(false);
+        Topmost = true;
+    }
+
+    /// <summary>Save the chosen location and restore play-mode click-through.</summary>
+    public void ExitPlacement()
+    {
+        if (!_placement) return;
+        _placement = false;
+        _settings.AlertLeft = Position.X;
+        _settings.AlertTop = Position.Y;
+        _settings.Save();
+        ApplyClickThrough(true);
+        Hide();
+    }
+
+    private void ShowOwned()
+    {
+        if (!IsVisible) Show(_owner);
+    }
+
+    private void PositionFromSettings()
+    {
+        var screen = _owner.Screens.ScreenFromWindow(_owner) ?? _owner.Screens.Primary;
+        var work = screen?.WorkingArea ?? new PixelRect(0, 0, 1920, 1080);
+        var left = _settings.AlertLeft;
+        var top = _settings.AlertTop;
+        if (double.IsNaN(left) || double.IsNaN(top))
+        {
+            left = _owner.Position.X;
+            top = _owner.Position.Y - 64;
+        }
+
+        Position = new PixelPoint(
+            (int)Math.Clamp(left, work.X, work.Right - 140),
+            (int)Math.Clamp(top, work.Y, work.Bottom - 44));
+    }
+
+    private void OnDrag(object? sender, PointerPressedEventArgs e)
+    {
+        if (_placement && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(e);
+    }
+
+    private void ApplyClickThrough(bool enabled)
+    {
+        if (TryGetPlatformHandle() is null) return;
+        X11ClickThrough.Set(this, enabled);
+    }
+}

--- a/src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj
+++ b/src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj
@@ -20,4 +20,9 @@
     <ProjectReference Include="..\EQBuddy.Core\EQBuddy.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AvaloniaResource Include="..\EQBuddy\Assets\tutorial\*.png"
+                      Link="Assets\tutorial\%(Filename)%(Extension)" />
+  </ItemGroup>
+
 </Project>

--- a/src/EQBuddy.Avalonia/HistoryWindow.cs
+++ b/src/EQBuddy.Avalonia/HistoryWindow.cs
@@ -235,7 +235,7 @@ public sealed class HistoryWindow : Window
             foreach (var d in s.DamageBySource.Take(8))
                 sb.AppendLine($"  {d.Name,-24} {ShareBar((double)d.Total / top),-10} {d.Total,8:N0}" +
                     $" - {100.0 * d.Total / grand,3:0}% - {d.Hits} hits - avg {(double)d.Total / Math.Max(1, d.Hits):0.#}" +
-                    (d.ActiveSeconds > 0 ? $" - {d.Total / d.ActiveSeconds:0.#} dps" : "") +
+                    $" - {d.Total / Math.Max(1, s.CombatSeconds):0.#} dps" +
                     (d.Crits > 0 ? $" - {100.0 * d.Crits / Math.Max(1, d.Hits):0}% crit" : ""));
             sb.AppendLine();
         }
@@ -248,7 +248,7 @@ public sealed class HistoryWindow : Window
                 sb.AppendLine($"  {h.Name,-24} {ShareBar((double)h.Total / top),-10} {h.Total,8:N0}" +
                     $" - {100.0 * h.Total / grand,3:0}% - {h.Hits} cast{(h.Hits == 1 ? "" : "s")}" +
                     $" - avg {(double)h.Total / Math.Max(1, h.Hits):0.#}" +
-                    (h.ActiveSeconds > 0 ? $" - {h.Total / h.ActiveSeconds:0.#} hps" : ""));
+                    $" - {h.Total / Math.Max(1, s.CombatSeconds):0.#} hps");
             sb.AppendLine();
         }
         if (s.YourKills.Count > 0)

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -33,8 +33,6 @@ public sealed class MainWindow : Window
     private readonly TextBlock _charLabel = AppTheme.DimText("looking for a character...");
     private readonly ScrollViewer _sectionScroll = new();
     private readonly Border _logBanner = Banner(AppTheme.WarnBrush);
-    private readonly Border _alertBanner = Banner(AppTheme.AccentBrush);
-    private readonly TextBlock _alertText = new() { FontSize = 12, Foreground = AppTheme.AccentBrush, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap };
     private readonly Border _updateBanner = Banner(AppTheme.GoodBrush);
     private readonly TextBlock _updateText = new() { FontSize = 12, Foreground = AppTheme.GoodBrush, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap };
     private readonly TextBlock _zoneText = AppTheme.DimText("-");
@@ -106,6 +104,7 @@ public sealed class MainWindow : Window
     private X11HotkeyService? _hotkeys;
     private HistoryWindow? _historyWindow;
     private OptionsWindow? _optionsWindow;
+    private AlertWindow? _alertWindow;
     private StatSort _dmgOutSort = StatSort.Total;
     private StatSort _dmgInSort = StatSort.Total;
     private StatSort _healSort = StatSort.Total;
@@ -235,13 +234,10 @@ public sealed class MainWindow : Window
             Margin = new Thickness(10),
             Children =
             {
-                _alertBanner,
                 BuildMiniRoot(),
                 BuildNormalRoot(),
             },
         };
-        _alertBanner.Child = _alertText;
-        _alertBanner.Margin = new Thickness(0, 0, 0, 8);
         return _scaleRoot;
     }
 
@@ -647,11 +643,6 @@ public sealed class MainWindow : Window
             _updateBanner.IsVisible = false;
             _upToDateNoticeUntil = DateTime.MinValue;
         }
-        if (_alertUntil != DateTime.MinValue && DateTime.Now > _alertUntil)
-        {
-            _alertBanner.IsVisible = false;
-            _alertUntil = DateTime.MinValue;
-        }
         if (_watcher.LastError is { } err) App.LogError(err);
 
         var s = CurrentSnapshot();
@@ -820,7 +811,9 @@ public sealed class MainWindow : Window
     private readonly Dictionary<string, int> _ruleBaseline = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, DateTime> _ruleLastAlert = new(StringComparer.OrdinalIgnoreCase);
     private string? _alertBaselinePath;
-    private DateTime _alertUntil = DateTime.MinValue;
+
+    /// <summary>The floating alert tile, created on first use and owned by the widget.</summary>
+    internal AlertWindow AlertTile => _alertWindow ??= new AlertWindow(_settings, this);
 
     private void RenderTracked(StatsSnapshot s)
     {
@@ -897,11 +890,7 @@ public sealed class MainWindow : Window
             if (DateTime.Now - last < TimeSpan.FromSeconds(5)) continue;
             _ruleLastAlert[r.Name] = DateTime.Now;
             if (rule.AlertBanner)
-            {
-                _alertText.Text = $"* {r.Name}: {r.LastItem ?? "match"}{(delta > 1 ? $" x{delta}" : "")}";
-                _alertBanner.IsVisible = true;
-                _alertUntil = DateTime.Now.AddSeconds(6);
-            }
+                AlertTile.ShowAlert($"★ {r.Name}: {r.LastItem ?? "match"}{(delta > 1 ? $" ×{delta}" : "")}");
             if (rule.AlertSound) PlayAlertSound();
         }
     }
@@ -992,7 +981,9 @@ public sealed class MainWindow : Window
             return;
         }
         _optionsWindow = new OptionsWindow(this);
+        _optionsWindow.Closed += (_, _) => _alertWindow?.ExitPlacement();
         _optionsWindow.Show(this);
+        AlertTile.EnterPlacement();
     }
 
     private void OnHistory(object? sender, EventArgs e)
@@ -1420,6 +1411,7 @@ public sealed class MainWindow : Window
         if (_clickThrough)
             X11ClickThrough.Set(this, enabled: false);
         _hotkeys?.Dispose();
+        _alertWindow?.Close();
         _archiver.FinalizeActiveSync(CurrentSnapshot(), "ApplicationExit");
         _watcher.Dispose();
         _repo.Dispose();

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -512,7 +512,7 @@ public sealed class MainWindow : Window
         var version = new MenuItem { Header = $"EQBuddy v{UpdateChecker.CurrentVersion}", IsEnabled = false };
         var check = new MenuItem { Header = "Check for updates" };
         check.Click += (_, _) => { _lastUpdateCheck = DateTime.Now; CheckForUpdates(manual: true); };
-        var options = new MenuItem { Header = "Options... (size, opacity, tracked loot)" };
+        var options = new MenuItem { Header = "Options... (size, opacity, watch rules)" };
         options.Click += OnOptions;
         var marker = new MenuItem { Header = "Drop camp marker" };
         marker.Click += (_, _) => DropCampMarker();

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -130,6 +130,10 @@ public sealed class MainWindow : Window
         Opacity = _settings.Opacity;
         Content = BuildRoot();
 
+        // Migration: any old per-rule pin enables the replacement group pin.
+        if (!_settings.PinWatchChips && _settings.TrackedRules.Any(r => r.Pinned))
+            _settings.PinWatchChips = true;
+
         if (_settings.LogFolder is { } saved && !Directory.Exists(saved))
             _settings.LogFolder = null;
         _settings.LogFolder ??= LogWatcher.FindDefaultLogFolder();
@@ -146,7 +150,9 @@ public sealed class MainWindow : Window
 
         if (_settings.LogFolder is { } lf)
         {
-            var prune = _settings.TruncateLogs;
+            // Page one of the launch tour is the log-truncation consent question.
+            // Leave existing logs untouched until the user has answered it.
+            var prune = _settings.TruncateLogs && !_settings.ShowTutorial;
             Task.Run(() =>
             {
                 EqConfig.EnsureLoggingEnabled(lf);
@@ -161,6 +167,8 @@ public sealed class MainWindow : Window
         {
             UpdateWindowHeightLimit();
             RegisterGlobalHotkeys();
+            if (_settings.ShowTutorial)
+                new TutorialWindow(this).Show(this);
         };
     }
 
@@ -514,6 +522,8 @@ public sealed class MainWindow : Window
         check.Click += (_, _) => { _lastUpdateCheck = DateTime.Now; CheckForUpdates(manual: true); };
         var options = new MenuItem { Header = "Options... (size, opacity, watch rules)" };
         options.Click += OnOptions;
+        var tutorial = new MenuItem { Header = "Quick tutorial..." };
+        tutorial.Click += OnTutorial;
         var marker = new MenuItem { Header = "Drop camp marker" };
         marker.Click += (_, _) => DropCampMarker();
         var history = new MenuItem { Header = "Session history..." };
@@ -531,6 +541,7 @@ public sealed class MainWindow : Window
         menu.Items.Add(version);
         menu.Items.Add(check);
         menu.Items.Add(options);
+        menu.Items.Add(tutorial);
         menu.Items.Add(marker);
         menu.Items.Add(history);
         menu.Items.Add(new Separator());
@@ -629,7 +640,7 @@ public sealed class MainWindow : Window
         if (_settings.LogFolder is { } folder && DateTime.Now - _lastJanitorRun > TimeSpan.FromMinutes(10))
         {
             _lastJanitorRun = DateTime.Now;
-            var prune = _settings.TruncateLogs;
+            var prune = _settings.TruncateLogs && !_settings.ShowTutorial;
             Task.Run(() =>
             {
                 EqConfig.EnsureLoggingEnabled(folder);
@@ -952,7 +963,9 @@ public sealed class MainWindow : Window
                 Margin = new Thickness(0, 0, 12, 0),
             });
         }
-        foreach (var rule in _settings.TrackedRules.Where(r => r.Enabled && r.Pinned))
+        foreach (var rule in _settings.PinWatchChips
+                     ? _settings.TrackedRules.Where(r => r.Enabled)
+                     : [])
         {
             var name = rule.Name.Length > 0 ? rule.Name : rule.Pattern;
             var result = s.Tracked.FirstOrDefault(t =>
@@ -985,6 +998,8 @@ public sealed class MainWindow : Window
         _optionsWindow.Show(this);
         AlertTile.EnterPlacement();
     }
+
+    private void OnTutorial(object? sender, EventArgs e) => new TutorialWindow(this).Show(this);
 
     private void OnHistory(object? sender, EventArgs e)
     {

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -479,8 +479,9 @@ public sealed class MainWindow : Window
         sortBar.HorizontalAlignment = HorizontalAlignment.Right;
         sortBar.Children.Add(AppTheme.DimText("sort:", new Thickness(0, 0, 4, 0)));
         total = SortLink("total", "total", handler, selected: true);
+        var rateSubject = title.Contains("Heal", StringComparison.OrdinalIgnoreCase) ? "spell" : "ability";
         rate = rateText is null ? null : SortLink(rateText, "rate", handler,
-            tip: $"Per-ability {rateText}: total divided by the time that ability was in use");
+            tip: $"Per-{rateSubject} {rateText}: that {rateSubject}'s total divided by total time in combat");
         hits = SortLink(title.Contains("Heal", StringComparison.OrdinalIgnoreCase) ? "casts" : "hits", "hits", handler);
         avg = SortLink("avg", "avg", handler);
         sortBar.Children.Add(total);
@@ -697,7 +698,7 @@ public sealed class MainWindow : Window
                 (s.SpecialHits.Count > 0 ? "\n" + string.Join(" - ", s.SpecialHits.Select(x => $"{x.Name} {x.Count}")) : "") +
                 (s.Fizzles + s.Resists > 0 ? $"\nFizzles {s.Fizzles} - resists {s.Resists}" : "") +
                 (s.CurrentStance.Length > 0 ? $"\nStance: {s.CurrentStance}" : "");
-            FillBreakdown(_damageSourceList, s.DamageBySource, _dmgOutSort, "dps");
+            FillBreakdown(_damageSourceList, s.DamageBySource, _dmgOutSort, s.CombatSeconds, "dps");
             FillStatList(_damageTakenList, s.DamageByAttacker, _dmgInSort, "hit");
             _recentFightsLabel.IsVisible = s.RecentEncounters.Count > 0;
             var topFightDps = Math.Max(0.1, s.RecentEncounters.Count > 0
@@ -721,7 +722,7 @@ public sealed class MainWindow : Window
             var showSpells = s.HealsBySpell.Count > 0;
             _healSpellsLabel.IsVisible = showSpells;
             _healSortBar.IsVisible = showSpells;
-            FillBreakdown(_healSpellList, s.HealsBySpell, _healSort, "hps");
+            FillBreakdown(_healSpellList, s.HealsBySpell, _healSort, s.CombatSeconds, "hps");
             _healersLabel.IsVisible = s.HealsByHealer.Count > 0;
             FillList(_healerList, s.HealsByHealer.Select(h => (h.Name, $"{h.Total:N0} - {h.Hits} heal{(h.Hits == 1 ? "" : "s")}")));
         }
@@ -1228,11 +1229,15 @@ public sealed class MainWindow : Window
         });
     }
 
+    /// <summary>Details-style breakdown whose displayed rate follows parser convention:
+    /// source total divided by total combat time. The source's active-time burst rate
+    /// remains available in the row tooltip.</summary>
     private void FillBreakdown(ItemsControl list, IEnumerable<SourceDamage> stats,
-        StatSort sort, string rateLabel)
+        StatSort sort, double combatSeconds, string rateLabel)
     {
+        var secs = Math.Max(1, combatSeconds);
         static double Avg(SourceDamage d) => (double)d.Total / Math.Max(1, d.Hits);
-        static double Rate(SourceDamage d) => d.Total / Math.Max(1, d.ActiveSeconds);
+        double Rate(SourceDamage d) => d.Total / secs;
         var sorted = (sort switch
         {
             StatSort.Hits => stats.OrderByDescending(d => d.Hits),
@@ -1261,11 +1266,10 @@ public sealed class MainWindow : Window
             var critPart = d.Crits > 0
                 ? $" - {100.0 * d.Crits / Math.Max(1, d.Hits):0}% crit"
                 : "";
-            var ratePart = d.ActiveSeconds > 0 ? $" - {Rate(d):0.#} {rateLabel}" : "";
-            var value = $"{d.Total:N0} - ×{d.Hits} - avg {Avg(d):0.#}{ratePart}{critPart}";
-            var tooltip = $"{100.0 * d.Total / grand:0.#}% of total" +
+            var value = $"{d.Total:N0} - ×{d.Hits} - avg {Avg(d):0.#} - {Rate(d):0.#} {rateLabel}{critPart}";
+            var tooltip = $"{100.0 * d.Total / grand:0.#}% of total - {rateLabel} = total / {secs:0}s in combat" +
                 (d.ActiveSeconds > 0
-                    ? $" - {rateLabel} = total / ~{d.ActiveSeconds:0}s this ability was in use"
+                    ? $" - burst {d.Total / Math.Max(1, d.ActiveSeconds):0.#}/s over the ~{d.ActiveSeconds:0}s it was in use"
                     : "");
             return BarRow(d.Name, value, metric(d) / topMetric, barBrush, tooltip);
         }).ToList();

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -129,8 +129,8 @@ public sealed class OptionsWindow : Window
         panel.Children.Add(Row("Recent-rate window", _windowCombo, new Thickness(0, 12, 0, 0)));
         panel.Children.Add(AppTheme.DimText("The Last Xm figures on Combat, Kills, Money, and Progress."));
 
-        panel.Children.Add(Heading("Tracked loot", new Thickness(0, 14, 0, 2)));
-        panel.Children.Add(AppTheme.DimText("Choose what to watch and give the rule a display name. Match text is an optional case-insensitive filter; when empty, the display name is used. P pins a mini chip, B shows a banner, and S plays a sound."));
+        panel.Children.Add(Heading("Watch rules", new Thickness(0, 14, 0, 2)));
+        panel.Children.Add(AppTheme.DimText("Watch loot, kills, skill-ups, deaths, milestones, or your spells wearing off (SpellFade — the mez/charm-break alarm). Match is a case-insensitive substring, e.g. 'mote' or 'Befriend'; when empty, the display name is used. P pins a mini chip, B shows a banner, and S plays a sound."));
         panel.Children.Add(_rulesPanel);
         var add = AppTheme.IconButton("+ Add tracked item", "Add tracked item");
         add.HorizontalAlignment = HorizontalAlignment.Left;

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -20,6 +20,8 @@ public sealed class OptionsWindow : Window
     private readonly Slider _bgOpacitySlider = Slider(0.15, 1.0, 0.05);
     private readonly Slider _opacitySlider = Slider(0.5, 1.0, 0.02);
     private readonly CheckBox _truncateCheck = new() { Margin = new Thickness(0, 12, 0, 0) };
+    private readonly CheckBox _tutorialCheck = new() { Margin = new Thickness(0, 10, 0, 0) };
+    private readonly CheckBox _pinChipsCheck = new() { Margin = new Thickness(0, 6, 0, 0) };
     private readonly ComboBox _windowCombo = new() { Width = 90, FontSize = 12 };
     private readonly ComboBox _soundCombo = new() { Width = 120, FontSize = 12 };
     private readonly TextBlock _soundFileNote = AppTheme.DimText("");
@@ -67,6 +69,34 @@ public sealed class OptionsWindow : Window
         _truncateCheck.IsCheckedChanged += (_, _) =>
         {
             if (_ready) _main.SetTruncateLogs(_truncateCheck.IsChecked == true);
+        };
+
+        _tutorialCheck.Content = new TextBlock
+        {
+            Text = "Show quick tutorial at launch",
+            FontSize = 12,
+            Foreground = AppTheme.TextBrush,
+        };
+        _tutorialCheck.IsChecked = main.Settings.ShowTutorial;
+        _tutorialCheck.IsCheckedChanged += (_, _) =>
+        {
+            if (!_ready) return;
+            _main.Settings.ShowTutorial = _tutorialCheck.IsChecked == true;
+            _main.PersistSettings();
+        };
+
+        _pinChipsCheck.Content = new TextBlock
+        {
+            Text = "📌 Show watch chips in the mini dashboard",
+            FontSize = 12,
+            Foreground = AppTheme.TextBrush,
+        };
+        _pinChipsCheck.IsChecked = main.Settings.PinWatchChips;
+        _pinChipsCheck.IsCheckedChanged += (_, _) =>
+        {
+            if (!_ready) return;
+            _main.Settings.PinWatchChips = _pinChipsCheck.IsChecked == true;
+            _main.PersistSettings();
         };
 
         foreach (var m in (int[])[5, 15, 30]) _windowCombo.Items.Add($"{m} min");
@@ -125,14 +155,15 @@ public sealed class OptionsWindow : Window
         panel.Children.Add(AppTheme.DimText(
             "Turn off if you upload your log files elsewhere - they will grow forever, so clean them up yourself occasionally.",
             new Thickness(20, 2, 0, 0)));
+        panel.Children.Add(_tutorialCheck);
 
         panel.Children.Add(Row("Recent-rate window", _windowCombo, new Thickness(0, 12, 0, 0)));
         panel.Children.Add(AppTheme.DimText("The Last Xm figures on Combat, Kills, Money, and Progress."));
 
         panel.Children.Add(Heading("Watch rules", new Thickness(0, 14, 0, 2)));
-        panel.Children.Add(AppTheme.DimText("Watch loot, kills, skill-ups, deaths, milestones, or your spells wearing off (SpellFade — the mez/charm-break alarm). Match is a case-insensitive substring, e.g. 'mote' or 'Befriend'; when empty, the display name is used. P pins a mini chip, B shows a banner, and S plays a sound."));
+        panel.Children.Add(AppTheme.DimText("Watch loot, kills, skill-ups, deaths, milestones, or your spells wearing off (SpellFade — the mez/charm-break alarm). Match is a case-insensitive substring, e.g. 'mote' or 'Befriend'; when empty, the display name is used. B shows a banner and S plays a sound."));
         panel.Children.Add(_rulesPanel);
-        var add = AppTheme.IconButton("+ Add tracked item", "Add tracked item");
+        var add = AppTheme.IconButton("+ Add watch rule", "Add watch rule");
         add.HorizontalAlignment = HorizontalAlignment.Left;
         add.FontSize = 12;
         add.Click += (_, _) =>
@@ -142,6 +173,7 @@ public sealed class OptionsWindow : Window
             BuildRulesEditor();
         };
         panel.Children.Add(add);
+        panel.Children.Add(_pinChipsCheck);
 
         var soundRow = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
         soundRow.Children.Add(_soundCombo);
@@ -174,7 +206,7 @@ public sealed class OptionsWindow : Window
             row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(92)));
             row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(115)));
             row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-            for (var i = 0; i < 4; i++)
+            for (var i = 0; i < 3; i++)
                 row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
 
             var kind = new ComboBox { FontSize = 11, Margin = new Thickness(0, 0, 4, 0) };
@@ -203,9 +235,8 @@ public sealed class OptionsWindow : Window
             Grid.SetColumn(pattern, 2);
             row.Children.Add(pattern);
 
-            row.Children.Add(RuleToggle("P", "Pin to mini dashboard", 3, rule.Pinned, v => rule.Pinned = v));
-            row.Children.Add(RuleToggle("B", "Banner alert on match", 4, rule.AlertBanner, v => rule.AlertBanner = v));
-            row.Children.Add(RuleToggle("S", "Sound alert on match", 5, rule.AlertSound, v => rule.AlertSound = v));
+            row.Children.Add(RuleToggle("B", "Banner alert on match", 3, rule.AlertBanner, v => rule.AlertBanner = v));
+            row.Children.Add(RuleToggle("S", "Sound alert on match", 4, rule.AlertSound, v => rule.AlertSound = v));
 
             var del = AppTheme.IconButton("x", "Delete rule");
             del.Click += (_, _) =>
@@ -214,7 +245,7 @@ public sealed class OptionsWindow : Window
                 _main.PersistSettings();
                 BuildRulesEditor();
             };
-            Grid.SetColumn(del, 6);
+            Grid.SetColumn(del, 5);
             row.Children.Add(del);
             _rulesPanel.Children.Add(row);
         }

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -151,6 +151,9 @@ public sealed class OptionsWindow : Window
         soundRow.Children.Add(test);
         panel.Children.Add(Row("Alert sound", soundRow, new Thickness(0, 8, 0, 0)));
         panel.Children.Add(_soundFileNote);
+        panel.Children.Add(AppTheme.DimText(
+            "While Options is open, the ★ alert banner tile is visible — drag it to where alerts should appear. During play it's click-through and never steals focus.",
+            new Thickness(0, 4, 0, 0)));
 
         panel.Children.Add(Heading("Overlay cards", new Thickness(0, 14, 0, 2)));
         panel.Children.Add(_cardsPanel);

--- a/src/EQBuddy.Avalonia/TutorialWindow.cs
+++ b/src/EQBuddy.Avalonia/TutorialWindow.cs
@@ -1,0 +1,232 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.VisualTree;
+
+namespace EQBuddy.Avalonia;
+
+/// <summary>
+/// Six-page quick tour. Its first page is the log-truncation consent question, so
+/// startup cleanup remains deferred while the launch tutorial setting is enabled.
+/// </summary>
+public sealed class TutorialWindow : Window
+{
+    private readonly MainWindow _main;
+    private readonly TextBlock _pageTitle = new();
+    private readonly TextBlock _pageBody = new();
+    private readonly TextBlock _pageDots = new();
+    private readonly CheckBox _keepLogs = new();
+    private readonly Border _imageFrame = new();
+    private readonly Image _pageImage = new();
+    private readonly Button _previous;
+    private readonly Button _next;
+    private bool _ready;
+    private int _page;
+
+    private sealed record Page(string Title, string Body, string? Image, bool TruncationChoice = false);
+
+    private static readonly Page[] Pages =
+    [
+        new("Your log files — one decision first",
+            "EQBuddy reads the log file EverQuest Legends writes (the /log command — EQBuddy " +
+            "turns it on for you). It never touches the game itself.\n\n" +
+            "Because logging stays on permanently, EQBuddy automatically EMPTIES a character's " +
+            "log after it has been quiet for 60+ minutes (a finished play session), so the files " +
+            "never grow forever.\n\n" +
+            "If you keep your logs — for example to upload them to another parser — turn that " +
+            "off below. You can change this any time in ⚙ Options.",
+            null, TruncationChoice: true),
+
+        new("The widget",
+            "An always-on-top card that follows whoever is playing. Click any section to drill " +
+            "into details, drag anywhere to move it. The dot is green while the log is live. " +
+            "↻ restarts the session count; – minimizes to the mini pill; ⚙ opens Options.",
+            "t-widget.png"),
+
+        new("Combat, Details!-style",
+            "Damage by attack with share bars: total · hits · average · per-ability DPS · crit " +
+            "rate. Click the sort labels to re-rank (the bars follow the sorted column). Below: " +
+            "damage taken per mob, your recent fights with per-fight DPS, and a stance " +
+            "breakdown. Healing gets the same treatment.",
+            "t-combat.png"),
+
+        new("Watch rules & alerts",
+            "⚙ Options → Watch rules: watch Loot ('mote'), Kills, Skill-ups, Deaths, " +
+            "Milestones, or SpellFade — your mez or charm breaking. Matches count on the 🎯 " +
+            "Tracked card with per-hour rates, and can 🔔 pop a floating banner and 🔊 play a " +
+            "sound. The banner tile is click-through and movable — drag it while Options is open.",
+            "t-watch.png"),
+
+        new("Mini mode & hotkeys",
+            "Star ★ the stats you care about, then minimize: a tiny pill shows just those, " +
+            "plus watch-rule chips. Global hotkeys: Ctrl+Shift+H hide/show · Ctrl+Shift+T " +
+            "click-through (play right through the widget) · Ctrl+Shift+M mini mode · " +
+            "Ctrl+Shift+K camp marker.",
+            "t-mini.png"),
+
+        new("Session history",
+            "Every session saves itself to a local database — nothing uploads, ever. " +
+            "Right-click → Session history: search anything, add notes and tags, Ctrl-click " +
+            "two sessions to compare rates, import old log files, export JSON.\n\n" +
+            "That's the tour — happy hunting! Finishing turns off this launch tour; get it " +
+            "back any time via right-click → Quick tutorial…, or re-enable it in ⚙ Options.",
+            "t-history.png"),
+    ];
+
+    public TutorialWindow(MainWindow main)
+    {
+        _main = main;
+        Title = "Welcome to EQBuddy";
+        Width = 580;
+        SizeToContent = SizeToContent.Height;
+        WindowDecorations = global::Avalonia.Controls.WindowDecorations.None;
+        TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
+        Background = Brushes.Transparent;
+        WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        ShowInTaskbar = false;
+        Topmost = true;
+        CanResize = false;
+
+        _pageTitle.FontSize = 16;
+        _pageTitle.FontWeight = FontWeight.Bold;
+        _pageTitle.Foreground = AppTheme.AccentBrush;
+        _pageDots.FontSize = 12;
+        _pageDots.Foreground = AppTheme.DimBrush;
+        _pageDots.HorizontalAlignment = HorizontalAlignment.Right;
+        _pageDots.VerticalAlignment = VerticalAlignment.Center;
+        _pageBody.FontSize = 13;
+        _pageBody.Foreground = AppTheme.TextBrush;
+        _pageBody.TextWrapping = TextWrapping.Wrap;
+        _pageBody.LineHeight = 19;
+        _pageBody.Margin = new Thickness(0, 10, 0, 0);
+
+        _keepLogs.Content = new TextBlock
+        {
+            Text = "Keep my log files — disable auto-empty",
+            FontSize = 13,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = AppTheme.TextBrush,
+        };
+        _keepLogs.Margin = new Thickness(0, 14, 0, 2);
+        _keepLogs.IsChecked = !main.Settings.TruncateLogs;
+        _keepLogs.IsCheckedChanged += (_, _) =>
+        {
+            if (_ready) _main.SetTruncateLogs(_keepLogs.IsChecked != true);
+        };
+
+        _pageImage.MaxHeight = 320;
+        _pageImage.MaxWidth = 528;
+        _pageImage.Stretch = Stretch.Uniform;
+        _imageFrame.Margin = new Thickness(0, 14, 0, 0);
+        _imageFrame.HorizontalAlignment = HorizontalAlignment.Center;
+        _imageFrame.BorderBrush = AppTheme.BorderBrush;
+        _imageFrame.BorderThickness = new Thickness(1);
+        _imageFrame.CornerRadius = new CornerRadius(6);
+        _imageFrame.Child = _pageImage;
+
+        _previous = AppTheme.IconButton("◀ Previous", "Previous page");
+        _previous.FontSize = 12;
+        _previous.Click += (_, _) => { if (_page > 0) { _page--; Render(); } };
+        _next = AppTheme.IconButton("Next ▶", "Next page");
+        _next.FontSize = 12;
+        _next.FontWeight = FontWeight.SemiBold;
+        _next.Foreground = AppTheme.AccentBrush;
+        _next.Margin = new Thickness(14, 0, 0, 0);
+        _next.Click += (_, _) =>
+        {
+            if (_page < Pages.Length - 1) { _page++; Render(); }
+            else Finish();
+        };
+
+        Content = BuildContent();
+        PointerPressed += OnDrag;
+        _ready = true;
+        Render();
+    }
+
+    private Control BuildContent()
+    {
+        var header = new Grid();
+        header.Children.Add(_pageTitle);
+        header.Children.Add(_pageDots);
+
+        var never = AppTheme.IconButton("Never show again", "Don't show this tour at launch");
+        never.FontSize = 12;
+        never.Foreground = AppTheme.DimBrush;
+        never.Click += (_, _) => Finish();
+        var skip = AppTheme.IconButton("Skip for now", "Show this tour again next launch");
+        skip.FontSize = 12;
+        skip.Foreground = AppTheme.DimBrush;
+        skip.Margin = new Thickness(10, 0, 0, 0);
+        skip.Click += (_, _) => Close();
+        var left = new StackPanel { Orientation = Orientation.Horizontal };
+        left.Children.Add(never);
+        left.Children.Add(skip);
+
+        var right = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+        };
+        right.Children.Add(_previous);
+        right.Children.Add(_next);
+        var buttons = new Grid { Margin = new Thickness(0, 18, 0, 0) };
+        buttons.Children.Add(left);
+        buttons.Children.Add(right);
+
+        var panel = new StackPanel();
+        panel.Children.Add(header);
+        panel.Children.Add(_pageBody);
+        panel.Children.Add(_keepLogs);
+        panel.Children.Add(_imageFrame);
+        panel.Children.Add(buttons);
+        return new Border
+        {
+            Background = AppTheme.BgBrush,
+            BorderBrush = AppTheme.BorderBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(10),
+            Padding = new Thickness(20, 16),
+            Child = panel,
+        };
+    }
+
+    private void Render()
+    {
+        var page = Pages[_page];
+        _pageTitle.Text = page.Title;
+        _pageBody.Text = page.Body;
+        _pageDots.Text = $"{_page + 1} of {Pages.Length}";
+        _keepLogs.IsVisible = page.TruncationChoice;
+        _imageFrame.IsVisible = page.Image is not null;
+        if (page.Image is { } image)
+        {
+            using var stream = AssetLoader.Open(
+                new Uri($"avares://EQBuddy.Avalonia/Assets/tutorial/{image}"));
+            _pageImage.Source = new Bitmap(stream);
+        }
+        _previous.IsEnabled = _page > 0;
+        _next.Content = _page == Pages.Length - 1 ? "Finish ✔" : "Next ▶";
+    }
+
+    private void Finish()
+    {
+        _main.Settings.ShowTutorial = false;
+        _main.PersistSettings();
+        Close();
+    }
+
+    private void OnDrag(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.Source is Visual source && source.GetSelfAndVisualAncestors().Any(IsInteractiveControl))
+            return;
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(e);
+    }
+
+    private static bool IsInteractiveControl(Visual visual) => visual is Button or CheckBox;
+}


### PR DESCRIPTION
1.8.9:  This now matches.
1.8.10:  No changes needed, but I can't test due to beta being closed.
1.8.11:  Implemented, but can't test.
1.8.12:  You didn't comment, but it looks like there were some minor renaming or small UI changes.  I believe I matched these.
1.8.13:  I matched the implementation here, complete with your Windows screenshots.  I think it's all close enough to make no difference, but if we get feedback I can try to replace them.

Aside:  It looks like you renamed "Tracked Loot" to "Watch Rules" in the Options.  But the card still says "Tracked".  I left Avalonia to match.