### PR TITLE
Move the History window UI to follow a shared ViewModel/Presentation layer that can be better shared with the WPF version

### DIFF
--- a/EQBuddy.slnx
+++ b/EQBuddy.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj" />
     <Project Path="src/EQBuddy.Core/EQBuddy.Core.csproj" />
+    <Project Path="src/EQBuddy.UI.Shared/EQBuddy.UI.Shared.csproj" />
     <Project Path="src/EQBuddy/EQBuddy.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/src/EQBuddy.Avalonia/AlertWindow.cs
+++ b/src/EQBuddy.Avalonia/AlertWindow.cs
@@ -1,0 +1,131 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using EQBuddy.Core;
+
+namespace EQBuddy.Avalonia;
+
+/// <summary>
+/// Floating tracked-rule alert tile. During play it never activates and its X11 input
+/// region is empty; while Options is open it becomes a draggable placement target.
+/// </summary>
+public sealed class AlertWindow : Window
+{
+    private readonly AppSettings _settings;
+    private readonly MainWindow _owner;
+    private readonly TextBlock _alertText;
+    private readonly DispatcherTimer _hide;
+    private bool _placement;
+
+    public AlertWindow(AppSettings settings, MainWindow owner)
+    {
+        _settings = settings;
+        _owner = owner;
+        Title = "EQBuddy Alert";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        WindowDecorations = global::Avalonia.Controls.WindowDecorations.None;
+        TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
+        Background = Brushes.Transparent;
+        Topmost = true;
+        ShowInTaskbar = false;
+        ShowActivated = false;
+        CanResize = false;
+
+        _alertText = new TextBlock
+        {
+            FontSize = 13,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = AppTheme.AccentBrush,
+            TextWrapping = TextWrapping.Wrap,
+        };
+        Content = new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0xF0, 0x1E, 0x1A, 0x14)),
+            BorderBrush = AppTheme.AccentBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(12, 8),
+            MaxWidth = 380,
+            Child = _alertText,
+        };
+
+        _hide = new DispatcherTimer { Interval = TimeSpan.FromSeconds(6) };
+        _hide.Tick += (_, _) =>
+        {
+            _hide.Stop();
+            if (!_placement) Hide();
+        };
+        Opened += (_, _) => ApplyClickThrough(!_placement);
+        PointerPressed += OnDrag;
+    }
+
+    public void ShowAlert(string text)
+    {
+        _alertText.Text = text;
+        PositionFromSettings();
+        ShowOwned();
+        Topmost = true;
+        _hide.Stop();
+        _hide.Start();
+    }
+
+    /// <summary>Show a draggable preview while Options is open.</summary>
+    public void EnterPlacement()
+    {
+        _placement = true;
+        _hide.Stop();
+        _alertText.Text = "★ Alert banner — drag me to where alerts should appear";
+        PositionFromSettings();
+        ShowOwned();
+        ApplyClickThrough(false);
+        Topmost = true;
+    }
+
+    /// <summary>Save the chosen location and restore play-mode click-through.</summary>
+    public void ExitPlacement()
+    {
+        if (!_placement) return;
+        _placement = false;
+        _settings.AlertLeft = Position.X;
+        _settings.AlertTop = Position.Y;
+        _settings.Save();
+        ApplyClickThrough(true);
+        Hide();
+    }
+
+    private void ShowOwned()
+    {
+        if (!IsVisible) Show(_owner);
+    }
+
+    private void PositionFromSettings()
+    {
+        var screen = _owner.Screens.ScreenFromWindow(_owner) ?? _owner.Screens.Primary;
+        var work = screen?.WorkingArea ?? new PixelRect(0, 0, 1920, 1080);
+        var left = _settings.AlertLeft;
+        var top = _settings.AlertTop;
+        if (double.IsNaN(left) || double.IsNaN(top))
+        {
+            left = _owner.Position.X;
+            top = _owner.Position.Y - 64;
+        }
+
+        Position = new PixelPoint(
+            (int)Math.Clamp(left, work.X, work.Right - 140),
+            (int)Math.Clamp(top, work.Y, work.Bottom - 44));
+    }
+
+    private void OnDrag(object? sender, PointerPressedEventArgs e)
+    {
+        if (_placement && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(e);
+    }
+
+    private void ApplyClickThrough(bool enabled)
+    {
+        if (TryGetPlatformHandle() is null) return;
+        X11ClickThrough.Set(this, enabled);
+    }
+}

--- a/src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj
+++ b/src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EQBuddy.Core\EQBuddy.Core.csproj" />
+    <ProjectReference Include="..\EQBuddy.UI.Shared\EQBuddy.UI.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj
+++ b/src/EQBuddy.Avalonia/EQBuddy.Avalonia.csproj
@@ -20,4 +20,9 @@
     <ProjectReference Include="..\EQBuddy.Core\EQBuddy.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AvaloniaResource Include="..\EQBuddy\Assets\tutorial\*.png"
+                      Link="Assets\tutorial\%(Filename)%(Extension)" />
+  </ItemGroup>
+
 </Project>

--- a/src/EQBuddy.Avalonia/HistoryWindow.axaml
+++ b/src/EQBuddy.Avalonia/HistoryWindow.axaml
@@ -1,0 +1,149 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:shared="using:EQBuddy.UI.Shared"
+        x:Class="EQBuddy.Avalonia.HistoryWindow"
+        x:DataType="shared:HistoryViewModel"
+        Title="EQBuddy - Session History"
+        Width="860" Height="560"
+        MinWidth="640" MinHeight="400"
+        Background="#FF1C1917"
+        WindowStartupLocation="CenterScreen">
+
+  <Window.Styles>
+    <Style Selector="TextBlock">
+      <Setter Property="Foreground" Value="#FFEDE4D3" />
+    </Style>
+    <Style Selector="TextBlock.dim">
+      <Setter Property="Foreground" Value="#FF9C927F" />
+      <Setter Property="FontSize" Value="11" />
+    </Style>
+    <Style Selector="TextBox.dark">
+      <Setter Property="FontSize" Value="12" />
+      <Setter Property="Padding" Value="6,4" />
+      <Setter Property="Background" Value="#FF2A251F" />
+      <Setter Property="Foreground" Value="#FFEDE4D3" />
+      <Setter Property="BorderBrush" Value="#66C9A227" />
+      <Setter Property="CaretBrush" Value="#FFE3B341" />
+      <Setter Property="SelectionBrush" Value="#77E3B341" />
+    </Style>
+    <Style Selector="ComboBox.dark">
+      <Setter Property="FontSize" Value="12" />
+      <Setter Property="Background" Value="#FF2A251F" />
+      <Setter Property="Foreground" Value="#FFEDE4D3" />
+      <Setter Property="BorderBrush" Value="#66C9A227" />
+    </Style>
+    <Style Selector="Button.action">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Foreground" Value="#FF9C927F" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="6,2" />
+      <Setter Property="FontSize" Value="12" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="Button.action:pointerover">
+      <Setter Property="Background" Value="#33FFD98C" />
+      <Setter Property="Foreground" Value="#FFEDE4D3" />
+    </Style>
+    <Style Selector="Button.danger">
+      <Setter Property="Foreground" Value="#FFD9634F" />
+    </Style>
+    <Style Selector="ListBoxItem">
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="Margin" Value="0,0,0,2" />
+      <Setter Property="Padding" Value="8,6" />
+      <Setter Property="Background" Value="#552A251F" />
+      <Setter Property="BorderBrush" Value="#66C9A227" />
+      <Setter Property="BorderThickness" Value="0,0,0,1" />
+    </Style>
+    <Style Selector="ListBoxItem:pointerover">
+      <Setter Property="Background" Value="#772F2A22" />
+    </Style>
+    <Style Selector="ListBoxItem:selected">
+      <Setter Property="Background" Value="#885A4513" />
+      <Setter Property="BorderBrush" Value="#FFE3B341" />
+    </Style>
+  </Window.Styles>
+
+  <Grid Margin="10" RowDefinitions="Auto,*" ColumnDefinitions="330,*">
+    <Grid Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,8"
+          ColumnDefinitions="180,*,Auto,Auto">
+      <ComboBox x:Name="CharFilter"
+                Classes="dark"
+                ItemsSource="{Binding Filters}"
+                SelectedItem="{Binding SelectedFilter}"
+                SelectionChanged="OnFilterChanged" />
+      <TextBox x:Name="SearchBox"
+               Grid.Column="1"
+               Classes="dark"
+               Margin="8,0,0,0"
+               Text="{Binding SearchText}"
+               TextChanged="OnSearchChanged"
+               PlaceholderText="Search"
+               ToolTip.Tip="Search character, zone, notes, tags, loot, or creature names" />
+      <TextBlock Grid.Column="2"
+                 Classes="dim"
+                 VerticalAlignment="Center"
+                 Margin="8,0,0,0"
+                 Text="{Binding CountText}" />
+      <Button Grid.Column="3"
+              Classes="action"
+              Margin="8,0,0,0"
+              Content="Import log..."
+              Click="OnImportLog"
+              ToolTip.Tip="Parse an existing eqlog file into session history" />
+    </Grid>
+
+    <ListBox x:Name="SessionList"
+             Grid.Row="1"
+             ItemsSource="{Binding Sessions}"
+             SelectionMode="Multiple"
+             SelectionChanged="OnSessionSelected"
+             Background="#441C1917"
+             BorderThickness="0"
+             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+      <ListBox.ItemTemplate>
+        <DataTemplate x:DataType="shared:HistorySessionItem">
+          <TextBlock Text="{Binding DisplayText}"
+                     FontSize="12"
+                     TextWrapping="Wrap" />
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
+
+    <Grid Grid.Row="1" Grid.Column="1" Margin="10,0,0,0" RowDefinitions="*,Auto">
+      <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <TextBlock FontSize="12"
+                   TextWrapping="Wrap"
+                   Foreground="#FFEDE4D3"
+                   FontFamily="Consolas, monospace"
+                   Text="{Binding DetailText}" />
+      </ScrollViewer>
+
+      <StackPanel Grid.Row="1" Margin="0,8,0,0">
+        <Grid ColumnDefinitions="Auto,*">
+          <TextBlock Classes="dim" Text="Notes:"
+                     VerticalAlignment="Center" Margin="0,0,6,0" />
+          <TextBox x:Name="NoteBox"
+                   Grid.Column="1"
+                   Classes="dark"
+                   Text="{Binding Note}" />
+        </Grid>
+        <Grid Margin="0,4,0,0" ColumnDefinitions="Auto,*">
+          <TextBlock Classes="dim" Text="Tags:"
+                     VerticalAlignment="Center" Margin="0,0,6,0" />
+          <TextBox x:Name="TagsBox"
+                   Grid.Column="1"
+                   Classes="dark"
+                   Text="{Binding Tags}"
+                   ToolTip.Tip="Comma-separated, e.g. solo, basement, new weapon" />
+        </Grid>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+          <Button Classes="action" Content="Save notes" Click="OnSaveMeta" />
+          <Button Classes="action" Content="Copy summary" Click="OnCopySummary" Margin="8,0,0,0" />
+          <Button Classes="action" Content="Export JSON" Click="OnExportJson" Margin="8,0,0,0" />
+          <Button Classes="action danger" Content="Delete session" Click="OnDelete" Margin="24,0,0,0" />
+        </StackPanel>
+      </StackPanel>
+    </Grid>
+  </Grid>
+</Window>

--- a/src/EQBuddy.Avalonia/HistoryWindow.cs
+++ b/src/EQBuddy.Avalonia/HistoryWindow.cs
@@ -1,198 +1,63 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
-using Avalonia.Input;
 using Avalonia.Input.Platform;
-using Avalonia.Layout;
-using Avalonia.Media;
+using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using EQBuddy.Core;
 using EQBuddy.UI.Shared;
 
 namespace EQBuddy.Avalonia;
 
-public sealed class HistoryWindow : Window
+public sealed partial class HistoryWindow : Window
 {
     private readonly HistoryViewModel _viewModel;
-    private readonly ComboBox _charFilter = new() { Width = 180 };
-    private readonly TextBox _searchBox = TextBox("");
-    private readonly TextBlock _countText = AppTheme.DimText("");
-    private readonly StackPanel _sessionRows = new();
-    private readonly TextBlock _detailText = new()
-    {
-        Text = HistoryPresentation.SelectSessionText,
-        FontSize = 12,
-        TextWrapping = TextWrapping.Wrap,
-        Foreground = AppTheme.TextBrush,
-        FontFamily = FontFamily.Parse("Consolas, monospace"),
-    };
-    private readonly TextBox _noteBox = TextBox("");
-    private readonly TextBox _tagsBox = TextBox("");
-    private bool _rendering;
+    private bool _refreshing;
 
     public HistoryWindow(SessionRepository repository)
     {
         _viewModel = new HistoryViewModel(repository);
-        Title = "EQBuddy - Session History";
-        Width = 860;
-        Height = 560;
-        MinWidth = 640;
-        MinHeight = 400;
-        Background = AppTheme.BgBrush;
-        StyleDarkCombo(_charFilter);
-        Content = BuildContent();
-        RenderAll();
+        InitializeComponent();
+        DataContext = _viewModel;
     }
 
-    private Control BuildContent()
+    private void OnFilterChanged(object? sender, SelectionChangedEventArgs e)
     {
-        var root = new Grid { Margin = new Thickness(10) };
-        root.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
-        root.RowDefinitions.Add(new RowDefinition(GridLength.Star));
-        root.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(330)));
-        root.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-
-        var filter = new Grid { Margin = new Thickness(0, 0, 0, 8) };
-        filter.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(180)));
-        filter.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-        filter.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-        filter.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-        _charFilter.SelectionChanged += (_, _) =>
-        {
-            if (_rendering || _charFilter.SelectedItem is not HistoryFilterOption selected) return;
-            _viewModel.SelectedFilter = selected;
-            _viewModel.RefreshSessions();
-            RenderSessionsAndDetail();
-        };
-        filter.Children.Add(_charFilter);
-        _searchBox.Margin = new Thickness(8, 0, 0, 0);
-        _searchBox.TextChanged += (_, _) =>
-        {
-            if (_rendering) return;
-            _viewModel.SearchText = _searchBox.Text ?? "";
-            _viewModel.RefreshSessions();
-            RenderSessionsAndDetail();
-        };
-        Grid.SetColumn(_searchBox, 1);
-        filter.Children.Add(_searchBox);
-        _countText.VerticalAlignment = VerticalAlignment.Center;
-        _countText.Margin = new Thickness(8, 0, 0, 0);
-        Grid.SetColumn(_countText, 2);
-        filter.Children.Add(_countText);
-        var import = AppTheme.IconButton("Import log...", "Parse an existing eqlog file into session history");
-        import.FontSize = 12;
-        import.Margin = new Thickness(8, 0, 0, 0);
-        import.Click += OnImportLog;
-        Grid.SetColumn(import, 3);
-        filter.Children.Add(import);
-        Grid.SetColumnSpan(filter, 2);
-        root.Children.Add(filter);
-
-        var sessionScroll = new ScrollViewer
-        {
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
-            Background = new SolidColorBrush(Color.FromArgb(0x44, 0x1C, 0x19, 0x17)),
-            Content = _sessionRows,
-        };
-        Grid.SetRow(sessionScroll, 1);
-        root.Children.Add(sessionScroll);
-
-        var detail = new Grid { Margin = new Thickness(10, 0, 0, 0) };
-        detail.RowDefinitions.Add(new RowDefinition(GridLength.Star));
-        detail.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
-        detail.Children.Add(new ScrollViewer
-        {
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            Content = _detailText,
-        });
-        var meta = BuildMetaPanel();
-        Grid.SetRow(meta, 1);
-        detail.Children.Add(meta);
-        Grid.SetRow(detail, 1);
-        Grid.SetColumn(detail, 1);
-        root.Children.Add(detail);
-        return root;
+        if (_refreshing || CharFilter.SelectedItem is not HistoryFilterOption selected) return;
+        _viewModel.SelectedFilter = selected;
+        RefreshSessions();
     }
 
-    private Control BuildMetaPanel()
+    private void OnSearchChanged(object? sender, TextChangedEventArgs e)
     {
-        var panel = new StackPanel { Margin = new Thickness(0, 8, 0, 0) };
-        panel.Children.Add(LabeledBox("Notes:", _noteBox));
-        panel.Children.Add(LabeledBox("Tags:", _tagsBox, new Thickness(0, 4, 0, 0)));
-        var buttons = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 8, 0, 0) };
-        buttons.Children.Add(ActionButton("Save notes", OnSaveMeta));
-        buttons.Children.Add(ActionButton("Copy summary", OnCopySummary, new Thickness(8, 0, 0, 0)));
-        buttons.Children.Add(ActionButton("Export JSON", OnExportJson, new Thickness(8, 0, 0, 0)));
-        var delete = ActionButton("Delete session", OnDelete, new Thickness(24, 0, 0, 0));
-        delete.Foreground = AppTheme.BadBrush;
-        buttons.Children.Add(delete);
-        panel.Children.Add(buttons);
-        return panel;
+        if (_refreshing) return;
+        _viewModel.SearchText = SearchBox.Text ?? "";
+        RefreshSessions();
     }
 
-    private void RenderAll()
+    private void OnSessionSelected(object? sender, SelectionChangedEventArgs e)
     {
-        _rendering = true;
+        if (_refreshing) return;
+
+        foreach (var removed in e.RemovedItems.OfType<HistorySessionItem>())
+            _viewModel.SelectSession(removed.Row.Id, additive: true);
+        foreach (var added in e.AddedItems.OfType<HistorySessionItem>())
+            _viewModel.SelectSession(added.Row.Id, additive: true);
+    }
+
+    private void RefreshSessions()
+    {
+        _refreshing = true;
         try
         {
-            _charFilter.Items.Clear();
-            foreach (var filter in _viewModel.Filters) _charFilter.Items.Add(filter);
-            _charFilter.SelectedItem = _viewModel.SelectedFilter;
-            _searchBox.Text = _viewModel.SearchText;
+            _viewModel.RefreshSessions();
+            SessionList.SelectedItems?.Clear();
         }
         finally
         {
-            _rendering = false;
-        }
-        RenderSessionsAndDetail();
-    }
-
-    private void RenderSessionsAndDetail()
-    {
-        _sessionRows.Children.Clear();
-        foreach (var item in _viewModel.Sessions)
-            _sessionRows.Children.Add(SessionRow(item));
-        RenderDetail();
-    }
-
-    private void RenderDetail()
-    {
-        _rendering = true;
-        try
-        {
-            _countText.Text = _viewModel.CountText;
-            _detailText.Text = _viewModel.DetailText;
-            _noteBox.Text = _viewModel.Note;
-            _tagsBox.Text = _viewModel.Tags;
-            RefreshRowSelectionVisuals();
-        }
-        finally
-        {
-            _rendering = false;
+            _refreshing = false;
         }
     }
 
-    private void OnSessionSelected(long id, KeyModifiers modifiers)
-    {
-        _viewModel.SelectSession(id, modifiers.HasFlag(KeyModifiers.Control));
-        RenderDetail();
-    }
-
-    private void RefreshRowSelectionVisuals()
-    {
-        for (var i = 0; i < _sessionRows.Children.Count && i < _viewModel.Sessions.Count; i++)
-        {
-            if (_sessionRows.Children[i] is not Border row) continue;
-            var selected = _viewModel.IsSelected(_viewModel.Sessions[i].Row.Id);
-            row.Background = selected
-                ? new SolidColorBrush(Color.FromArgb(0x88, 0x5A, 0x45, 0x13))
-                : new SolidColorBrush(Color.FromArgb(0x55, 0x2A, 0x25, 0x1F));
-            row.BorderBrush = selected ? AppTheme.AccentBrush : AppTheme.BorderBrush;
-        }
-    }
-
-    private async void OnImportLog(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    private async void OnImportLog(object? sender, RoutedEventArgs e)
     {
         var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
         {
@@ -207,35 +72,31 @@ public sealed class HistoryWindow : Window
         var path = files.FirstOrDefault()?.TryGetLocalPath();
         if (path is null) return;
 
-        _detailText.Text = HistoryPresentation.BuildImporting(path);
         try
         {
             await _viewModel.ImportAsync(path);
-            RenderAll();
         }
         catch (Exception ex)
         {
             CoreLog.Error(ex);
-            _detailText.Text = $"Could not import {Path.GetFileName(path)}.";
         }
     }
 
-    private void OnSaveMeta(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    private void OnSaveMeta(object? sender, RoutedEventArgs e)
     {
-        _viewModel.Note = _noteBox.Text ?? "";
-        _viewModel.Tags = _tagsBox.Text ?? "";
+        _viewModel.Note = NoteBox.Text ?? "";
+        _viewModel.Tags = TagsBox.Text ?? "";
         _viewModel.SaveMetadata();
-        RenderSessionsAndDetail();
     }
 
-    private async void OnCopySummary(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    private async void OnCopySummary(object? sender, RoutedEventArgs e)
     {
         if (_viewModel.SelectedSummary is not { } summary) return;
         if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
             await clipboard.SetTextAsync(summary);
     }
 
-    private async void OnExportJson(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    private async void OnExportJson(object? sender, RoutedEventArgs e)
     {
         if (_viewModel.ExportFileName is not { } fileName || _viewModel.ExportJson is not { } json) return;
         var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
@@ -248,105 +109,8 @@ public sealed class HistoryWindow : Window
         if (path is not null) await File.WriteAllTextAsync(path, json);
     }
 
-    private void OnDelete(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    private void OnDelete(object? sender, RoutedEventArgs e)
     {
         _viewModel.DeleteSelected();
-        RenderAll();
-    }
-
-    private static Control LabeledBox(string label, TextBox box, Thickness? margin = null)
-    {
-        var row = new Grid { Margin = margin ?? default };
-        row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-        row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-        row.Children.Add(AppTheme.DimText(label, new Thickness(0, 0, 6, 0)));
-        Grid.SetColumn(box, 1);
-        row.Children.Add(box);
-        return row;
-    }
-
-    private static Button ActionButton(string text,
-        EventHandler<global::Avalonia.Interactivity.RoutedEventArgs> action, Thickness? margin = null)
-    {
-        var button = AppTheme.IconButton(text, text);
-        button.FontSize = 12;
-        button.Margin = margin ?? default;
-        button.Click += action;
-        return button;
-    }
-
-    private static TextBox TextBox(string text)
-    {
-        var box = new TextBox
-        {
-            Text = text,
-            FontSize = 12,
-            Padding = new Thickness(6, 4),
-            Background = new SolidColorBrush(Color.FromRgb(0x2A, 0x25, 0x1F)),
-            Foreground = AppTheme.TextBrush,
-            BorderBrush = AppTheme.BorderBrush,
-            CaretBrush = AppTheme.AccentBrush,
-            SelectionBrush = new SolidColorBrush(Color.FromArgb(0x77, 0xE3, 0xB3, 0x41)),
-        };
-        box.GotFocus += (_, _) => ApplyDarkInput(box);
-        box.LostFocus += (_, _) => ApplyDarkInput(box);
-        return box;
-    }
-
-    private static void ApplyDarkInput(TextBox box)
-    {
-        box.Background = new SolidColorBrush(Color.FromRgb(0x2A, 0x25, 0x1F));
-        box.Foreground = AppTheme.TextBrush;
-        box.BorderBrush = AppTheme.BorderBrush;
-    }
-
-    private Border SessionRow(HistorySessionItem item)
-    {
-        var row = new Border
-        {
-            Margin = new Thickness(0, 0, 0, 2),
-            Background = new SolidColorBrush(Color.FromArgb(0x55, 0x2A, 0x25, 0x1F)),
-            BorderBrush = AppTheme.BorderBrush,
-            BorderThickness = new Thickness(0, 0, 0, 1),
-            Padding = new Thickness(8, 6),
-            Cursor = new Cursor(StandardCursorType.Hand),
-            Child = new TextBlock
-            {
-                Text = item.DisplayText,
-                FontSize = 12,
-                Foreground = AppTheme.TextBrush,
-                TextWrapping = TextWrapping.Wrap,
-            },
-        };
-        row.PointerPressed += (_, args) =>
-        {
-            OnSessionSelected(item.Row.Id, args.KeyModifiers);
-            args.Handled = true;
-        };
-        row.PointerEntered += (_, _) =>
-        {
-            if (!_viewModel.IsSelected(item.Row.Id))
-                row.Background = new SolidColorBrush(Color.FromArgb(0x77, 0x2F, 0x2A, 0x22));
-        };
-        row.PointerExited += (_, _) => RefreshRowSelectionVisuals();
-        return row;
-    }
-
-    private static void StyleDarkCombo(ComboBox combo)
-    {
-        combo.Background = new SolidColorBrush(Color.FromRgb(0x2A, 0x25, 0x1F));
-        combo.Foreground = AppTheme.TextBrush;
-        combo.BorderBrush = AppTheme.BorderBrush;
-        combo.FontSize = 12;
-        combo.GotFocus += (_, _) =>
-        {
-            combo.Background = new SolidColorBrush(Color.FromRgb(0x2A, 0x25, 0x1F));
-            combo.Foreground = AppTheme.TextBrush;
-        };
-        combo.LostFocus += (_, _) =>
-        {
-            combo.Background = new SolidColorBrush(Color.FromRgb(0x2A, 0x25, 0x1F));
-            combo.Foreground = AppTheme.TextBrush;
-        };
     }
 }

--- a/src/EQBuddy.Avalonia/HistoryWindow.cs
+++ b/src/EQBuddy.Avalonia/HistoryWindow.cs
@@ -235,7 +235,7 @@ public sealed class HistoryWindow : Window
             foreach (var d in s.DamageBySource.Take(8))
                 sb.AppendLine($"  {d.Name,-24} {ShareBar((double)d.Total / top),-10} {d.Total,8:N0}" +
                     $" - {100.0 * d.Total / grand,3:0}% - {d.Hits} hits - avg {(double)d.Total / Math.Max(1, d.Hits):0.#}" +
-                    (d.ActiveSeconds > 0 ? $" - {d.Total / d.ActiveSeconds:0.#} dps" : "") +
+                    $" - {d.Total / Math.Max(1, s.CombatSeconds):0.#} dps" +
                     (d.Crits > 0 ? $" - {100.0 * d.Crits / Math.Max(1, d.Hits):0}% crit" : ""));
             sb.AppendLine();
         }
@@ -248,7 +248,7 @@ public sealed class HistoryWindow : Window
                 sb.AppendLine($"  {h.Name,-24} {ShareBar((double)h.Total / top),-10} {h.Total,8:N0}" +
                     $" - {100.0 * h.Total / grand,3:0}% - {h.Hits} cast{(h.Hits == 1 ? "" : "s")}" +
                     $" - avg {(double)h.Total / Math.Max(1, h.Hits):0.#}" +
-                    (h.ActiveSeconds > 0 ? $" - {h.Total / h.ActiveSeconds:0.#} hps" : ""));
+                    $" - {h.Total / Math.Max(1, s.CombatSeconds):0.#} hps");
             sb.AppendLine();
         }
         if (s.YourKills.Count > 0)

--- a/src/EQBuddy.Avalonia/HistoryWindow.cs
+++ b/src/EQBuddy.Avalonia/HistoryWindow.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using System.Text;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -8,21 +6,21 @@ using Avalonia.Input.Platform;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
-using Avalonia.Threading;
 using EQBuddy.Core;
+using EQBuddy.UI.Shared;
 
 namespace EQBuddy.Avalonia;
 
 public sealed class HistoryWindow : Window
 {
-    private readonly SessionRepository _repo;
+    private readonly HistoryViewModel _viewModel;
     private readonly ComboBox _charFilter = new() { Width = 180 };
     private readonly TextBox _searchBox = TextBox("");
     private readonly TextBlock _countText = AppTheme.DimText("");
     private readonly StackPanel _sessionRows = new();
     private readonly TextBlock _detailText = new()
     {
-        Text = "Select a session.",
+        Text = HistoryPresentation.SelectSessionText,
         FontSize = 12,
         TextWrapping = TextWrapping.Wrap,
         Foreground = AppTheme.TextBrush,
@@ -30,14 +28,11 @@ public sealed class HistoryWindow : Window
     };
     private readonly TextBox _noteBox = TextBox("");
     private readonly TextBox _tagsBox = TextBox("");
-    private List<SessionRow> _rows = [];
-    private readonly HashSet<int> _selectedIndexes = [];
-    private SessionRow? _selected;
-    private StatsSnapshot? _selectedSnapshot;
+    private bool _rendering;
 
-    public HistoryWindow(SessionRepository repo)
+    public HistoryWindow(SessionRepository repository)
     {
-        _repo = repo;
+        _viewModel = new HistoryViewModel(repository);
         Title = "EQBuddy - Session History";
         Width = 860;
         Height = 560;
@@ -46,8 +41,7 @@ public sealed class HistoryWindow : Window
         Background = AppTheme.BgBrush;
         StyleDarkCombo(_charFilter);
         Content = BuildContent();
-        RefreshFilters();
-        RefreshList();
+        RenderAll();
     }
 
     private Control BuildContent()
@@ -63,10 +57,22 @@ public sealed class HistoryWindow : Window
         filter.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
         filter.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
         filter.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
-        _charFilter.SelectionChanged += (_, _) => RefreshList();
+        _charFilter.SelectionChanged += (_, _) =>
+        {
+            if (_rendering || _charFilter.SelectedItem is not HistoryFilterOption selected) return;
+            _viewModel.SelectedFilter = selected;
+            _viewModel.RefreshSessions();
+            RenderSessionsAndDetail();
+        };
         filter.Children.Add(_charFilter);
         _searchBox.Margin = new Thickness(8, 0, 0, 0);
-        _searchBox.TextChanged += (_, _) => RefreshList();
+        _searchBox.TextChanged += (_, _) =>
+        {
+            if (_rendering) return;
+            _viewModel.SearchText = _searchBox.Text ?? "";
+            _viewModel.RefreshSessions();
+            RenderSessionsAndDetail();
+        };
         Grid.SetColumn(_searchBox, 1);
         filter.Children.Add(_searchBox);
         _countText.VerticalAlignment = VerticalAlignment.Center;
@@ -95,8 +101,11 @@ public sealed class HistoryWindow : Window
         var detail = new Grid { Margin = new Thickness(10, 0, 0, 0) };
         detail.RowDefinitions.Add(new RowDefinition(GridLength.Star));
         detail.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
-        var scroll = new ScrollViewer { VerticalScrollBarVisibility = ScrollBarVisibility.Auto, Content = _detailText };
-        detail.Children.Add(scroll);
+        detail.Children.Add(new ScrollViewer
+        {
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            Content = _detailText,
+        });
         var meta = BuildMetaPanel();
         Grid.SetRow(meta, 1);
         detail.Children.Add(meta);
@@ -122,201 +131,65 @@ public sealed class HistoryWindow : Window
         return panel;
     }
 
-    private void RefreshFilters()
+    private void RenderAll()
     {
-        var current = _charFilter.SelectedItem as string;
-        _charFilter.Items.Clear();
-        _charFilter.Items.Add("All characters");
-        foreach (var (server, character) in _repo.Characters())
-            _charFilter.Items.Add($"{character} ({server})");
-        _charFilter.SelectedItem = current is not null && _charFilter.Items.Contains(current)
-            ? current : "All characters";
+        _rendering = true;
+        try
+        {
+            _charFilter.Items.Clear();
+            foreach (var filter in _viewModel.Filters) _charFilter.Items.Add(filter);
+            _charFilter.SelectedItem = _viewModel.SelectedFilter;
+            _searchBox.Text = _viewModel.SearchText;
+        }
+        finally
+        {
+            _rendering = false;
+        }
+        RenderSessionsAndDetail();
     }
 
-    private (string? Server, string? Character) SelectedFilter()
+    private void RenderSessionsAndDetail()
     {
-        if (_charFilter.SelectedItem is not string sel || sel == "All characters")
-            return (null, null);
-        var open = sel.LastIndexOf(" (", StringComparison.Ordinal);
-        return (sel[(open + 2)..^1], sel[..open]);
-    }
-
-    private void RefreshList()
-    {
-        var (server, character) = SelectedFilter();
-        _rows = _repo.Query(server, character, _searchBox.Text);
-        _selectedIndexes.Clear();
-        _selected = null;
-        _selectedSnapshot = null;
         _sessionRows.Children.Clear();
-        for (var i = 0; i < _rows.Count; i++)
-        {
-            var r = _rows[i];
-            var dur = TimeSpan.FromSeconds(r.ElapsedSeconds);
-            _sessionRows.Children.Add(SessionRow(i,
-                $"{r.StartLocal:MMM d h:mm tt} - {r.Character}\n" +
-                $"   {(r.PrimaryZone.Length > 0 ? r.PrimaryZone : "-")} - {(int)dur.TotalHours}h {dur.Minutes}m - " +
-                $"{r.Kills} kills - {r.XpPercent:0.#}% xp - {StatsSnapshot.FormatCoin(r.Copper)}" +
-                (r.EndReason == "RecoveredAfterCrash" ? " - (recovered)" : "") +
-                (r.EndReason == "Active" ? " - (in progress)" : "")));
-        }
-        _countText.Text = $"{_rows.Count} session{(_rows.Count == 1 ? "" : "s")}";
+        foreach (var item in _viewModel.Sessions)
+            _sessionRows.Children.Add(SessionRow(item));
+        RenderDetail();
     }
 
-    private void OnSessionSelected(int index, KeyModifiers modifiers)
+    private void RenderDetail()
     {
-        if (modifiers.HasFlag(KeyModifiers.Control))
+        _rendering = true;
+        try
         {
-            if (!_selectedIndexes.Remove(index))
-                _selectedIndexes.Add(index);
+            _countText.Text = _viewModel.CountText;
+            _detailText.Text = _viewModel.DetailText;
+            _noteBox.Text = _viewModel.Note;
+            _tagsBox.Text = _viewModel.Tags;
+            RefreshRowSelectionVisuals();
         }
-        else
+        finally
         {
-            _selectedIndexes.Clear();
-            _selectedIndexes.Add(index);
+            _rendering = false;
         }
-        RefreshRowSelectionVisuals();
+    }
 
-        if (_selectedIndexes.Count == 2)
-        {
-            var idx = _selectedIndexes.OrderBy(x => x).ToList();
-            _selected = null;
-            _selectedSnapshot = null;
-            _detailText.Text = BuildComparison(_rows[idx[0]], _rows[idx[1]]);
-            return;
-        }
-
-        if (index < 0 || index >= _rows.Count) { _selected = null; return; }
-        _selected = _rows[index];
-        _selectedSnapshot = _repo.LoadSnapshot(_selected.Id);
-        _noteBox.Text = _selected.Note;
-        _tagsBox.Text = _selected.Tags;
-        _detailText.Text = _selectedSnapshot is null
-            ? "Could not load session detail."
-            : BuildOverview(_selected, _selectedSnapshot);
+    private void OnSessionSelected(long id, KeyModifiers modifiers)
+    {
+        _viewModel.SelectSession(id, modifiers.HasFlag(KeyModifiers.Control));
+        RenderDetail();
     }
 
     private void RefreshRowSelectionVisuals()
     {
-        for (var i = 0; i < _sessionRows.Children.Count; i++)
+        for (var i = 0; i < _sessionRows.Children.Count && i < _viewModel.Sessions.Count; i++)
         {
             if (_sessionRows.Children[i] is not Border row) continue;
-            var selected = _selectedIndexes.Contains(i);
+            var selected = _viewModel.IsSelected(_viewModel.Sessions[i].Row.Id);
             row.Background = selected
                 ? new SolidColorBrush(Color.FromArgb(0x88, 0x5A, 0x45, 0x13))
                 : new SolidColorBrush(Color.FromArgb(0x55, 0x2A, 0x25, 0x1F));
             row.BorderBrush = selected ? AppTheme.AccentBrush : AppTheme.BorderBrush;
         }
-    }
-
-    internal static string BuildOverview(SessionRow r, StatsSnapshot s)
-    {
-        var sb = new StringBuilder();
-        var dur = TimeSpan.FromSeconds(r.ElapsedSeconds);
-        var act = TimeSpan.FromSeconds(r.ActiveSeconds);
-        sb.AppendLine($"{r.Character} ({r.Server}) - {r.StartLocal:dddd MMM d, h:mm tt}");
-        sb.AppendLine($"Duration {(int)dur.TotalHours}h {dur.Minutes}m - active {(int)act.TotalMinutes}m - ended: {r.EndReason}");
-        sb.AppendLine();
-        sb.AppendLine($"Kills      {s.YourKillCount} (+{s.PartyKillCount} group) - {s.KillsPerHour:0.0}/hr");
-        sb.AppendLine($"XP         {s.XpPercent:0.0}% - {s.XpPerHour:0.0}%/hr" +
-                      (s.Levels.Count > 0 ? $" - {string.Join(", ", s.Levels.Select(l => l.Text))}" : "") +
-                      (s.AaGained > 0 ? $" - {s.AaGained} AA" : ""));
-        sb.AppendLine($"Damage     {s.DamageDealt:N0} dealt - {s.SessionDps:0.0} dps - taken {s.DamageTaken:N0}");
-        if (s.HealingDone > 0)
-            sb.AppendLine($"Healing    {s.HealingDone:N0} done - {s.Hps:0.#} hps");
-        sb.AppendLine($"Money      {StatsSnapshot.FormatCoin(s.Copper)} ({StatsSnapshot.FormatCoin(s.CopperPerHour)}/hr)");
-        sb.AppendLine($"Deaths     {s.Deaths.Count}");
-        sb.AppendLine();
-        if (s.DamageBySource.Count > 0)
-        {
-            sb.AppendLine("Top damage sources:");
-            var grand = Math.Max(1, s.DamageBySource.Sum(x => x.Total));
-            var top = Math.Max(1, s.DamageBySource.Max(x => x.Total));
-            foreach (var d in s.DamageBySource.Take(8))
-                sb.AppendLine($"  {d.Name,-24} {ShareBar((double)d.Total / top),-10} {d.Total,8:N0}" +
-                    $" - {100.0 * d.Total / grand,3:0}% - {d.Hits} hits - avg {(double)d.Total / Math.Max(1, d.Hits):0.#}" +
-                    $" - {d.Total / Math.Max(1, s.CombatSeconds):0.#} dps" +
-                    (d.Crits > 0 ? $" - {100.0 * d.Crits / Math.Max(1, d.Hits):0}% crit" : ""));
-            sb.AppendLine();
-        }
-        if (s.HealsBySpell.Count > 0)
-        {
-            sb.AppendLine("Top heals:");
-            var grand = Math.Max(1, s.HealsBySpell.Sum(x => x.Total));
-            var top = Math.Max(1, s.HealsBySpell.Max(x => x.Total));
-            foreach (var h in s.HealsBySpell.Take(6))
-                sb.AppendLine($"  {h.Name,-24} {ShareBar((double)h.Total / top),-10} {h.Total,8:N0}" +
-                    $" - {100.0 * h.Total / grand,3:0}% - {h.Hits} cast{(h.Hits == 1 ? "" : "s")}" +
-                    $" - avg {(double)h.Total / Math.Max(1, h.Hits):0.#}" +
-                    $" - {h.Total / Math.Max(1, s.CombatSeconds):0.#} hps");
-            sb.AppendLine();
-        }
-        if (s.YourKills.Count > 0)
-        {
-            sb.AppendLine("Kills by creature:");
-            foreach (var k in s.YourKills.Take(10))
-                sb.AppendLine($"  {k.Name,-28} x{k.Count}");
-            sb.AppendLine();
-        }
-        if (s.Loot.Count > 0)
-        {
-            sb.AppendLine("Loot:");
-            foreach (var l in s.Loot.Take(15))
-                sb.AppendLine($"  {l.Item,-34} x{l.Count}");
-            sb.AppendLine();
-        }
-        var farmed = s.Mobs.Where(m => m.Kills > 0).Take(8).ToList();
-        if (farmed.Count > 0)
-        {
-            sb.AppendLine("Mob farming (observed personal rates):");
-            foreach (var m in farmed)
-            {
-                sb.AppendLine($"  {m.Name} - {m.Kills} kills - avg fight {m.AvgFightSeconds:0}s - " +
-                              $"{m.XpPercent:0.0}% xp - {StatsSnapshot.FormatCoin(m.Copper)}");
-                foreach (var l in m.Loot.Take(4))
-                    sb.AppendLine($"      {l.Item,-30} x{l.Count}" +
-                        (l.DropRatePct is { } pct ? $"  {pct:0.#}% ({l.Count}/{m.Kills})" : ""));
-            }
-            sb.AppendLine();
-        }
-        if (s.Stances.Count > 0)
-            sb.AppendLine("Stances: " + string.Join(" - ",
-                s.Stances.Select(x => $"{x.Name} {x.Damage:N0} dmg over {(int)x.CombatSeconds}s ({x.Dps:0.#} dps)")));
-        if (s.Zones.Count > 0)
-            sb.AppendLine("Zones: " + string.Join(" -> ", s.Zones.Select(z => z.Text)));
-        if (s.Markers.Count > 0)
-            sb.AppendLine("Markers: " + string.Join(" - ", s.Markers.Select(m => $"{m.Text} ({m.Time:h:mm tt})")));
-        return sb.ToString();
-    }
-
-    private static string ShareBar(double fraction) =>
-        new('█', Math.Clamp((int)Math.Round(fraction * 10), 1, 10));
-
-    private string BuildComparison(SessionRow ra, SessionRow rb)
-    {
-        var sa = _repo.LoadSnapshot(ra.Id);
-        var sb2 = _repo.LoadSnapshot(rb.Id);
-        if (sa is null || sb2 is null) return "Could not load one of the sessions.";
-        var b = new StringBuilder();
-        b.AppendLine("SESSION COMPARISON");
-        b.AppendLine($"A: {ra.Character} - {ra.StartLocal:MMM d h:mm tt} - {ra.PrimaryZone}");
-        b.AppendLine($"B: {rb.Character} - {rb.StartLocal:MMM d h:mm tt} - {rb.PrimaryZone}");
-        if (ra.Character != rb.Character || ra.PrimaryZone != rb.PrimaryZone)
-            b.AppendLine("(different character/zone - rates may not compare directly)");
-        b.AppendLine();
-        b.AppendLine($"{"",-16}{"A",14}{"B",14}");
-        void Row(string label, string a, string c) => b.AppendLine($"{label,-16}{a,14}{c,14}");
-        Row("Duration", $"{ra.ElapsedSeconds / 3600:0.0}h", $"{rb.ElapsedSeconds / 3600:0.0}h");
-        Row("Active", $"{ra.ActiveSeconds / 60:0}m", $"{rb.ActiveSeconds / 60:0}m");
-        Row("XP/hr", $"{sa.XpPerHour:0.0}%", $"{sb2.XpPerHour:0.0}%");
-        Row("Kills/hr", $"{sa.KillsPerHour:0.0}", $"{sb2.KillsPerHour:0.0}");
-        Row("Money/hr", StatsSnapshot.FormatCoin(sa.CopperPerHour), StatsSnapshot.FormatCoin(sb2.CopperPerHour));
-        Row("DPS", $"{sa.SessionDps:0.0}", $"{sb2.SessionDps:0.0}");
-        Row("HPS", $"{sa.Hps:0.0}", $"{sb2.Hps:0.0}");
-        Row("Damage taken", $"{sa.DamageTaken:N0}", $"{sb2.DamageTaken:N0}");
-        Row("Deaths", $"{sa.Deaths.Count}", $"{sb2.Deaths.Count}");
-        Row("Loot items", $"{sa.LootTotal}", $"{sb2.LootTotal}");
-        return b.ToString();
     }
 
     private async void OnImportLog(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
@@ -333,85 +206,52 @@ public sealed class HistoryWindow : Window
         });
         var path = files.FirstOrDefault()?.TryGetLocalPath();
         if (path is null) return;
-        var info = CharacterLog.FromPath(path);
-        var character = info?.Character ?? Path.GetFileNameWithoutExtension(path);
-        var server = info?.Server ?? "imported";
-        _detailText.Text = $"Importing {Path.GetFileName(path)}...";
-        _ = Task.Run(() =>
+
+        _detailText.Text = HistoryPresentation.BuildImporting(path);
+        try
         {
-            var imported = 0;
-            try
-            {
-                var stats = new SessionStats { CharacterName = character, ServerName = server };
-                stats.SessionEnding += snap =>
-                {
-                    if (SessionRepository.IsMeaningful(snap))
-                    {
-                        _repo.Checkpoint(0, snap, server, character, "ImportedBoundary");
-                        imported++;
-                    }
-                };
-                foreach (var line in File.ReadLines(path))
-                {
-                    var evt = LogParser.Parse(line);
-                    if (evt is not null) stats.Apply(evt);
-                }
-                var final = stats.Snapshot();
-                if (SessionRepository.IsMeaningful(final))
-                {
-                    _repo.Checkpoint(0, final, server, character, "ImportedBoundary");
-                    imported++;
-                }
-            }
-            catch (Exception ex) { CoreLog.Error(ex); }
-            Dispatcher.UIThread.Post(() =>
-            {
-                _detailText.Text = $"Imported {imported} session{(imported == 1 ? "" : "s")} from {Path.GetFileName(path)}.";
-                RefreshFilters();
-                RefreshList();
-            });
-        });
+            await _viewModel.ImportAsync(path);
+            RenderAll();
+        }
+        catch (Exception ex)
+        {
+            CoreLog.Error(ex);
+            _detailText.Text = $"Could not import {Path.GetFileName(path)}.";
+        }
     }
 
     private void OnSaveMeta(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
-        if (_selected is null) return;
-        _repo.SetNoteTags(_selected.Id, (_noteBox.Text ?? "").Trim(), (_tagsBox.Text ?? "").Trim());
-        RefreshList();
+        _viewModel.Note = _noteBox.Text ?? "";
+        _viewModel.Tags = _tagsBox.Text ?? "";
+        _viewModel.SaveMetadata();
+        RenderSessionsAndDetail();
     }
 
     private async void OnCopySummary(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
-        if (_selected is null || _selectedSnapshot is null) return;
+        if (_viewModel.SelectedSummary is not { } summary) return;
         if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
-            await clipboard.SetTextAsync(BuildOverview(_selected, _selectedSnapshot));
+            await clipboard.SetTextAsync(summary);
     }
 
     private async void OnExportJson(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
-        if (_selected is null || _selectedSnapshot is null) return;
+        if (_viewModel.ExportFileName is not { } fileName || _viewModel.ExportJson is not { } json) return;
         var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
         {
             Title = "Export session JSON",
-            SuggestedFileName = $"eqbuddy-{_selected.Character}-{_selected.StartLocal:yyyyMMdd-HHmm}.json",
+            SuggestedFileName = fileName,
             FileTypeChoices = [new FilePickerFileType("JSON") { Patterns = ["*.json"] }],
         });
         var path = file?.TryGetLocalPath();
-        if (path is null) return;
-        await File.WriteAllTextAsync(path,
-            System.Text.Json.JsonSerializer.Serialize(_selectedSnapshot,
-                new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+        if (path is not null) await File.WriteAllTextAsync(path, json);
     }
 
     private void OnDelete(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
     {
-        if (_selected is null) return;
-        _repo.Delete(_selected.Id);
-        _selected = null;
-        _selectedSnapshot = null;
-        _detailText.Text = "Select a session.";
-        RefreshFilters();
-        RefreshList();
+        _viewModel.DeleteSelected();
+        RenderAll();
     }
 
     private static Control LabeledBox(string label, TextBox box, Thickness? margin = null)
@@ -425,7 +265,8 @@ public sealed class HistoryWindow : Window
         return row;
     }
 
-    private static Button ActionButton(string text, EventHandler<global::Avalonia.Interactivity.RoutedEventArgs> action, Thickness? margin = null)
+    private static Button ActionButton(string text,
+        EventHandler<global::Avalonia.Interactivity.RoutedEventArgs> action, Thickness? margin = null)
     {
         var button = AppTheme.IconButton(text, text);
         button.FontSize = 12;
@@ -459,7 +300,7 @@ public sealed class HistoryWindow : Window
         box.BorderBrush = AppTheme.BorderBrush;
     }
 
-    private Border SessionRow(int index, string text)
+    private Border SessionRow(HistorySessionItem item)
     {
         var row = new Border
         {
@@ -471,7 +312,7 @@ public sealed class HistoryWindow : Window
             Cursor = new Cursor(StandardCursorType.Hand),
             Child = new TextBlock
             {
-                Text = text,
+                Text = item.DisplayText,
                 FontSize = 12,
                 Foreground = AppTheme.TextBrush,
                 TextWrapping = TextWrapping.Wrap,
@@ -479,12 +320,12 @@ public sealed class HistoryWindow : Window
         };
         row.PointerPressed += (_, args) =>
         {
-            OnSessionSelected(index, args.KeyModifiers);
+            OnSessionSelected(item.Row.Id, args.KeyModifiers);
             args.Handled = true;
         };
         row.PointerEntered += (_, _) =>
         {
-            if (!_selectedIndexes.Contains(index))
+            if (!_viewModel.IsSelected(item.Row.Id))
                 row.Background = new SolidColorBrush(Color.FromArgb(0x77, 0x2F, 0x2A, 0x22));
         };
         row.PointerExited += (_, _) => RefreshRowSelectionVisuals();

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -33,8 +33,6 @@ public sealed class MainWindow : Window
     private readonly TextBlock _charLabel = AppTheme.DimText("looking for a character...");
     private readonly ScrollViewer _sectionScroll = new();
     private readonly Border _logBanner = Banner(AppTheme.WarnBrush);
-    private readonly Border _alertBanner = Banner(AppTheme.AccentBrush);
-    private readonly TextBlock _alertText = new() { FontSize = 12, Foreground = AppTheme.AccentBrush, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap };
     private readonly Border _updateBanner = Banner(AppTheme.GoodBrush);
     private readonly TextBlock _updateText = new() { FontSize = 12, Foreground = AppTheme.GoodBrush, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap };
     private readonly TextBlock _zoneText = AppTheme.DimText("-");
@@ -106,6 +104,7 @@ public sealed class MainWindow : Window
     private X11HotkeyService? _hotkeys;
     private HistoryWindow? _historyWindow;
     private OptionsWindow? _optionsWindow;
+    private AlertWindow? _alertWindow;
     private StatSort _dmgOutSort = StatSort.Total;
     private StatSort _dmgInSort = StatSort.Total;
     private StatSort _healSort = StatSort.Total;
@@ -235,13 +234,10 @@ public sealed class MainWindow : Window
             Margin = new Thickness(10),
             Children =
             {
-                _alertBanner,
                 BuildMiniRoot(),
                 BuildNormalRoot(),
             },
         };
-        _alertBanner.Child = _alertText;
-        _alertBanner.Margin = new Thickness(0, 0, 0, 8);
         return _scaleRoot;
     }
 
@@ -647,11 +643,6 @@ public sealed class MainWindow : Window
             _updateBanner.IsVisible = false;
             _upToDateNoticeUntil = DateTime.MinValue;
         }
-        if (_alertUntil != DateTime.MinValue && DateTime.Now > _alertUntil)
-        {
-            _alertBanner.IsVisible = false;
-            _alertUntil = DateTime.MinValue;
-        }
         if (_watcher.LastError is { } err) App.LogError(err);
 
         var s = CurrentSnapshot();
@@ -820,7 +811,9 @@ public sealed class MainWindow : Window
     private readonly Dictionary<string, int> _ruleBaseline = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, DateTime> _ruleLastAlert = new(StringComparer.OrdinalIgnoreCase);
     private string? _alertBaselinePath;
-    private DateTime _alertUntil = DateTime.MinValue;
+
+    /// <summary>The floating alert tile, created on first use and owned by the widget.</summary>
+    internal AlertWindow AlertTile => _alertWindow ??= new AlertWindow(_settings, this);
 
     private void RenderTracked(StatsSnapshot s)
     {
@@ -897,11 +890,7 @@ public sealed class MainWindow : Window
             if (DateTime.Now - last < TimeSpan.FromSeconds(5)) continue;
             _ruleLastAlert[r.Name] = DateTime.Now;
             if (rule.AlertBanner)
-            {
-                _alertText.Text = $"* {r.Name}: {r.LastItem ?? "match"}{(delta > 1 ? $" x{delta}" : "")}";
-                _alertBanner.IsVisible = true;
-                _alertUntil = DateTime.Now.AddSeconds(6);
-            }
+                AlertTile.ShowAlert($"★ {r.Name}: {r.LastItem ?? "match"}{(delta > 1 ? $" ×{delta}" : "")}");
             if (rule.AlertSound) PlayAlertSound();
         }
     }
@@ -992,7 +981,9 @@ public sealed class MainWindow : Window
             return;
         }
         _optionsWindow = new OptionsWindow(this);
+        _optionsWindow.Closed += (_, _) => _alertWindow?.ExitPlacement();
         _optionsWindow.Show(this);
+        AlertTile.EnterPlacement();
     }
 
     private void OnHistory(object? sender, EventArgs e)
@@ -1420,6 +1411,7 @@ public sealed class MainWindow : Window
         if (_clickThrough)
             X11ClickThrough.Set(this, enabled: false);
         _hotkeys?.Dispose();
+        _alertWindow?.Close();
         _archiver.FinalizeActiveSync(CurrentSnapshot(), "ApplicationExit");
         _watcher.Dispose();
         _repo.Dispose();

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -512,7 +512,7 @@ public sealed class MainWindow : Window
         var version = new MenuItem { Header = $"EQBuddy v{UpdateChecker.CurrentVersion}", IsEnabled = false };
         var check = new MenuItem { Header = "Check for updates" };
         check.Click += (_, _) => { _lastUpdateCheck = DateTime.Now; CheckForUpdates(manual: true); };
-        var options = new MenuItem { Header = "Options... (size, opacity, tracked loot)" };
+        var options = new MenuItem { Header = "Options... (size, opacity, watch rules)" };
         options.Click += OnOptions;
         var marker = new MenuItem { Header = "Drop camp marker" };
         marker.Click += (_, _) => DropCampMarker();

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -130,6 +130,10 @@ public sealed class MainWindow : Window
         Opacity = _settings.Opacity;
         Content = BuildRoot();
 
+        // Migration: any old per-rule pin enables the replacement group pin.
+        if (!_settings.PinWatchChips && _settings.TrackedRules.Any(r => r.Pinned))
+            _settings.PinWatchChips = true;
+
         if (_settings.LogFolder is { } saved && !Directory.Exists(saved))
             _settings.LogFolder = null;
         _settings.LogFolder ??= LogWatcher.FindDefaultLogFolder();
@@ -146,7 +150,9 @@ public sealed class MainWindow : Window
 
         if (_settings.LogFolder is { } lf)
         {
-            var prune = _settings.TruncateLogs;
+            // Page one of the launch tour is the log-truncation consent question.
+            // Leave existing logs untouched until the user has answered it.
+            var prune = _settings.TruncateLogs && !_settings.ShowTutorial;
             Task.Run(() =>
             {
                 EqConfig.EnsureLoggingEnabled(lf);
@@ -161,6 +167,8 @@ public sealed class MainWindow : Window
         {
             UpdateWindowHeightLimit();
             RegisterGlobalHotkeys();
+            if (_settings.ShowTutorial)
+                new TutorialWindow(this).Show(this);
         };
     }
 
@@ -514,6 +522,8 @@ public sealed class MainWindow : Window
         check.Click += (_, _) => { _lastUpdateCheck = DateTime.Now; CheckForUpdates(manual: true); };
         var options = new MenuItem { Header = "Options... (size, opacity, watch rules)" };
         options.Click += OnOptions;
+        var tutorial = new MenuItem { Header = "Quick tutorial..." };
+        tutorial.Click += OnTutorial;
         var marker = new MenuItem { Header = "Drop camp marker" };
         marker.Click += (_, _) => DropCampMarker();
         var history = new MenuItem { Header = "Session history..." };
@@ -531,6 +541,7 @@ public sealed class MainWindow : Window
         menu.Items.Add(version);
         menu.Items.Add(check);
         menu.Items.Add(options);
+        menu.Items.Add(tutorial);
         menu.Items.Add(marker);
         menu.Items.Add(history);
         menu.Items.Add(new Separator());
@@ -629,7 +640,7 @@ public sealed class MainWindow : Window
         if (_settings.LogFolder is { } folder && DateTime.Now - _lastJanitorRun > TimeSpan.FromMinutes(10))
         {
             _lastJanitorRun = DateTime.Now;
-            var prune = _settings.TruncateLogs;
+            var prune = _settings.TruncateLogs && !_settings.ShowTutorial;
             Task.Run(() =>
             {
                 EqConfig.EnsureLoggingEnabled(folder);
@@ -952,7 +963,9 @@ public sealed class MainWindow : Window
                 Margin = new Thickness(0, 0, 12, 0),
             });
         }
-        foreach (var rule in _settings.TrackedRules.Where(r => r.Enabled && r.Pinned))
+        foreach (var rule in _settings.PinWatchChips
+                     ? _settings.TrackedRules.Where(r => r.Enabled)
+                     : [])
         {
             var name = rule.Name.Length > 0 ? rule.Name : rule.Pattern;
             var result = s.Tracked.FirstOrDefault(t =>
@@ -985,6 +998,8 @@ public sealed class MainWindow : Window
         _optionsWindow.Show(this);
         AlertTile.EnterPlacement();
     }
+
+    private void OnTutorial(object? sender, EventArgs e) => new TutorialWindow(this).Show(this);
 
     private void OnHistory(object? sender, EventArgs e)
     {

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -479,8 +479,9 @@ public sealed class MainWindow : Window
         sortBar.HorizontalAlignment = HorizontalAlignment.Right;
         sortBar.Children.Add(AppTheme.DimText("sort:", new Thickness(0, 0, 4, 0)));
         total = SortLink("total", "total", handler, selected: true);
+        var rateSubject = title.Contains("Heal", StringComparison.OrdinalIgnoreCase) ? "spell" : "ability";
         rate = rateText is null ? null : SortLink(rateText, "rate", handler,
-            tip: $"Per-ability {rateText}: total divided by the time that ability was in use");
+            tip: $"Per-{rateSubject} {rateText}: that {rateSubject}'s total divided by total time in combat");
         hits = SortLink(title.Contains("Heal", StringComparison.OrdinalIgnoreCase) ? "casts" : "hits", "hits", handler);
         avg = SortLink("avg", "avg", handler);
         sortBar.Children.Add(total);
@@ -697,7 +698,7 @@ public sealed class MainWindow : Window
                 (s.SpecialHits.Count > 0 ? "\n" + string.Join(" - ", s.SpecialHits.Select(x => $"{x.Name} {x.Count}")) : "") +
                 (s.Fizzles + s.Resists > 0 ? $"\nFizzles {s.Fizzles} - resists {s.Resists}" : "") +
                 (s.CurrentStance.Length > 0 ? $"\nStance: {s.CurrentStance}" : "");
-            FillBreakdown(_damageSourceList, s.DamageBySource, _dmgOutSort, "dps");
+            FillBreakdown(_damageSourceList, s.DamageBySource, _dmgOutSort, s.CombatSeconds, "dps");
             FillStatList(_damageTakenList, s.DamageByAttacker, _dmgInSort, "hit");
             _recentFightsLabel.IsVisible = s.RecentEncounters.Count > 0;
             var topFightDps = Math.Max(0.1, s.RecentEncounters.Count > 0
@@ -721,7 +722,7 @@ public sealed class MainWindow : Window
             var showSpells = s.HealsBySpell.Count > 0;
             _healSpellsLabel.IsVisible = showSpells;
             _healSortBar.IsVisible = showSpells;
-            FillBreakdown(_healSpellList, s.HealsBySpell, _healSort, "hps");
+            FillBreakdown(_healSpellList, s.HealsBySpell, _healSort, s.CombatSeconds, "hps");
             _healersLabel.IsVisible = s.HealsByHealer.Count > 0;
             FillList(_healerList, s.HealsByHealer.Select(h => (h.Name, $"{h.Total:N0} - {h.Hits} heal{(h.Hits == 1 ? "" : "s")}")));
         }
@@ -1228,11 +1229,15 @@ public sealed class MainWindow : Window
         });
     }
 
+    /// <summary>Details-style breakdown whose displayed rate follows parser convention:
+    /// source total divided by total combat time. The source's active-time burst rate
+    /// remains available in the row tooltip.</summary>
     private void FillBreakdown(ItemsControl list, IEnumerable<SourceDamage> stats,
-        StatSort sort, string rateLabel)
+        StatSort sort, double combatSeconds, string rateLabel)
     {
+        var secs = Math.Max(1, combatSeconds);
         static double Avg(SourceDamage d) => (double)d.Total / Math.Max(1, d.Hits);
-        static double Rate(SourceDamage d) => d.Total / Math.Max(1, d.ActiveSeconds);
+        double Rate(SourceDamage d) => d.Total / secs;
         var sorted = (sort switch
         {
             StatSort.Hits => stats.OrderByDescending(d => d.Hits),
@@ -1261,11 +1266,10 @@ public sealed class MainWindow : Window
             var critPart = d.Crits > 0
                 ? $" - {100.0 * d.Crits / Math.Max(1, d.Hits):0}% crit"
                 : "";
-            var ratePart = d.ActiveSeconds > 0 ? $" - {Rate(d):0.#} {rateLabel}" : "";
-            var value = $"{d.Total:N0} - ×{d.Hits} - avg {Avg(d):0.#}{ratePart}{critPart}";
-            var tooltip = $"{100.0 * d.Total / grand:0.#}% of total" +
+            var value = $"{d.Total:N0} - ×{d.Hits} - avg {Avg(d):0.#} - {Rate(d):0.#} {rateLabel}{critPart}";
+            var tooltip = $"{100.0 * d.Total / grand:0.#}% of total - {rateLabel} = total / {secs:0}s in combat" +
                 (d.ActiveSeconds > 0
-                    ? $" - {rateLabel} = total / ~{d.ActiveSeconds:0}s this ability was in use"
+                    ? $" - burst {d.Total / Math.Max(1, d.ActiveSeconds):0.#}/s over the ~{d.ActiveSeconds:0}s it was in use"
                     : "");
             return BarRow(d.Name, value, metric(d) / topMetric, barBrush, tooltip);
         }).ToList();

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -129,8 +129,8 @@ public sealed class OptionsWindow : Window
         panel.Children.Add(Row("Recent-rate window", _windowCombo, new Thickness(0, 12, 0, 0)));
         panel.Children.Add(AppTheme.DimText("The Last Xm figures on Combat, Kills, Money, and Progress."));
 
-        panel.Children.Add(Heading("Tracked loot", new Thickness(0, 14, 0, 2)));
-        panel.Children.Add(AppTheme.DimText("Choose what to watch and give the rule a display name. Match text is an optional case-insensitive filter; when empty, the display name is used. P pins a mini chip, B shows a banner, and S plays a sound."));
+        panel.Children.Add(Heading("Watch rules", new Thickness(0, 14, 0, 2)));
+        panel.Children.Add(AppTheme.DimText("Watch loot, kills, skill-ups, deaths, milestones, or your spells wearing off (SpellFade — the mez/charm-break alarm). Match is a case-insensitive substring, e.g. 'mote' or 'Befriend'; when empty, the display name is used. P pins a mini chip, B shows a banner, and S plays a sound."));
         panel.Children.Add(_rulesPanel);
         var add = AppTheme.IconButton("+ Add tracked item", "Add tracked item");
         add.HorizontalAlignment = HorizontalAlignment.Left;

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -20,6 +20,8 @@ public sealed class OptionsWindow : Window
     private readonly Slider _bgOpacitySlider = Slider(0.15, 1.0, 0.05);
     private readonly Slider _opacitySlider = Slider(0.5, 1.0, 0.02);
     private readonly CheckBox _truncateCheck = new() { Margin = new Thickness(0, 12, 0, 0) };
+    private readonly CheckBox _tutorialCheck = new() { Margin = new Thickness(0, 10, 0, 0) };
+    private readonly CheckBox _pinChipsCheck = new() { Margin = new Thickness(0, 6, 0, 0) };
     private readonly ComboBox _windowCombo = new() { Width = 90, FontSize = 12 };
     private readonly ComboBox _soundCombo = new() { Width = 120, FontSize = 12 };
     private readonly TextBlock _soundFileNote = AppTheme.DimText("");
@@ -67,6 +69,34 @@ public sealed class OptionsWindow : Window
         _truncateCheck.IsCheckedChanged += (_, _) =>
         {
             if (_ready) _main.SetTruncateLogs(_truncateCheck.IsChecked == true);
+        };
+
+        _tutorialCheck.Content = new TextBlock
+        {
+            Text = "Show quick tutorial at launch",
+            FontSize = 12,
+            Foreground = AppTheme.TextBrush,
+        };
+        _tutorialCheck.IsChecked = main.Settings.ShowTutorial;
+        _tutorialCheck.IsCheckedChanged += (_, _) =>
+        {
+            if (!_ready) return;
+            _main.Settings.ShowTutorial = _tutorialCheck.IsChecked == true;
+            _main.PersistSettings();
+        };
+
+        _pinChipsCheck.Content = new TextBlock
+        {
+            Text = "📌 Show watch chips in the mini dashboard",
+            FontSize = 12,
+            Foreground = AppTheme.TextBrush,
+        };
+        _pinChipsCheck.IsChecked = main.Settings.PinWatchChips;
+        _pinChipsCheck.IsCheckedChanged += (_, _) =>
+        {
+            if (!_ready) return;
+            _main.Settings.PinWatchChips = _pinChipsCheck.IsChecked == true;
+            _main.PersistSettings();
         };
 
         foreach (var m in (int[])[5, 15, 30]) _windowCombo.Items.Add($"{m} min");
@@ -125,14 +155,15 @@ public sealed class OptionsWindow : Window
         panel.Children.Add(AppTheme.DimText(
             "Turn off if you upload your log files elsewhere - they will grow forever, so clean them up yourself occasionally.",
             new Thickness(20, 2, 0, 0)));
+        panel.Children.Add(_tutorialCheck);
 
         panel.Children.Add(Row("Recent-rate window", _windowCombo, new Thickness(0, 12, 0, 0)));
         panel.Children.Add(AppTheme.DimText("The Last Xm figures on Combat, Kills, Money, and Progress."));
 
         panel.Children.Add(Heading("Watch rules", new Thickness(0, 14, 0, 2)));
-        panel.Children.Add(AppTheme.DimText("Watch loot, kills, skill-ups, deaths, milestones, or your spells wearing off (SpellFade — the mez/charm-break alarm). Match is a case-insensitive substring, e.g. 'mote' or 'Befriend'; when empty, the display name is used. P pins a mini chip, B shows a banner, and S plays a sound."));
+        panel.Children.Add(AppTheme.DimText("Watch loot, kills, skill-ups, deaths, milestones, or your spells wearing off (SpellFade — the mez/charm-break alarm). Match is a case-insensitive substring, e.g. 'mote' or 'Befriend'; when empty, the display name is used. B shows a banner and S plays a sound."));
         panel.Children.Add(_rulesPanel);
-        var add = AppTheme.IconButton("+ Add tracked item", "Add tracked item");
+        var add = AppTheme.IconButton("+ Add watch rule", "Add watch rule");
         add.HorizontalAlignment = HorizontalAlignment.Left;
         add.FontSize = 12;
         add.Click += (_, _) =>
@@ -142,6 +173,7 @@ public sealed class OptionsWindow : Window
             BuildRulesEditor();
         };
         panel.Children.Add(add);
+        panel.Children.Add(_pinChipsCheck);
 
         var soundRow = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
         soundRow.Children.Add(_soundCombo);
@@ -174,7 +206,7 @@ public sealed class OptionsWindow : Window
             row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(92)));
             row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(115)));
             row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-            for (var i = 0; i < 4; i++)
+            for (var i = 0; i < 3; i++)
                 row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
 
             var kind = new ComboBox { FontSize = 11, Margin = new Thickness(0, 0, 4, 0) };
@@ -203,9 +235,8 @@ public sealed class OptionsWindow : Window
             Grid.SetColumn(pattern, 2);
             row.Children.Add(pattern);
 
-            row.Children.Add(RuleToggle("P", "Pin to mini dashboard", 3, rule.Pinned, v => rule.Pinned = v));
-            row.Children.Add(RuleToggle("B", "Banner alert on match", 4, rule.AlertBanner, v => rule.AlertBanner = v));
-            row.Children.Add(RuleToggle("S", "Sound alert on match", 5, rule.AlertSound, v => rule.AlertSound = v));
+            row.Children.Add(RuleToggle("B", "Banner alert on match", 3, rule.AlertBanner, v => rule.AlertBanner = v));
+            row.Children.Add(RuleToggle("S", "Sound alert on match", 4, rule.AlertSound, v => rule.AlertSound = v));
 
             var del = AppTheme.IconButton("x", "Delete rule");
             del.Click += (_, _) =>
@@ -214,7 +245,7 @@ public sealed class OptionsWindow : Window
                 _main.PersistSettings();
                 BuildRulesEditor();
             };
-            Grid.SetColumn(del, 6);
+            Grid.SetColumn(del, 5);
             row.Children.Add(del);
             _rulesPanel.Children.Add(row);
         }

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -151,6 +151,9 @@ public sealed class OptionsWindow : Window
         soundRow.Children.Add(test);
         panel.Children.Add(Row("Alert sound", soundRow, new Thickness(0, 8, 0, 0)));
         panel.Children.Add(_soundFileNote);
+        panel.Children.Add(AppTheme.DimText(
+            "While Options is open, the ★ alert banner tile is visible — drag it to where alerts should appear. During play it's click-through and never steals focus.",
+            new Thickness(0, 4, 0, 0)));
 
         panel.Children.Add(Heading("Overlay cards", new Thickness(0, 14, 0, 2)));
         panel.Children.Add(_cardsPanel);

--- a/src/EQBuddy.Avalonia/TutorialWindow.cs
+++ b/src/EQBuddy.Avalonia/TutorialWindow.cs
@@ -1,0 +1,232 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.VisualTree;
+
+namespace EQBuddy.Avalonia;
+
+/// <summary>
+/// Six-page quick tour. Its first page is the log-truncation consent question, so
+/// startup cleanup remains deferred while the launch tutorial setting is enabled.
+/// </summary>
+public sealed class TutorialWindow : Window
+{
+    private readonly MainWindow _main;
+    private readonly TextBlock _pageTitle = new();
+    private readonly TextBlock _pageBody = new();
+    private readonly TextBlock _pageDots = new();
+    private readonly CheckBox _keepLogs = new();
+    private readonly Border _imageFrame = new();
+    private readonly Image _pageImage = new();
+    private readonly Button _previous;
+    private readonly Button _next;
+    private bool _ready;
+    private int _page;
+
+    private sealed record Page(string Title, string Body, string? Image, bool TruncationChoice = false);
+
+    private static readonly Page[] Pages =
+    [
+        new("Your log files — one decision first",
+            "EQBuddy reads the log file EverQuest Legends writes (the /log command — EQBuddy " +
+            "turns it on for you). It never touches the game itself.\n\n" +
+            "Because logging stays on permanently, EQBuddy automatically EMPTIES a character's " +
+            "log after it has been quiet for 60+ minutes (a finished play session), so the files " +
+            "never grow forever.\n\n" +
+            "If you keep your logs — for example to upload them to another parser — turn that " +
+            "off below. You can change this any time in ⚙ Options.",
+            null, TruncationChoice: true),
+
+        new("The widget",
+            "An always-on-top card that follows whoever is playing. Click any section to drill " +
+            "into details, drag anywhere to move it. The dot is green while the log is live. " +
+            "↻ restarts the session count; – minimizes to the mini pill; ⚙ opens Options.",
+            "t-widget.png"),
+
+        new("Combat, Details!-style",
+            "Damage by attack with share bars: total · hits · average · per-ability DPS · crit " +
+            "rate. Click the sort labels to re-rank (the bars follow the sorted column). Below: " +
+            "damage taken per mob, your recent fights with per-fight DPS, and a stance " +
+            "breakdown. Healing gets the same treatment.",
+            "t-combat.png"),
+
+        new("Watch rules & alerts",
+            "⚙ Options → Watch rules: watch Loot ('mote'), Kills, Skill-ups, Deaths, " +
+            "Milestones, or SpellFade — your mez or charm breaking. Matches count on the 🎯 " +
+            "Tracked card with per-hour rates, and can 🔔 pop a floating banner and 🔊 play a " +
+            "sound. The banner tile is click-through and movable — drag it while Options is open.",
+            "t-watch.png"),
+
+        new("Mini mode & hotkeys",
+            "Star ★ the stats you care about, then minimize: a tiny pill shows just those, " +
+            "plus watch-rule chips. Global hotkeys: Ctrl+Shift+H hide/show · Ctrl+Shift+T " +
+            "click-through (play right through the widget) · Ctrl+Shift+M mini mode · " +
+            "Ctrl+Shift+K camp marker.",
+            "t-mini.png"),
+
+        new("Session history",
+            "Every session saves itself to a local database — nothing uploads, ever. " +
+            "Right-click → Session history: search anything, add notes and tags, Ctrl-click " +
+            "two sessions to compare rates, import old log files, export JSON.\n\n" +
+            "That's the tour — happy hunting! Finishing turns off this launch tour; get it " +
+            "back any time via right-click → Quick tutorial…, or re-enable it in ⚙ Options.",
+            "t-history.png"),
+    ];
+
+    public TutorialWindow(MainWindow main)
+    {
+        _main = main;
+        Title = "Welcome to EQBuddy";
+        Width = 580;
+        SizeToContent = SizeToContent.Height;
+        WindowDecorations = global::Avalonia.Controls.WindowDecorations.None;
+        TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
+        Background = Brushes.Transparent;
+        WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        ShowInTaskbar = false;
+        Topmost = true;
+        CanResize = false;
+
+        _pageTitle.FontSize = 16;
+        _pageTitle.FontWeight = FontWeight.Bold;
+        _pageTitle.Foreground = AppTheme.AccentBrush;
+        _pageDots.FontSize = 12;
+        _pageDots.Foreground = AppTheme.DimBrush;
+        _pageDots.HorizontalAlignment = HorizontalAlignment.Right;
+        _pageDots.VerticalAlignment = VerticalAlignment.Center;
+        _pageBody.FontSize = 13;
+        _pageBody.Foreground = AppTheme.TextBrush;
+        _pageBody.TextWrapping = TextWrapping.Wrap;
+        _pageBody.LineHeight = 19;
+        _pageBody.Margin = new Thickness(0, 10, 0, 0);
+
+        _keepLogs.Content = new TextBlock
+        {
+            Text = "Keep my log files — disable auto-empty",
+            FontSize = 13,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = AppTheme.TextBrush,
+        };
+        _keepLogs.Margin = new Thickness(0, 14, 0, 2);
+        _keepLogs.IsChecked = !main.Settings.TruncateLogs;
+        _keepLogs.IsCheckedChanged += (_, _) =>
+        {
+            if (_ready) _main.SetTruncateLogs(_keepLogs.IsChecked != true);
+        };
+
+        _pageImage.MaxHeight = 320;
+        _pageImage.MaxWidth = 528;
+        _pageImage.Stretch = Stretch.Uniform;
+        _imageFrame.Margin = new Thickness(0, 14, 0, 0);
+        _imageFrame.HorizontalAlignment = HorizontalAlignment.Center;
+        _imageFrame.BorderBrush = AppTheme.BorderBrush;
+        _imageFrame.BorderThickness = new Thickness(1);
+        _imageFrame.CornerRadius = new CornerRadius(6);
+        _imageFrame.Child = _pageImage;
+
+        _previous = AppTheme.IconButton("◀ Previous", "Previous page");
+        _previous.FontSize = 12;
+        _previous.Click += (_, _) => { if (_page > 0) { _page--; Render(); } };
+        _next = AppTheme.IconButton("Next ▶", "Next page");
+        _next.FontSize = 12;
+        _next.FontWeight = FontWeight.SemiBold;
+        _next.Foreground = AppTheme.AccentBrush;
+        _next.Margin = new Thickness(14, 0, 0, 0);
+        _next.Click += (_, _) =>
+        {
+            if (_page < Pages.Length - 1) { _page++; Render(); }
+            else Finish();
+        };
+
+        Content = BuildContent();
+        PointerPressed += OnDrag;
+        _ready = true;
+        Render();
+    }
+
+    private Control BuildContent()
+    {
+        var header = new Grid();
+        header.Children.Add(_pageTitle);
+        header.Children.Add(_pageDots);
+
+        var never = AppTheme.IconButton("Never show again", "Don't show this tour at launch");
+        never.FontSize = 12;
+        never.Foreground = AppTheme.DimBrush;
+        never.Click += (_, _) => Finish();
+        var skip = AppTheme.IconButton("Skip for now", "Show this tour again next launch");
+        skip.FontSize = 12;
+        skip.Foreground = AppTheme.DimBrush;
+        skip.Margin = new Thickness(10, 0, 0, 0);
+        skip.Click += (_, _) => Close();
+        var left = new StackPanel { Orientation = Orientation.Horizontal };
+        left.Children.Add(never);
+        left.Children.Add(skip);
+
+        var right = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+        };
+        right.Children.Add(_previous);
+        right.Children.Add(_next);
+        var buttons = new Grid { Margin = new Thickness(0, 18, 0, 0) };
+        buttons.Children.Add(left);
+        buttons.Children.Add(right);
+
+        var panel = new StackPanel();
+        panel.Children.Add(header);
+        panel.Children.Add(_pageBody);
+        panel.Children.Add(_keepLogs);
+        panel.Children.Add(_imageFrame);
+        panel.Children.Add(buttons);
+        return new Border
+        {
+            Background = AppTheme.BgBrush,
+            BorderBrush = AppTheme.BorderBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(10),
+            Padding = new Thickness(20, 16),
+            Child = panel,
+        };
+    }
+
+    private void Render()
+    {
+        var page = Pages[_page];
+        _pageTitle.Text = page.Title;
+        _pageBody.Text = page.Body;
+        _pageDots.Text = $"{_page + 1} of {Pages.Length}";
+        _keepLogs.IsVisible = page.TruncationChoice;
+        _imageFrame.IsVisible = page.Image is not null;
+        if (page.Image is { } image)
+        {
+            using var stream = AssetLoader.Open(
+                new Uri($"avares://EQBuddy.Avalonia/Assets/tutorial/{image}"));
+            _pageImage.Source = new Bitmap(stream);
+        }
+        _previous.IsEnabled = _page > 0;
+        _next.Content = _page == Pages.Length - 1 ? "Finish ✔" : "Next ▶";
+    }
+
+    private void Finish()
+    {
+        _main.Settings.ShowTutorial = false;
+        _main.PersistSettings();
+        Close();
+    }
+
+    private void OnDrag(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.Source is Visual source && source.GetSelfAndVisualAncestors().Any(IsInteractiveControl))
+            return;
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(e);
+    }
+
+    private static bool IsInteractiveControl(Visual visual) => visual is Button or CheckBox;
+}

--- a/src/EQBuddy.UI.Shared/EQBuddy.UI.Shared.csproj
+++ b/src/EQBuddy.UI.Shared/EQBuddy.UI.Shared.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>EQBuddy.UI.Shared</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EQBuddy.Core\EQBuddy.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EQBuddy.UI.Shared/HistoryImportService.cs
+++ b/src/EQBuddy.UI.Shared/HistoryImportService.cs
@@ -1,0 +1,43 @@
+using EQBuddy.Core;
+
+namespace EQBuddy.UI.Shared;
+
+public sealed class HistoryImportService(SessionRepository repository)
+{
+    public Task<HistoryImportResult> ImportAsync(string path, CancellationToken cancellationToken = default) =>
+        Task.Run(() => Import(path, cancellationToken), cancellationToken);
+
+    private HistoryImportResult Import(string path, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var info = CharacterLog.FromPath(path);
+        var character = info?.Character ?? Path.GetFileNameWithoutExtension(path);
+        var server = info?.Server ?? "imported";
+        var imported = 0;
+        var stats = new SessionStats { CharacterName = character, ServerName = server };
+        stats.SessionEnding += snapshot =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!SessionRepository.IsMeaningful(snapshot)) return;
+            repository.Checkpoint(0, snapshot, server, character, "ImportedBoundary");
+            imported++;
+        };
+
+        foreach (var line in File.ReadLines(path))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var gameEvent = LogParser.Parse(line);
+            if (gameEvent is not null) stats.Apply(gameEvent);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var final = stats.Snapshot();
+        if (SessionRepository.IsMeaningful(final))
+        {
+            repository.Checkpoint(0, final, server, character, "ImportedBoundary");
+            imported++;
+        }
+
+        return HistoryPresentation.BuildImportResult(path, imported);
+    }
+}

--- a/src/EQBuddy.UI.Shared/HistoryPresentation.cs
+++ b/src/EQBuddy.UI.Shared/HistoryPresentation.cs
@@ -1,0 +1,170 @@
+using System.Text;
+using System.Text.Json;
+using EQBuddy.Core;
+
+namespace EQBuddy.UI.Shared;
+
+public sealed record HistoryFilterOption(string Label, string? Server = null, string? Character = null)
+{
+    public static HistoryFilterOption All { get; } = new("All characters");
+    public override string ToString() => Label;
+}
+
+public sealed record HistorySessionItem(SessionRow Row, string DisplayText);
+
+public sealed record HistoryImportResult(string FileName, int ImportedSessions, string Message);
+
+public static class HistoryPresentation
+{
+    public const string SelectSessionText = "Select a session.";
+    public const string MissingSessionText = "Could not load session detail.";
+    public const string MissingComparisonText = "Could not load one of the sessions.";
+
+    public static HistoryFilterOption BuildFilter(string server, string character) =>
+        new($"{character} ({server})", server, character);
+
+    public static string BuildCount(int count) =>
+        $"{count} session{(count == 1 ? "" : "s")}";
+
+    public static string BuildSessionRow(SessionRow row)
+    {
+        var duration = TimeSpan.FromSeconds(row.ElapsedSeconds);
+        return $"{row.StartLocal:MMM d h:mm tt} - {row.Character}\n" +
+               $"   {(row.PrimaryZone.Length > 0 ? row.PrimaryZone : "-")} - " +
+               $"{(int)duration.TotalHours}h {duration.Minutes}m - " +
+               $"{row.Kills} kills - {row.XpPercent:0.#}% xp - {StatsSnapshot.FormatCoin(row.Copper)}" +
+               (row.EndReason == "RecoveredAfterCrash" ? " - (recovered)" : "") +
+               (row.EndReason == "Active" ? " - (in progress)" : "");
+    }
+
+    public static string BuildOverview(SessionRow row, StatsSnapshot snapshot)
+    {
+        var text = new StringBuilder();
+        var duration = TimeSpan.FromSeconds(row.ElapsedSeconds);
+        var active = TimeSpan.FromSeconds(row.ActiveSeconds);
+        text.AppendLine($"{row.Character} ({row.Server}) - {row.StartLocal:dddd MMM d, h:mm tt}");
+        text.AppendLine($"Duration {(int)duration.TotalHours}h {duration.Minutes}m - active {(int)active.TotalMinutes}m - ended: {row.EndReason}");
+        text.AppendLine();
+        text.AppendLine($"Kills      {snapshot.YourKillCount} (+{snapshot.PartyKillCount} group) - {snapshot.KillsPerHour:0.0}/hr");
+        text.AppendLine($"XP         {snapshot.XpPercent:0.0}% - {snapshot.XpPerHour:0.0}%/hr" +
+                        (snapshot.Levels.Count > 0 ? $" - {string.Join(", ", snapshot.Levels.Select(level => level.Text))}" : "") +
+                        (snapshot.AaGained > 0 ? $" - {snapshot.AaGained} AA" : ""));
+        text.AppendLine($"Damage     {snapshot.DamageDealt:N0} dealt - {snapshot.SessionDps:0.0} dps - taken {snapshot.DamageTaken:N0}");
+        if (snapshot.HealingDone > 0)
+            text.AppendLine($"Healing    {snapshot.HealingDone:N0} done - {snapshot.Hps:0.#} hps");
+        text.AppendLine($"Money      {StatsSnapshot.FormatCoin(snapshot.Copper)} ({StatsSnapshot.FormatCoin(snapshot.CopperPerHour)}/hr)");
+        text.AppendLine($"Deaths     {snapshot.Deaths.Count}");
+        text.AppendLine();
+
+        if (snapshot.DamageBySource.Count > 0)
+        {
+            text.AppendLine("Top damage sources:");
+            var grandTotal = Math.Max(1, snapshot.DamageBySource.Sum(source => source.Total));
+            var topTotal = Math.Max(1, snapshot.DamageBySource.Max(source => source.Total));
+            foreach (var source in snapshot.DamageBySource.Take(8))
+                text.AppendLine($"  {source.Name,-24} {ShareBar((double)source.Total / topTotal),-10} {source.Total,8:N0}" +
+                    $" - {100.0 * source.Total / grandTotal,3:0}% - {source.Hits} hits - avg {(double)source.Total / Math.Max(1, source.Hits):0.#}" +
+                    $" - {source.Total / Math.Max(1, snapshot.CombatSeconds):0.#} dps" +
+                    (source.Crits > 0 ? $" - {100.0 * source.Crits / Math.Max(1, source.Hits):0}% crit" : ""));
+            text.AppendLine();
+        }
+
+        if (snapshot.HealsBySpell.Count > 0)
+        {
+            text.AppendLine("Top heals:");
+            var grandTotal = Math.Max(1, snapshot.HealsBySpell.Sum(heal => heal.Total));
+            var topTotal = Math.Max(1, snapshot.HealsBySpell.Max(heal => heal.Total));
+            foreach (var heal in snapshot.HealsBySpell.Take(6))
+                text.AppendLine($"  {heal.Name,-24} {ShareBar((double)heal.Total / topTotal),-10} {heal.Total,8:N0}" +
+                    $" - {100.0 * heal.Total / grandTotal,3:0}% - {heal.Hits} cast{(heal.Hits == 1 ? "" : "s")}" +
+                    $" - avg {(double)heal.Total / Math.Max(1, heal.Hits):0.#}" +
+                    $" - {heal.Total / Math.Max(1, snapshot.CombatSeconds):0.#} hps");
+            text.AppendLine();
+        }
+
+        if (snapshot.YourKills.Count > 0)
+        {
+            text.AppendLine("Kills by creature:");
+            foreach (var kill in snapshot.YourKills.Take(10))
+                text.AppendLine($"  {kill.Name,-28} x{kill.Count}");
+            text.AppendLine();
+        }
+
+        if (snapshot.Loot.Count > 0)
+        {
+            text.AppendLine("Loot:");
+            foreach (var loot in snapshot.Loot.Take(15))
+                text.AppendLine($"  {loot.Item,-34} x{loot.Count}");
+            text.AppendLine();
+        }
+
+        var farmed = snapshot.Mobs.Where(mob => mob.Kills > 0).Take(8).ToList();
+        if (farmed.Count > 0)
+        {
+            text.AppendLine("Mob farming (observed personal rates):");
+            foreach (var mob in farmed)
+            {
+                text.AppendLine($"  {mob.Name} - {mob.Kills} kills - avg fight {mob.AvgFightSeconds:0}s - " +
+                                $"{mob.XpPercent:0.0}% xp - {StatsSnapshot.FormatCoin(mob.Copper)}");
+                foreach (var loot in mob.Loot.Take(4))
+                    text.AppendLine($"      {loot.Item,-30} x{loot.Count}" +
+                        (loot.DropRatePct is { } percent ? $"  {percent:0.#}% ({loot.Count}/{mob.Kills})" : ""));
+            }
+            text.AppendLine();
+        }
+
+        if (snapshot.Stances.Count > 0)
+            text.AppendLine("Stances: " + string.Join(" - ",
+                snapshot.Stances.Select(stance => $"{stance.Name} {stance.Damage:N0} dmg over {(int)stance.CombatSeconds}s ({stance.Dps:0.#} dps)")));
+        if (snapshot.Zones.Count > 0)
+            text.AppendLine("Zones: " + string.Join(" -> ", snapshot.Zones.Select(zone => zone.Text)));
+        if (snapshot.Markers.Count > 0)
+            text.AppendLine("Markers: " + string.Join(" - ", snapshot.Markers.Select(marker => $"{marker.Text} ({marker.Time:h:mm tt})")));
+        return text.ToString();
+    }
+
+    public static string BuildComparison(SessionRow firstRow, StatsSnapshot? firstSnapshot,
+        SessionRow secondRow, StatsSnapshot? secondSnapshot)
+    {
+        if (firstSnapshot is null || secondSnapshot is null) return MissingComparisonText;
+
+        var text = new StringBuilder();
+        text.AppendLine("SESSION COMPARISON");
+        text.AppendLine($"A: {firstRow.Character} - {firstRow.StartLocal:MMM d h:mm tt} - {firstRow.PrimaryZone}");
+        text.AppendLine($"B: {secondRow.Character} - {secondRow.StartLocal:MMM d h:mm tt} - {secondRow.PrimaryZone}");
+        if (firstRow.Character != secondRow.Character || firstRow.PrimaryZone != secondRow.PrimaryZone)
+            text.AppendLine("(different character/zone - rates may not compare directly)");
+        text.AppendLine();
+        text.AppendLine($"{"",-16}{"A",14}{"B",14}");
+        void AddRow(string label, string first, string second) => text.AppendLine($"{label,-16}{first,14}{second,14}");
+        AddRow("Duration", $"{firstRow.ElapsedSeconds / 3600:0.0}h", $"{secondRow.ElapsedSeconds / 3600:0.0}h");
+        AddRow("Active", $"{firstRow.ActiveSeconds / 60:0}m", $"{secondRow.ActiveSeconds / 60:0}m");
+        AddRow("XP/hr", $"{firstSnapshot.XpPerHour:0.0}%", $"{secondSnapshot.XpPerHour:0.0}%");
+        AddRow("Kills/hr", $"{firstSnapshot.KillsPerHour:0.0}", $"{secondSnapshot.KillsPerHour:0.0}");
+        AddRow("Money/hr", StatsSnapshot.FormatCoin(firstSnapshot.CopperPerHour), StatsSnapshot.FormatCoin(secondSnapshot.CopperPerHour));
+        AddRow("DPS", $"{firstSnapshot.SessionDps:0.0}", $"{secondSnapshot.SessionDps:0.0}");
+        AddRow("HPS", $"{firstSnapshot.Hps:0.0}", $"{secondSnapshot.Hps:0.0}");
+        AddRow("Damage taken", $"{firstSnapshot.DamageTaken:N0}", $"{secondSnapshot.DamageTaken:N0}");
+        AddRow("Deaths", $"{firstSnapshot.Deaths.Count}", $"{secondSnapshot.Deaths.Count}");
+        AddRow("Loot items", $"{firstSnapshot.LootTotal}", $"{secondSnapshot.LootTotal}");
+        return text.ToString();
+    }
+
+    public static string BuildImporting(string path) => $"Importing {Path.GetFileName(path)}...";
+
+    public static HistoryImportResult BuildImportResult(string path, int importedSessions)
+    {
+        var fileName = Path.GetFileName(path);
+        return new HistoryImportResult(fileName, importedSessions,
+            $"Imported {importedSessions} session{(importedSessions == 1 ? "" : "s")} from {fileName}.");
+    }
+
+    public static string BuildExportFileName(SessionRow row) =>
+        $"eqbuddy-{row.Character}-{row.StartLocal:yyyyMMdd-HHmm}.json";
+
+    public static string BuildExportJson(StatsSnapshot snapshot) =>
+        JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
+
+    private static string ShareBar(double fraction) =>
+        new('█', Math.Clamp((int)Math.Round(fraction * 10), 1, 10));
+}

--- a/src/EQBuddy.UI.Shared/HistoryViewModel.cs
+++ b/src/EQBuddy.UI.Shared/HistoryViewModel.cs
@@ -1,0 +1,206 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using EQBuddy.Core;
+
+namespace EQBuddy.UI.Shared;
+
+public sealed class HistoryViewModel : INotifyPropertyChanged
+{
+    private readonly SessionRepository _repository;
+    private readonly HistoryImportService _importService;
+    private readonly List<long> _selectionOrder = [];
+    private HistoryFilterOption _selectedFilter = HistoryFilterOption.All;
+    private string _searchText = "";
+    private string _countText = HistoryPresentation.BuildCount(0);
+    private string _detailText = HistoryPresentation.SelectSessionText;
+    private string _note = "";
+    private string _tags = "";
+    private SessionRow? _selectedRow;
+    private StatsSnapshot? _selectedSnapshot;
+
+    public HistoryViewModel(SessionRepository repository, HistoryImportService? importService = null)
+    {
+        _repository = repository;
+        _importService = importService ?? new HistoryImportService(repository);
+        RefreshFilters();
+        RefreshSessions();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public ObservableCollection<HistoryFilterOption> Filters { get; } = [];
+    public ObservableCollection<HistorySessionItem> Sessions { get; } = [];
+    public IReadOnlySet<long> SelectedSessionIds => _selectionOrder.ToHashSet();
+
+    public HistoryFilterOption SelectedFilter
+    {
+        get => _selectedFilter;
+        set => SetField(ref _selectedFilter, value);
+    }
+
+    public string SearchText
+    {
+        get => _searchText;
+        set => SetField(ref _searchText, value ?? "");
+    }
+
+    public string CountText { get => _countText; private set => SetField(ref _countText, value); }
+    public string DetailText { get => _detailText; private set => SetField(ref _detailText, value); }
+
+    public string Note
+    {
+        get => _note;
+        set => SetField(ref _note, value ?? "");
+    }
+
+    public string Tags
+    {
+        get => _tags;
+        set => SetField(ref _tags, value ?? "");
+    }
+
+    public bool HasSelectedSession => _selectedRow is not null && _selectedSnapshot is not null;
+    public string? SelectedSummary => HasSelectedSession
+        ? HistoryPresentation.BuildOverview(_selectedRow!, _selectedSnapshot!)
+        : null;
+    public string? ExportFileName => HasSelectedSession ? HistoryPresentation.BuildExportFileName(_selectedRow!) : null;
+    public string? ExportJson => HasSelectedSession ? HistoryPresentation.BuildExportJson(_selectedSnapshot!) : null;
+
+    public void RefreshFilters()
+    {
+        var selectedServer = SelectedFilter.Server;
+        var selectedCharacter = SelectedFilter.Character;
+        Filters.Clear();
+        Filters.Add(HistoryFilterOption.All);
+        foreach (var (server, character) in _repository.Characters())
+            Filters.Add(HistoryPresentation.BuildFilter(server, character));
+        SelectedFilter = Filters.FirstOrDefault(filter =>
+            filter.Server == selectedServer && filter.Character == selectedCharacter) ?? Filters[0];
+    }
+
+    public void RefreshSessions()
+    {
+        var rows = _repository.Query(SelectedFilter.Server, SelectedFilter.Character, SearchText);
+        Sessions.Clear();
+        foreach (var row in rows)
+            Sessions.Add(new HistorySessionItem(row, HistoryPresentation.BuildSessionRow(row)));
+        CountText = HistoryPresentation.BuildCount(Sessions.Count);
+        ClearSelection();
+    }
+
+    public void SelectSession(long id, bool additive)
+    {
+        if (Sessions.All(item => item.Row.Id != id)) return;
+
+        if (!additive)
+            _selectionOrder.Clear();
+
+        var existing = _selectionOrder.IndexOf(id);
+        if (additive && existing >= 0)
+            _selectionOrder.RemoveAt(existing);
+        else
+        {
+            if (existing >= 0) _selectionOrder.RemoveAt(existing);
+            _selectionOrder.Add(id);
+        }
+
+        UpdateSelectionDetail();
+        OnPropertyChanged(nameof(SelectedSessionIds));
+    }
+
+    public bool IsSelected(long id) => _selectionOrder.Contains(id);
+
+    public void SaveMetadata()
+    {
+        if (_selectedRow is null) return;
+        _repository.SetNoteTags(_selectedRow.Id, Note.Trim(), Tags.Trim());
+        RefreshSessions();
+    }
+
+    public void DeleteSelected()
+    {
+        if (_selectedRow is null) return;
+        _repository.Delete(_selectedRow.Id);
+        RefreshFilters();
+        RefreshSessions();
+    }
+
+    public async Task ImportAsync(string path, CancellationToken cancellationToken = default)
+    {
+        DetailText = HistoryPresentation.BuildImporting(path);
+        var result = await _importService.ImportAsync(path, cancellationToken);
+        RefreshFilters();
+        RefreshSessions();
+        DetailText = result.Message;
+    }
+
+    private void UpdateSelectionDetail()
+    {
+        _selectedRow = null;
+        _selectedSnapshot = null;
+
+        if (_selectionOrder.Count == 2)
+        {
+            var selected = Sessions.Where(item => _selectionOrder.Contains(item.Row.Id)).ToList();
+            if (selected.Count == 2)
+                DetailText = HistoryPresentation.BuildComparison(
+                    selected[0].Row, _repository.LoadSnapshot(selected[0].Row.Id),
+                    selected[1].Row, _repository.LoadSnapshot(selected[1].Row.Id));
+            Note = "";
+            Tags = "";
+            NotifyCommandState();
+            return;
+        }
+
+        var latestId = _selectionOrder.LastOrDefault();
+        var latest = Sessions.FirstOrDefault(item => item.Row.Id == latestId);
+        if (latest is null)
+        {
+            DetailText = HistoryPresentation.SelectSessionText;
+            Note = "";
+            Tags = "";
+            NotifyCommandState();
+            return;
+        }
+
+        _selectedRow = latest.Row;
+        _selectedSnapshot = _repository.LoadSnapshot(latest.Row.Id);
+        Note = latest.Row.Note;
+        Tags = latest.Row.Tags;
+        DetailText = _selectedSnapshot is null
+            ? HistoryPresentation.MissingSessionText
+            : HistoryPresentation.BuildOverview(latest.Row, _selectedSnapshot);
+        NotifyCommandState();
+    }
+
+    private void ClearSelection()
+    {
+        _selectionOrder.Clear();
+        _selectedRow = null;
+        _selectedSnapshot = null;
+        Note = "";
+        Tags = "";
+        DetailText = HistoryPresentation.SelectSessionText;
+        OnPropertyChanged(nameof(SelectedSessionIds));
+        NotifyCommandState();
+    }
+
+    private void NotifyCommandState()
+    {
+        OnPropertyChanged(nameof(HasSelectedSession));
+        OnPropertyChanged(nameof(SelectedSummary));
+        OnPropertyChanged(nameof(ExportFileName));
+        OnPropertyChanged(nameof(ExportJson));
+    }
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/tests/EQBuddy.Tests/EQBuddy.Tests.csproj
+++ b/tests/EQBuddy.Tests/EQBuddy.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EQBuddy.Core\EQBuddy.Core.csproj" />
+    <ProjectReference Include="..\..\src\EQBuddy.UI.Shared\EQBuddy.UI.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/EQBuddy.Tests/HistoryPresentationTests.cs
+++ b/tests/EQBuddy.Tests/HistoryPresentationTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using EQBuddy.Core;
+using EQBuddy.UI.Shared;
+
+namespace EQBuddy.Tests;
+
+public sealed class HistoryPresentationTests
+{
+    [Fact]
+    public void FilterRetainsQueryValuesWithoutParsingLabel()
+    {
+        var filter = HistoryPresentation.BuildFilter("freeport", "Kaybek");
+
+        Assert.Equal("Kaybek (freeport)", filter.Label);
+        Assert.Equal("freeport", filter.Server);
+        Assert.Equal("Kaybek", filter.Character);
+        Assert.Equal("All characters", HistoryFilterOption.All.Label);
+    }
+
+    [Theory]
+    [InlineData("", " - 1h 2m")]
+    [InlineData("Clan Crushbone", "Clan Crushbone - 1h 2m")]
+    public void SessionRowFormatsZoneAndDuration(string zone, string expected)
+    {
+        var row = Row(primaryZone: zone, endReason: "Active");
+
+        var text = HistoryPresentation.BuildSessionRow(row);
+
+        Assert.Contains(expected, text);
+        Assert.Contains("1 kill", text);
+        Assert.EndsWith(" - (in progress)", text);
+    }
+
+    [Fact]
+    public void SessionRowMarksRecoveredSession()
+    {
+        var text = HistoryPresentation.BuildSessionRow(Row(endReason: "RecoveredAfterCrash"));
+        Assert.EndsWith(" - (recovered)", text);
+    }
+
+    [Fact]
+    public void OverviewAndComparisonContainSharedReportSections()
+    {
+        var snapshot = Snapshot();
+        var first = Row(character: "Kaybek", primaryZone: "Clan Crushbone");
+        var second = Row(id: 2, character: "Douglas", primaryZone: "Blackburrow");
+
+        var overview = HistoryPresentation.BuildOverview(first, snapshot);
+        var comparison = HistoryPresentation.BuildComparison(first, snapshot, second, snapshot);
+
+        Assert.Contains("Top damage sources:", overview);
+        Assert.Contains("Kills by creature:", overview);
+        Assert.Contains("Loot:", overview);
+        Assert.Contains("Zones:", overview);
+        Assert.Contains("SESSION COMPARISON", comparison);
+        Assert.Contains("different character/zone", comparison);
+        Assert.Equal(HistoryPresentation.MissingComparisonText,
+            HistoryPresentation.BuildComparison(first, null, second, snapshot));
+    }
+
+    [Fact]
+    public void ExportProducesSuggestedNameAndIndentedJson()
+    {
+        var row = Row(start: new DateTime(2026, 7, 18, 15, 4, 0));
+        var json = HistoryPresentation.BuildExportJson(Snapshot());
+
+        Assert.Equal("eqbuddy-Kaybek-20260718-1504.json", HistoryPresentation.BuildExportFileName(row));
+        Assert.Contains(Environment.NewLine, json);
+        Assert.NotNull(JsonDocument.Parse(json));
+    }
+
+    internal static StatsSnapshot Snapshot()
+    {
+        var stats = new SessionStats { CharacterName = "Kaybek", ServerName = "freeport" };
+        foreach (var line in new[]
+        {
+            "[Sat Jul 18 15:00:00 2026] You have entered Clan Crushbone.",
+            "[Sat Jul 18 15:00:05 2026] You slash orc pawn for 10 points of damage.",
+            "[Sat Jul 18 15:00:10 2026] You have slain orc pawn!",
+            "[Sat Jul 18 15:00:12 2026] --You have looted a Mote of Infinitesimal Potential from orc pawn's corpse.--",
+            "[Sat Jul 18 15:00:15 2026] You gain party experience! (1.5%)",
+        })
+            stats.Apply(LogParser.Parse(line)!);
+        return stats.Snapshot();
+    }
+
+    internal static SessionRow Row(long id = 1, string character = "Kaybek", string primaryZone = "Clan Crushbone",
+        string endReason = "Manual", DateTime? start = null) =>
+        new(id, "freeport", character, start ?? new DateTime(2026, 7, 18, 15, 0, 0), null,
+            3720, 120, endReason, primaryZone, 1, 1.5, 100, 1, 0, 5, "", "");
+}

--- a/tests/EQBuddy.Tests/HistoryViewModelTests.cs
+++ b/tests/EQBuddy.Tests/HistoryViewModelTests.cs
@@ -1,0 +1,154 @@
+using EQBuddy.Core;
+using EQBuddy.UI.Shared;
+
+namespace EQBuddy.Tests;
+
+public sealed class HistoryViewModelTests : IDisposable
+{
+    private readonly string _directory = Directory.CreateTempSubdirectory("eqbuddy-history-vm-").FullName;
+    private readonly SessionRepository _repository;
+
+    public HistoryViewModelTests() =>
+        _repository = new SessionRepository(Path.Combine(_directory, "history.db"));
+
+    public void Dispose()
+    {
+        _repository.Dispose();
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        Directory.Delete(_directory, recursive: true);
+    }
+
+    [Fact]
+    public void RefreshBuildsFiltersAndPreservesSelectedFilter()
+    {
+        AddSession("freeport", "Kaybek");
+        AddSession("qeynos", "Douglas");
+        var viewModel = new HistoryViewModel(_repository);
+        var kaybek = Assert.Single(viewModel.Filters, filter => filter.Character == "Kaybek");
+
+        viewModel.SelectedFilter = kaybek;
+        viewModel.RefreshSessions();
+        viewModel.RefreshFilters();
+
+        Assert.Equal("Kaybek", viewModel.SelectedFilter.Character);
+        Assert.Single(viewModel.Sessions);
+        Assert.Equal("1 session", viewModel.CountText);
+    }
+
+    [Fact]
+    public void SearchSelectionComparisonAndDeselectUpdateState()
+    {
+        AddSession("freeport", "Kaybek");
+        AddSession("qeynos", "Douglas");
+        var viewModel = new HistoryViewModel(_repository);
+        var first = viewModel.Sessions[0].Row.Id;
+        var second = viewModel.Sessions[1].Row.Id;
+
+        viewModel.SelectSession(first, additive: false);
+        Assert.True(viewModel.HasSelectedSession);
+        Assert.Contains("Kills", viewModel.DetailText);
+
+        viewModel.SelectSession(second, additive: true);
+        Assert.False(viewModel.HasSelectedSession);
+        Assert.Contains("SESSION COMPARISON", viewModel.DetailText);
+
+        viewModel.SelectSession(second, additive: true);
+        Assert.True(viewModel.HasSelectedSession);
+        Assert.Single(viewModel.SelectedSessionIds);
+
+        viewModel.SearchText = "does-not-exist";
+        viewModel.RefreshSessions();
+        Assert.Empty(viewModel.Sessions);
+        Assert.Equal("0 sessions", viewModel.CountText);
+        Assert.Equal(HistoryPresentation.SelectSessionText, viewModel.DetailText);
+    }
+
+    [Fact]
+    public void SaveMetadataTrimsValuesAndDeleteRefreshesRows()
+    {
+        AddSession("freeport", "Kaybek");
+        var viewModel = new HistoryViewModel(_repository);
+        viewModel.SelectSession(viewModel.Sessions[0].Row.Id, additive: false);
+        viewModel.Note = "  great camp  ";
+        viewModel.Tags = "  solo  ";
+
+        viewModel.SaveMetadata();
+
+        var stored = Assert.Single(_repository.Query());
+        Assert.Equal("great camp", stored.Note);
+        Assert.Equal("solo", stored.Tags);
+
+        viewModel.SelectSession(viewModel.Sessions[0].Row.Id, additive: false);
+        viewModel.DeleteSelected();
+        Assert.Empty(viewModel.Sessions);
+        Assert.Equal(HistoryPresentation.SelectSessionText, viewModel.DetailText);
+    }
+
+    [Fact]
+    public async Task ImportStreamsMeaningfulSessionsAndRefreshesViewModel()
+    {
+        var path = Path.Combine(_directory, "eqlog_Kaybek_freeport.txt");
+        await File.WriteAllLinesAsync(path,
+        [
+            "[Sat Jul 18 15:00:00 2026] You have entered Clan Crushbone.",
+            "[Sat Jul 18 15:00:05 2026] You slash orc pawn for 10 points of damage.",
+            "[Sat Jul 18 15:00:10 2026] You have slain orc pawn!",
+        ]);
+        var viewModel = new HistoryViewModel(_repository);
+
+        await viewModel.ImportAsync(path);
+
+        Assert.Single(viewModel.Sessions);
+        Assert.Contains("Imported 1 session", viewModel.DetailText);
+        Assert.Equal("Kaybek", Assert.Single(viewModel.Filters, filter => filter.Character == "Kaybek").Character);
+    }
+
+    [Fact]
+    public async Task ImportSplitsGapSeparatedSessionsAndReimportDoesNotDuplicate()
+    {
+        var path = Path.Combine(_directory, "eqlog_Kaybek_freeport.txt");
+        await File.WriteAllLinesAsync(path,
+        [
+            "[Sat Jul 18 15:00:00 2026] You slash orc pawn for 10 points of damage.",
+            "[Sat Jul 18 15:00:05 2026] You have slain orc pawn!",
+            "[Sat Jul 18 16:01:00 2026] You slash orc centurion for 20 points of damage.",
+            "[Sat Jul 18 16:01:05 2026] You have slain orc centurion!",
+        ]);
+        var service = new HistoryImportService(_repository);
+
+        var first = await service.ImportAsync(path);
+        var second = await service.ImportAsync(path);
+
+        Assert.Equal(2, first.ImportedSessions);
+        Assert.Equal(2, second.ImportedSessions);
+        Assert.Equal(2, _repository.Query().Count);
+    }
+
+    [Fact]
+    public async Task ImportSkipsEmptyLog()
+    {
+        var path = Path.Combine(_directory, "eqlog_Kaybek_freeport.txt");
+        await File.WriteAllTextAsync(path, "");
+
+        var result = await new HistoryImportService(_repository).ImportAsync(path);
+
+        Assert.Equal(0, result.ImportedSessions);
+        Assert.Empty(_repository.Query());
+    }
+
+    [Fact]
+    public async Task ImportHonorsCancellationAndInvalidPaths()
+    {
+        var service = new HistoryImportService(_repository);
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.ImportAsync(Path.Combine(_directory, "missing.txt"), cancelled.Token));
+        await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            service.ImportAsync(Path.Combine(_directory, "missing.txt")));
+    }
+
+    private long AddSession(string server, string character) =>
+        _repository.Checkpoint(0, HistoryPresentationTests.Snapshot(), server, character, "Manual");
+}


### PR DESCRIPTION
This is a potential first (of many) PR around the discussion in #6 .  

Key changes:
* Added framework-neutral [EQBuddy.UI.Shared](/home/don/src/EQBuddy/src/EQBuddy.UI.Shared/EQBuddy.UI.Shared.csproj) with:
  * HistoryViewModel
  * HistoryPresentation
  * HistoryImportService
  * Shared filter/session/import records
* Refactored [HistoryWindow.cs](/home/don/src/EQBuddy/src/EQBuddy.Avalonia/HistoryWindow.cs) into a thin Avalonia view.
* Added presentation, selection, repository workflow, export, metadata, delete, and import tests.
* Added project references and solution registration.
* Left all WPF source files unchanged.
* Confirmed shared code has no Avalonia or WPF references.

I also refactored the HistoryWindow to use Avalonia axaml format.  This lets us easier compare the two platforms and eye how big the code behind is getting, and look for more opportunities to share logic, since the 2 xaml can never be shared.

No changes are made to the WPF project, though it's version of HistoryWindow should be reasonably easily modified to use these same shared UI patterns.


Again -- this is a potential change, see what you think.  If you like the concept, feel free to accept it (it will only affect the Avalonia version) and then try merging the WPF HistoryWindow to use the shared logic.


This branch should be built on top of the 1.8.13 parity branch as a starting point.