### PR TITLE
Add selectable color themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 dist/
 *.user
+.vs/

--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -54,6 +54,9 @@ public sealed class AppSettings
     public string HotkeyClickThrough { get; set; } = "Ctrl+Shift+T";
     public string HotkeyMiniMode { get; set; } = "Ctrl+Shift+M";
     public string HotkeyCampMarker { get; set; } = "Ctrl+Shift+K";
+    /// <summary>Color theme key (see EQBuddy.UI.Shared.ThemeCatalog); defaults to the
+    /// original parchment-and-brass look so existing installs don't change on upgrade.</summary>
+    public string Theme { get; set; } = "ParchmentBrass";
 
     private static string FilePath => AppPaths.File("settings.json");
 

--- a/src/EQBuddy.UI.Shared/OptionsViewModel.cs
+++ b/src/EQBuddy.UI.Shared/OptionsViewModel.cs
@@ -75,6 +75,33 @@ public static class AlertSoundCatalog
     }
 }
 
+/// <summary>Color themes both UIs offer, keyed the same as the WPF app's
+/// Themes/*.xaml palette dictionaries so <see cref="AppSettings.Theme"/> round-trips
+/// between the two without translation.</summary>
+public static class ThemeCatalog
+{
+    public static readonly (string Key, string Label)[] Themes =
+    [
+        ("ParchmentBrass", "Parchment & Brass"),
+        ("BlueGrey", "Blue Grey"),
+        ("Turquoise", "Turquoise"),
+        ("Redish", "Redish"),
+        ("Grey", "Grey"),
+        ("Solarized", "Solarized"),
+        ("SolarizedDark", "Solarized Dark"),
+    ];
+
+    public static readonly string[] Labels = [.. Themes.Select(t => t.Label)];
+
+    /// <summary>Index of a theme key in <see cref="Themes"/>/<see cref="Labels"/>;
+    /// falls back to 0 for an unrecognized key (e.g. an older settings.json).</summary>
+    public static int IndexOf(string key)
+    {
+        var i = Array.FindIndex(Themes, t => t.Key == key);
+        return i >= 0 ? i : 0;
+    }
+}
+
 /// <summary>The overlay cards, in default order — shared by both UIs' layout and
 /// Options card editors.</summary>
 public static class OverlaySections
@@ -133,6 +160,18 @@ public sealed class OptionsViewModel : INotifyPropertyChanged
         set { _settings.BackgroundOpacity = Math.Clamp(value, 0.15, 1.0); Changed(); Changed(nameof(BackgroundOpacityLabel)); }
     }
     public string BackgroundOpacityLabel => $"{_settings.BackgroundOpacity * 100:0}%";
+
+    // ---- theme ----
+    /// <summary>Display labels for the theme picker, in <see cref="ThemeCatalog"/> order.</summary>
+    public static readonly string[] ThemeLabels = ThemeCatalog.Labels;
+
+    /// <summary>Index into <see cref="ThemeLabels"/>. The view applies the visual side
+    /// effect (swapping the live resource dictionary) after setting this.</summary>
+    public int ThemeIndex
+    {
+        get => ThemeCatalog.IndexOf(_settings.Theme);
+        set { _settings.Theme = ThemeCatalog.Themes[value].Key; PersistAnd(); }
+    }
 
     // ---- toggles ----
     public bool TruncateLogs

--- a/src/EQBuddy/AlertWindow.xaml
+++ b/src/EQBuddy/AlertWindow.xaml
@@ -1,13 +1,13 @@
-<Window x:Class="EQBuddy.AlertWindow"
+﻿<Window x:Class="EQBuddy.AlertWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="EQBuddy Alert" WindowStyle="None" AllowsTransparency="True"
         Background="Transparent" Topmost="True" ShowInTaskbar="False"
         ShowActivated="False" SizeToContent="WidthAndHeight" ResizeMode="NoResize"
         MouseLeftButtonDown="OnDrag">
-    <Border Background="#F01E1A14" BorderBrush="{StaticResource AccentBrush}"
+    <Border Background="#F01E1A14" BorderBrush="{DynamicResource AccentBrush}"
             BorderThickness="1" CornerRadius="8" Padding="12,8" MaxWidth="380">
         <TextBlock x:Name="AlertText" FontSize="13" FontWeight="SemiBold"
-                   Foreground="{StaticResource AccentBrush}" TextWrapping="Wrap"/>
+                   Foreground="{DynamicResource AccentBrush}" TextWrapping="Wrap"/>
     </Border>
 </Window>

--- a/src/EQBuddy/App.xaml
+++ b/src/EQBuddy/App.xaml
@@ -5,6 +5,11 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <!-- Index 0: the color palette — swapped at runtime by ThemeManager based
+                     on the saved theme; this is just the fallback shown before that runs. -->
+                <ResourceDictionary Source="Themes/ParchmentBrass.xaml"/>
+                <!-- Index 1: structural styles/templates, referencing palette brushes via
+                     DynamicResource so a palette swap repaints already-open windows. -->
                 <ResourceDictionary Source="Theme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/src/EQBuddy/App.xaml.cs
+++ b/src/EQBuddy/App.xaml.cs
@@ -75,6 +75,10 @@ public partial class App : Application
             Shutdown();
             return;
         }
+        // Applied before the StartupUri window is created (that happens after OnStartup
+        // returns), so the saved theme is already live for the very first frame.
+        try { ThemeManager.Apply(Core.AppSettings.Load().Theme); }
+        catch (Exception ex) { LogError(ex); }
         DispatcherUnhandledException += (_, args) =>
         {
             LogError(args.Exception);

--- a/src/EQBuddy/HistoryWindow.xaml
+++ b/src/EQBuddy/HistoryWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="EQBuddy.HistoryWindow"
+﻿<Window x:Class="EQBuddy.HistoryWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="EQBuddy — Session History" Width="860" Height="560"
@@ -24,8 +24,8 @@
             </Grid.ColumnDefinitions>
             <ComboBox x:Name="CharFilter" SelectionChanged="OnFilterChanged" Margin="0,0,8,0"/>
             <TextBox x:Name="SearchBox" Grid.Column="1" FontSize="12" Padding="6,4"
-                     Background="#FF2A251F" Foreground="{StaticResource TextBrush}"
-                     BorderBrush="{StaticResource BorderBrush}" TextChanged="OnSearchChanged"
+                     Background="{DynamicResource ComboBoxBrush}" Foreground="{DynamicResource TextBrush}"
+                     BorderBrush="{DynamicResource BorderBrush}" TextChanged="OnSearchChanged"
                      ToolTip="Search character, zone, notes, tags, loot, or creature names"/>
             <TextBlock x:Name="CountText" Grid.Column="2" Style="{StaticResource Dim}"
                        VerticalAlignment="Center" Margin="8,0,0,0"/>
@@ -36,7 +36,7 @@
 
         <!-- Session list (Ctrl-click two rows to compare) -->
         <ListBox x:Name="SessionList" Grid.Row="1" Background="#26FFFFFF" BorderThickness="0"
-                 Foreground="{StaticResource TextBrush}" SelectionChanged="OnSessionSelected"
+                 Foreground="{DynamicResource TextBrush}" SelectionChanged="OnSessionSelected"
                  SelectionMode="Extended"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"/>
 
@@ -49,18 +49,18 @@
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <StackPanel>
                     <TextBlock x:Name="DetailText" FontSize="12" TextWrapping="Wrap"
-                               Foreground="{StaticResource TextBrush}" FontFamily="Consolas"
+                               Foreground="{DynamicResource TextBrush}" FontFamily="Consolas"
                                Text="Select a session."/>
                     <TextBlock x:Name="DamageVisualLabel" Text="Top damage sources" FontSize="12"
-                               FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}"
+                               FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"
                                Margin="0,6,0,2" Visibility="Collapsed"/>
                     <ItemsControl x:Name="DamageVisualList" Margin="0,0,8,0"/>
                     <TextBlock x:Name="HealVisualLabel" Text="Top heals" FontSize="12"
-                               FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}"
+                               FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"
                                Margin="0,8,0,2" Visibility="Collapsed"/>
                     <ItemsControl x:Name="HealVisualList" Margin="0,0,8,0"/>
                     <TextBlock x:Name="DetailRest" FontSize="12" TextWrapping="Wrap"
-                               Foreground="{StaticResource TextBrush}" FontFamily="Consolas"
+                               Foreground="{DynamicResource TextBrush}" FontFamily="Consolas"
                                Margin="0,8,0,0" Visibility="Collapsed"/>
                 </StackPanel>
             </ScrollViewer>
@@ -72,8 +72,8 @@
                     </Grid.ColumnDefinitions>
                     <TextBlock Text="Notes:" Style="{StaticResource Dim}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <TextBox x:Name="NoteBox" Grid.Column="1" FontSize="12" Padding="4,2"
-                             Background="#FF2A251F" Foreground="{StaticResource TextBrush}"
-                             BorderBrush="{StaticResource BorderBrush}"/>
+                             Background="{DynamicResource ComboBoxBrush}" Foreground="{DynamicResource TextBrush}"
+                             BorderBrush="{DynamicResource BorderBrush}"/>
                 </Grid>
                 <Grid Margin="0,4,0,0">
                     <Grid.ColumnDefinitions>
@@ -82,8 +82,8 @@
                     </Grid.ColumnDefinitions>
                     <TextBlock Text="Tags:" Style="{StaticResource Dim}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <TextBox x:Name="TagsBox" Grid.Column="1" FontSize="12" Padding="4,2"
-                             Background="#FF2A251F" Foreground="{StaticResource TextBrush}"
-                             BorderBrush="{StaticResource BorderBrush}"
+                             Background="{DynamicResource ComboBoxBrush}" Foreground="{DynamicResource TextBrush}"
+                             BorderBrush="{DynamicResource BorderBrush}"
                              ToolTip="Comma-separated, e.g. solo, basement, new weapon"/>
                 </Grid>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
@@ -91,7 +91,7 @@
                     <Button Content="Copy summary" Style="{StaticResource IconButton}" FontSize="12" Click="OnCopySummary" Margin="8,0,0,0"/>
                     <Button Content="Export JSON" Style="{StaticResource IconButton}" FontSize="12" Click="OnExportJson" Margin="8,0,0,0"/>
                     <Button Content="Delete session" Style="{StaticResource IconButton}" FontSize="12" Click="OnDelete" Margin="24,0,0,0"
-                            Foreground="{StaticResource BadBrush}"/>
+                            Foreground="{DynamicResource BadBrush}"/>
                 </StackPanel>
             </StackPanel>
         </Grid>

--- a/src/EQBuddy/MainWindow.xaml
+++ b/src/EQBuddy/MainWindow.xaml
@@ -1,12 +1,12 @@
-<Window x:Class="EQBuddy.MainWindow"
+﻿<Window x:Class="EQBuddy.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="EQBuddy" SizeToContent="WidthAndHeight"
         WindowStyle="None" AllowsTransparency="True" Background="Transparent"
         Topmost="True" ShowInTaskbar="True" ResizeMode="NoResize">
 
-    <Border Background="{StaticResource BgBrush}" CornerRadius="10"
-            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+    <Border Background="{DynamicResource BgBrush}" CornerRadius="10"
+            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
             MouseLeftButtonDown="OnDrag">
         <Border.ContextMenu>
             <ContextMenu>
@@ -31,7 +31,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <Ellipse x:Name="MiniDot" Width="9" Height="9" Fill="{StaticResource BadBrush}"
+                <Ellipse x:Name="MiniDot" Width="9" Height="9" Fill="{DynamicResource BadBrush}"
                          VerticalAlignment="Center" Margin="2,0,8,0"
                          ToolTip="Log status"/>
                 <StackPanel x:Name="MiniChips" Grid.Column="1" Orientation="Horizontal"
@@ -57,13 +57,13 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <Ellipse x:Name="StatusDot" Width="9" Height="9" Fill="{StaticResource BadBrush}"
+                    <Ellipse x:Name="StatusDot" Width="9" Height="9" Fill="{DynamicResource BadBrush}"
                              VerticalAlignment="Center" Margin="2,0,7,0"/>
                     <TextBlock Text="EQBuddy" FontWeight="Bold" FontSize="14"
-                               Foreground="{StaticResource AccentBrush}"/>
+                               Foreground="{DynamicResource AccentBrush}"/>
                 </StackPanel>
                 <TextBlock x:Name="CharLabel" Grid.Column="1" Margin="10,0,6,0" VerticalAlignment="Center"
-                           FontSize="12" Foreground="{StaticResource DimBrush}"
+                           FontSize="12" Foreground="{DynamicResource DimBrush}"
                            TextTrimming="CharacterEllipsis" Text="looking for a character…"
                            ToolTip="Follows whoever is actively playing (log file growth)"/>
                 <Button x:Name="GearBtn" Grid.Column="2" Style="{StaticResource IconButton}"
@@ -80,8 +80,8 @@
             <Border x:Name="LogBanner" Background="#33E0A030" CornerRadius="6" Padding="8,6"
                     Margin="0,8,0,0" Visibility="Collapsed">
                 <TextBlock TextWrapping="Wrap" FontSize="12">
-                    <Run Foreground="{StaticResource WarnBrush}" FontWeight="SemiBold" Text="Logging looks off."/>
-                    <Run Text=" Type "/><Run FontFamily="Consolas" Foreground="{StaticResource AccentBrush}" Text="/log"/>
+                    <Run Foreground="{DynamicResource WarnBrush}" FontWeight="SemiBold" Text="Logging looks off."/>
+                    <Run Text=" Type "/><Run FontFamily="Consolas" Foreground="{DynamicResource AccentBrush}" Text="/log"/>
                     <Run Text=" in the game's chat window. (EQBuddy enables it automatically for future game launches.)"/>
                 </TextBlock>
             </Border>
@@ -91,7 +91,7 @@
                     Margin="0,8,0,0" Visibility="Collapsed" Cursor="Hand"
                     MouseLeftButtonDown="OnUpdateBannerClick">
                 <TextBlock x:Name="UpdateText" TextWrapping="Wrap" FontSize="12"
-                           Foreground="{StaticResource GoodBrush}" FontWeight="SemiBold"/>
+                           Foreground="{DynamicResource GoodBrush}" FontWeight="SemiBold"/>
             </Border>
 
             <!-- Session line -->
@@ -121,42 +121,42 @@
                 <StackPanel>
                     <TextBlock x:Name="CombatSummary" Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="0,2,0,4"/>
                     <Grid>
-                        <TextBlock Text="Damage by attack" FontSize="11" FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}"/>
+                        <TextBlock Text="Damage by attack" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"/>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                            <TextBlock Text="sort:" FontSize="10" Foreground="{StaticResource DimBrush}" Margin="0,0,4,0"/>
+                            <TextBlock Text="sort:" FontSize="10" Foreground="{DynamicResource DimBrush}" Margin="0,0,4,0"/>
                             <TextBlock x:Name="DmgOutSortTotal" Text="total" FontSize="10" Cursor="Hand" Tag="total"
-                                       Foreground="{StaticResource AccentBrush}" MouseLeftButtonDown="OnSortDmgOut"/>
+                                       Foreground="{DynamicResource AccentBrush}" MouseLeftButtonDown="OnSortDmgOut"/>
                             <TextBlock x:Name="DmgOutSortDps" Text="dps" FontSize="10" Cursor="Hand" Tag="rate" Margin="6,0,0,0"
                                        ToolTip="Per-ability DPS: that ability's damage ÷ total time in combat"
-                                       Foreground="{StaticResource DimBrush}" MouseLeftButtonDown="OnSortDmgOut"/>
+                                       Foreground="{DynamicResource DimBrush}" MouseLeftButtonDown="OnSortDmgOut"/>
                             <TextBlock x:Name="DmgOutSortHits" Text="hits" FontSize="10" Cursor="Hand" Tag="hits" Margin="6,0,0,0"
-                                       Foreground="{StaticResource DimBrush}" MouseLeftButtonDown="OnSortDmgOut"/>
+                                       Foreground="{DynamicResource DimBrush}" MouseLeftButtonDown="OnSortDmgOut"/>
                             <TextBlock x:Name="DmgOutSortAvg" Text="avg" FontSize="10" Cursor="Hand" Tag="avg" Margin="6,0,0,0"
-                                       Foreground="{StaticResource DimBrush}" MouseLeftButtonDown="OnSortDmgOut"/>
+                                       Foreground="{DynamicResource DimBrush}" MouseLeftButtonDown="OnSortDmgOut"/>
                         </StackPanel>
                     </Grid>
                     <ItemsControl x:Name="DamageSourceList" Margin="0,2,0,4"/>
                     <Grid>
-                        <TextBlock Text="Damage taken from" FontSize="11" FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}"/>
+                        <TextBlock Text="Damage taken from" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"/>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                            <TextBlock Text="sort:" FontSize="10" Foreground="{StaticResource DimBrush}" Margin="0,0,4,0"/>
+                            <TextBlock Text="sort:" FontSize="10" Foreground="{DynamicResource DimBrush}" Margin="0,0,4,0"/>
                             <TextBlock x:Name="DmgInSortTotal" Text="total" FontSize="10" Cursor="Hand" Tag="total"
-                                       Foreground="{StaticResource AccentBrush}" MouseLeftButtonDown="OnSortDmgIn"/>
+                                       Foreground="{DynamicResource AccentBrush}" MouseLeftButtonDown="OnSortDmgIn"/>
                             <TextBlock x:Name="DmgInSortHits" Text="hits" FontSize="10" Cursor="Hand" Tag="hits" Margin="6,0,0,0"
-                                       Foreground="{StaticResource DimBrush}" MouseLeftButtonDown="OnSortDmgIn"/>
+                                       Foreground="{DynamicResource DimBrush}" MouseLeftButtonDown="OnSortDmgIn"/>
                             <TextBlock x:Name="DmgInSortAvg" Text="avg" FontSize="10" Cursor="Hand" Tag="avg" Margin="6,0,0,0"
-                                       Foreground="{StaticResource DimBrush}" MouseLeftButtonDown="OnSortDmgIn"/>
+                                       Foreground="{DynamicResource DimBrush}" MouseLeftButtonDown="OnSortDmgIn"/>
                         </StackPanel>
                     </Grid>
                     <ItemsControl x:Name="DamageTakenList" Margin="0,2,0,4"/>
                     <TextBlock x:Name="RecentFightsLabel" Text="Recent fights" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource AccentBrush}" Visibility="Collapsed"/>
+                               Foreground="{DynamicResource AccentBrush}" Visibility="Collapsed"/>
                     <ItemsControl x:Name="RecentFightsList" Margin="0,2,0,4"/>
                     <TextBlock x:Name="AreaSpellLabel" Text="Area spells (per cast)" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource AccentBrush}" Visibility="Collapsed"/>
+                               Foreground="{DynamicResource AccentBrush}" Visibility="Collapsed"/>
                     <ItemsControl x:Name="AreaSpellList" Margin="0,2,0,4"/>
                     <TextBlock x:Name="StanceLabel" Text="By stance" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource AccentBrush}" Visibility="Collapsed"/>
+                               Foreground="{DynamicResource AccentBrush}" Visibility="Collapsed"/>
                     <ItemsControl x:Name="StanceList" Margin="0,2,0,0"/>
                 </StackPanel>
             </Expander>
@@ -179,23 +179,23 @@
                     <TextBlock x:Name="HealingSummary" Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="0,2,0,4"/>
                     <Grid>
                         <TextBlock x:Name="HealSpellsLabel" Text="Heals cast" FontSize="11" FontWeight="SemiBold"
-                                   Foreground="{StaticResource GoodBrush}" Visibility="Collapsed"/>
+                                   Foreground="{DynamicResource GoodBrush}" Visibility="Collapsed"/>
                         <StackPanel x:Name="HealSortBar" Orientation="Horizontal" HorizontalAlignment="Right" Visibility="Collapsed">
-                            <TextBlock Text="sort:" FontSize="10" Foreground="{StaticResource DimBrush}" Margin="0,0,4,0"/>
+                            <TextBlock Text="sort:" FontSize="10" Foreground="{DynamicResource DimBrush}" Margin="0,0,4,0"/>
                             <TextBlock x:Name="HealSortTotal" Text="total" FontSize="10" Cursor="Hand" Tag="total"
-                                       Foreground="{StaticResource AccentBrush}" MouseLeftButtonDown="OnSortHeal"/>
+                                       Foreground="{DynamicResource AccentBrush}" MouseLeftButtonDown="OnSortHeal"/>
                             <TextBlock x:Name="HealSortHps" Text="hps" FontSize="10" Cursor="Hand" Tag="rate" Margin="6,0,0,0"
                                        ToolTip="Per-spell HPS: that spell's healing ÷ total time in combat"
-                                       Foreground="{StaticResource DimBrush}" MouseLeftButtonDown="OnSortHeal"/>
+                                       Foreground="{DynamicResource DimBrush}" MouseLeftButtonDown="OnSortHeal"/>
                             <TextBlock x:Name="HealSortHits" Text="casts" FontSize="10" Cursor="Hand" Tag="hits" Margin="6,0,0,0"
-                                       Foreground="{StaticResource DimBrush}" MouseLeftButtonDown="OnSortHeal"/>
+                                       Foreground="{DynamicResource DimBrush}" MouseLeftButtonDown="OnSortHeal"/>
                             <TextBlock x:Name="HealSortAvg" Text="avg" FontSize="10" Cursor="Hand" Tag="avg" Margin="6,0,0,0"
-                                       Foreground="{StaticResource DimBrush}" MouseLeftButtonDown="OnSortHeal"/>
+                                       Foreground="{DynamicResource DimBrush}" MouseLeftButtonDown="OnSortHeal"/>
                         </StackPanel>
                     </Grid>
                     <ItemsControl x:Name="HealSpellList" Margin="0,2,0,4"/>
                     <TextBlock x:Name="HealersLabel" Text="Healed by" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource GoodBrush}" Visibility="Collapsed"/>
+                               Foreground="{DynamicResource GoodBrush}" Visibility="Collapsed"/>
                     <ItemsControl x:Name="HealerList" Margin="0,2,0,0"/>
                 </StackPanel>
             </Expander>
@@ -218,10 +218,10 @@
                     <TextBlock x:Name="KillsSummary" Style="{StaticResource Dim}" Margin="0,2,0,4"/>
                     <ItemsControl x:Name="KillList"/>
                     <TextBlock x:Name="FarmingLabel" Text="Farming (per creature)" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource AccentBrush}" Margin="0,6,0,0" Visibility="Collapsed"/>
+                               Foreground="{DynamicResource AccentBrush}" Margin="0,6,0,0" Visibility="Collapsed"/>
                     <ItemsControl x:Name="FarmingList" Margin="0,2,0,0"/>
                     <TextBlock x:Name="PartyKillsLabel" Text="Group kills" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource AccentBrush}" Margin="0,6,0,0"/>
+                               Foreground="{DynamicResource AccentBrush}" Margin="0,6,0,0"/>
                     <ItemsControl x:Name="PartyKillList" Margin="0,2,0,0"/>
                 </StackPanel>
             </Expander>
@@ -243,7 +243,7 @@
                 <StackPanel>
                     <ItemsControl x:Name="LootList"/>
                     <TextBlock x:Name="CraftedLabel" Text="Created by merging" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource AccentBrush}" Margin="0,6,0,0" Visibility="Collapsed"/>
+                               Foreground="{DynamicResource AccentBrush}" Margin="0,6,0,0" Visibility="Collapsed"/>
                     <ItemsControl x:Name="CraftedList" Margin="0,2,0,0"/>
                 </StackPanel>
             </Expander>
@@ -279,7 +279,7 @@
                 <StackPanel>
                     <TextBlock x:Name="MoneySummary" Style="{StaticResource Dim}" TextWrapping="Wrap"/>
                     <TextBlock x:Name="SoldLabel" Text="Sold to merchants" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource AccentBrush}" Margin="0,6,0,0" Visibility="Collapsed"/>
+                               Foreground="{DynamicResource AccentBrush}" Margin="0,6,0,0" Visibility="Collapsed"/>
                     <ItemsControl x:Name="SoldList" Margin="0,2,0,0"/>
                 </StackPanel>
             </Expander>
@@ -300,7 +300,7 @@
                 </Expander.Header>
                 <StackPanel>
                     <TextBlock x:Name="ProgressSummary" Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="0,2,0,4"/>
-                    <TextBlock Text="Skill-ups" FontSize="11" FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}"/>
+                    <TextBlock Text="Skill-ups" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"/>
                     <ItemsControl x:Name="SkillList" Margin="0,2,0,0"/>
                 </StackPanel>
             </Expander>
@@ -334,12 +334,12 @@
                     </Grid>
                 </Expander.Header>
                 <StackPanel>
-                    <TextBlock Text="Deaths" FontSize="11" FontWeight="SemiBold" Foreground="{StaticResource BadBrush}"/>
+                    <TextBlock Text="Deaths" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource BadBrush}"/>
                     <ItemsControl x:Name="DeathList" Margin="0,2,0,4"/>
-                    <TextBlock Text="Zones visited" FontSize="11" FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}"/>
+                    <TextBlock Text="Zones visited" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"/>
                     <ItemsControl x:Name="ZoneList" Margin="0,2,0,4"/>
                     <TextBlock x:Name="MarkersLabel" Text="Camp markers" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{StaticResource AccentBrush}" Visibility="Collapsed"/>
+                               Foreground="{DynamicResource AccentBrush}" Visibility="Collapsed"/>
                     <ItemsControl x:Name="MarkerList" Margin="0,2,0,0"/>
                 </StackPanel>
             </Expander>

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -212,9 +212,26 @@ public partial class MainWindow : Window
         _settings.Save();
     }
 
-    private void ApplyBackgroundOpacity(double opacity) =>
+    private void ApplyBackgroundOpacity(double opacity)
+    {
+        // Tint comes from the current theme's BgBrush rather than a fixed color, so this
+        // still reads right after a theme switch — only the alpha is opacity's to control.
+        var tint = ((SolidColorBrush)FindResource("BgBrush")).Color;
         RootBorder().Background = new SolidColorBrush(
-            Color.FromArgb((byte)(opacity * 255), 0x1C, 0x19, 0x17));
+            Color.FromArgb((byte)(opacity * 255), tint.R, tint.G, tint.B));
+    }
+
+    /// <summary>Re-applies visual state that was baked in via FindResource at construction
+    /// time rather than DynamicResource, so a live theme switch reaches it too.</summary>
+    public void RefreshTheme()
+    {
+        ApplyBackgroundOpacity(_settings.BackgroundOpacity);
+        RootBorder().BorderBrush = (Brush)FindResource(_clickThrough ? "WarnBrush" : "BorderBrush");
+        // Most stat rows bake their brush in via FindResource when built rather than a
+        // binding, and only get rebuilt on the next data change — force one now so an idle
+        // widget still repaints immediately when the theme switches.
+        RefreshUi();
+    }
 
     private OptionsWindow? _optionsWindow;
 

--- a/src/EQBuddy/OptionsWindow.xaml
+++ b/src/EQBuddy/OptionsWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="EQBuddy.OptionsWindow"
+﻿<Window x:Class="EQBuddy.OptionsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="EQBuddy Options" SizeToContent="Height"
@@ -12,8 +12,8 @@
          area of whichever monitor the window is on — at high Windows scaling the content
          is taller than the screen, so the body has to scroll. The title row stays outside
          the scroll so ✕ is always reachable. -->
-    <Border Background="{StaticResource BgBrush}" CornerRadius="10"
-            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+    <Border Background="{DynamicResource BgBrush}" CornerRadius="10"
+            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
             MouseLeftButtonDown="OnDrag">
       <Grid>
         <Grid.RowDefinitions>
@@ -23,7 +23,7 @@
 
         <Grid Grid.Row="0" Margin="16,16,16,6">
             <TextBlock Text="Options" FontWeight="Bold" FontSize="14"
-                       Foreground="{StaticResource AccentBrush}"/>
+                       Foreground="{DynamicResource AccentBrush}"/>
             <Button Style="{StaticResource IconButton}" Content="&#x2715;" ToolTip="Close"
                     HorizontalAlignment="Right" Click="OnClose"/>
         </Grid>
@@ -33,9 +33,15 @@
         <StackPanel Margin="16,0,16,16">
 
             <Grid>
+                <TextBlock Text="Theme" FontSize="12"/>
+                <ComboBox x:Name="ThemeCombo" HorizontalAlignment="Right" Width="130" FontSize="12"
+                          SelectionChanged="OnThemeChanged"/>
+            </Grid>
+
+            <Grid Margin="0,12,0,0">
                 <TextBlock Text="Widget size" FontSize="12"/>
                 <TextBlock x:Name="ScaleLabel" Text="100%" FontSize="12" HorizontalAlignment="Right"
-                           Foreground="{StaticResource AccentBrush}"/>
+                           Foreground="{DynamicResource AccentBrush}"/>
             </Grid>
             <Slider x:Name="ScaleSlider" Minimum="0.8" Maximum="1.6" TickFrequency="0.05"
                     IsSnapToTickEnabled="True" Margin="0,4,0,12"
@@ -44,7 +50,7 @@
             <Grid>
                 <TextBlock Text="Background see-through" FontSize="12"/>
                 <TextBlock x:Name="BgOpacityLabel" Text="95%" FontSize="12" HorizontalAlignment="Right"
-                           Foreground="{StaticResource AccentBrush}"/>
+                           Foreground="{DynamicResource AccentBrush}"/>
             </Grid>
             <TextBlock Text="Only the dark panel fades — text stays sharp." Style="{StaticResource Dim}"/>
             <Slider x:Name="BgOpacitySlider" Minimum="0.15" Maximum="1.0" TickFrequency="0.05"
@@ -54,7 +60,7 @@
             <Grid>
                 <TextBlock Text="Whole-widget opacity" FontSize="12"/>
                 <TextBlock x:Name="OpacityLabel" Text="96%" FontSize="12" HorizontalAlignment="Right"
-                           Foreground="{StaticResource AccentBrush}"/>
+                           Foreground="{DynamicResource AccentBrush}"/>
             </Grid>
             <TextBlock Text="Fades everything, text included." Style="{StaticResource Dim}"/>
             <Slider x:Name="OpacitySlider" Minimum="0.5" Maximum="1.0" TickFrequency="0.02"
@@ -64,7 +70,7 @@
             <CheckBox x:Name="TruncateCheck" Margin="0,12,0,0"
                       Checked="OnTruncateChanged" Unchecked="OnTruncateChanged">
                 <TextBlock Text="Auto-empty finished-session logs" FontSize="12"
-                           Foreground="{StaticResource TextBrush}"/>
+                           Foreground="{DynamicResource TextBrush}"/>
             </CheckBox>
             <TextBlock Text="Turn off if you upload your log files elsewhere — they will grow forever, so clean them up yourself occasionally."
                        Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="20,2,0,0"/>
@@ -72,7 +78,7 @@
             <CheckBox x:Name="TutorialCheck" Margin="0,10,0,0"
                       Checked="OnTutorialToggled" Unchecked="OnTutorialToggled">
                 <TextBlock Text="Show quick tutorial at launch" FontSize="12"
-                           Foreground="{StaticResource TextBrush}"/>
+                           Foreground="{DynamicResource TextBrush}"/>
             </CheckBox>
 
             <Grid Margin="0,12,0,0">
@@ -84,7 +90,7 @@
                        Style="{StaticResource Dim}" TextWrapping="Wrap"/>
 
             <TextBlock Text="Watch rules" FontSize="12" FontWeight="SemiBold"
-                       Foreground="{StaticResource AccentBrush}" Margin="0,14,0,2"/>
+                       Foreground="{DynamicResource AccentBrush}" Margin="0,14,0,2"/>
             <TextBlock Text="Watch loot, kills, skill-ups, deaths, milestones, or your spells wearing off. Spell fade rules pick either one named spell or a whole class (Any crowd control, Charm, Mez, Root, Lull, Stun) — a class needs no match text and keeps working as you level into new spells. Otherwise match is a substring, e.g. 'mote' or 'Befriend'. 🔔 shows a banner; the sound box picks this rule's own sound, so you can tell what happened by ear — 'Default' follows the shared choice below, 'Off' stays silent, 'Custom…' takes your own .wav/.mp3."
                        Style="{StaticResource Dim}" TextWrapping="Wrap"/>
             <!-- Shared-size scope so the header row's Auto columns track the rule rows'. -->
@@ -94,7 +100,7 @@
             <CheckBox x:Name="PinChipsCheck" Margin="0,6,0,0"
                       Checked="OnPinChipsChanged" Unchecked="OnPinChipsChanged">
                 <TextBlock Text="📌 Show watch chips in the mini dashboard" FontSize="12"
-                           Foreground="{StaticResource TextBrush}"/>
+                           Foreground="{DynamicResource TextBrush}"/>
             </CheckBox>
 
             <Grid Margin="0,8,0,0">
@@ -112,7 +118,7 @@
                        Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="0,4,0,0"/>
 
             <TextBlock Text="Overlay cards" FontSize="12" FontWeight="SemiBold"
-                       Foreground="{StaticResource AccentBrush}" Margin="0,14,0,2"/>
+                       Foreground="{DynamicResource AccentBrush}" Margin="0,14,0,2"/>
             <StackPanel x:Name="CardsPanel"/>
 
             <TextBlock Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="0,14,0,0">

--- a/src/EQBuddy/OptionsWindow.xaml.cs
+++ b/src/EQBuddy/OptionsWindow.xaml.cs
@@ -28,6 +28,9 @@ public partial class OptionsWindow : Window
         SourceInitialized += (_, _) => ClampToMonitor();
         LocationChanged += (_, _) => ClampToMonitor();
 
+        foreach (var label in OptionsViewModel.ThemeLabels) ThemeCombo.Items.Add(label);
+        ThemeCombo.SelectedIndex = _vm.ThemeIndex;
+
         ScaleSlider.Value = _vm.UiScale;
         OpacitySlider.Value = _vm.Opacity;
         BgOpacitySlider.Value = _vm.BackgroundOpacity;
@@ -112,6 +115,18 @@ public partial class OptionsWindow : Window
     private void OnWindowChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
     {
         if (_ready) _vm.RecentWindowIndex = WindowCombo.SelectedIndex;
+    }
+
+    private void OnThemeChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+    {
+        if (!_ready) return;
+        _vm.ThemeIndex = ThemeCombo.SelectedIndex;
+        ThemeManager.Apply(_vm.Settings.Theme);
+        // The card rows pick Foreground (dim vs. normal) via FindResource at construction
+        // time rather than a binding, so they need an explicit rebuild to pick up the new
+        // palette — everything else in the window repaints on its own via DynamicResource.
+        BuildCardsEditor();
+        _main.RefreshTheme();
     }
 
     private void OnSoundChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
@@ -441,15 +456,20 @@ public partial class OptionsWindow : Window
         return t;
     }
 
-    private System.Windows.Controls.TextBox DarkBox(string text, string tip) => new()
+    private System.Windows.Controls.TextBox DarkBox(string text, string tip)
     {
-        Text = text, ToolTip = tip, FontSize = 12,
-        Background = new System.Windows.Media.SolidColorBrush(
-            System.Windows.Media.Color.FromRgb(0x2A, 0x25, 0x1F)),
-        Foreground = (System.Windows.Media.Brush)FindResource("TextBrush"),
-        BorderBrush = (System.Windows.Media.Brush)FindResource("BorderBrush"),
-        Padding = new Thickness(4, 2, 4, 2),
-    };
+        var box = new System.Windows.Controls.TextBox
+        {
+            Text = text, ToolTip = tip, FontSize = 12,
+            Padding = new Thickness(4, 2, 4, 2),
+        };
+        // SetResourceReference (not FindResource) so an in-place theme switch repaints
+        // these rows too, not just the chrome built from XAML.
+        box.SetResourceReference(System.Windows.Controls.Control.BackgroundProperty, "ComboBoxBrush");
+        box.SetResourceReference(System.Windows.Controls.Control.ForegroundProperty, "TextBrush");
+        box.SetResourceReference(System.Windows.Controls.Control.BorderBrushProperty, "BorderBrush");
+        return box;
+    }
 
     private void BuildCardsEditor()
     {

--- a/src/EQBuddy/Theme.xaml
+++ b/src/EQBuddy/Theme.xaml
@@ -1,36 +1,28 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- Palette: dark parchment-and-brass fantasy -->
-    <SolidColorBrush x:Key="BgBrush" Color="#F21C1917"/>
-    <SolidColorBrush x:Key="PanelBrush" Color="#26FFFFFF"/>
-    <SolidColorBrush x:Key="PanelHoverBrush" Color="#33FFD98C"/>
-    <SolidColorBrush x:Key="BorderBrush" Color="#66C9A227"/>
-    <SolidColorBrush x:Key="TextBrush" Color="#FFEDE4D3"/>
-    <SolidColorBrush x:Key="DimBrush" Color="#FF9C927F"/>
-    <SolidColorBrush x:Key="AccentBrush" Color="#FFE3B341"/>
-    <SolidColorBrush x:Key="GoodBrush" Color="#FF7FBF5F"/>
-    <SolidColorBrush x:Key="BadBrush" Color="#FFD9634F"/>
-    <SolidColorBrush x:Key="WarnBrush" Color="#FFE0A030"/>
+    <!-- Color palette lives in Themes/*.xaml (swapped at runtime by ThemeManager);
+         everything below only references brush keys, via DynamicResource so a theme
+         switch repaints already-open windows. -->
 
     <Style TargetType="TextBlock">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
         <Setter Property="FontFamily" Value="Segoe UI"/>
     </Style>
 
     <Style x:Key="StatValue" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
         <Setter Property="FontWeight" Value="SemiBold"/>
-        <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
     </Style>
 
     <Style x:Key="Dim" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-        <Setter Property="Foreground" Value="{StaticResource DimBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource DimBrush}"/>
         <Setter Property="FontSize" Value="11"/>
     </Style>
 
     <Style x:Key="IconButton" TargetType="Button">
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Foreground" Value="{StaticResource DimBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource DimBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="6,2"/>
         <Setter Property="Cursor" Value="Hand"/>
@@ -44,8 +36,8 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource PanelHoverBrush}"/>
-                            <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource PanelHoverBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -55,7 +47,7 @@
 
     <Style x:Key="IconToggle" TargetType="ToggleButton">
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Foreground" Value="{StaticResource DimBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource DimBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="6,2"/>
         <Setter Property="Cursor" Value="Hand"/>
@@ -71,13 +63,13 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource PanelHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource PanelHoverBrush}"/>
                             <Setter TargetName="bd" Property="Opacity" Value="0.8"/>
                         </Trigger>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
                             <Setter TargetName="bd" Property="Opacity" Value="1"/>
-                            <Setter TargetName="bd" Property="Background" Value="#33E3B341"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource ToggleHighlightBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -87,12 +79,12 @@
 
     <!-- Collapsible stat section -->
     <Style x:Key="Section" TargetType="Expander">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
         <Setter Property="Margin" Value="0,2,0,0"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Expander">
-                    <Border Background="{StaticResource PanelBrush}" CornerRadius="6">
+                    <Border Background="{DynamicResource PanelBrush}" CornerRadius="6">
                         <StackPanel>
                             <ToggleButton IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                                           Cursor="Hand">
@@ -106,13 +98,13 @@
                                                 </Grid.ColumnDefinitions>
                                                 <ContentPresenter Content="{Binding Header, RelativeSource={RelativeSource AncestorType=Expander}}"/>
                                                 <TextBlock x:Name="chev" Grid.Column="1" Text="&#x25B8;"
-                                                           Foreground="{StaticResource DimBrush}"
+                                                           Foreground="{DynamicResource DimBrush}"
                                                            VerticalAlignment="Center" Margin="6,0,0,0"/>
                                             </Grid>
                                         </Border>
                                         <ControlTemplate.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter TargetName="hb" Property="Background" Value="{StaticResource PanelHoverBrush}"/>
+                                                <Setter TargetName="hb" Property="Background" Value="{DynamicResource PanelHoverBrush}"/>
                                             </Trigger>
                                             <Trigger Property="IsChecked" Value="True">
                                                 <Setter TargetName="chev" Property="Text" Value="&#x25BE;"/>
@@ -136,20 +128,20 @@
 
     <!-- Dark tooltips (default WPF tooltip is light and unreadable over the theme) -->
     <Style TargetType="ToolTip">
-        <Setter Property="Background" Value="#FF262119"/>
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource PopupBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">
                     <Border Background="{TemplateBinding Background}" CornerRadius="6"
-                            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                             Padding="8,5" MaxWidth="320">
                         <ContentPresenter TextElement.Foreground="{TemplateBinding Foreground}">
                             <ContentPresenter.Resources>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="TextWrapping" Value="Wrap"/>
-                                    <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
                                 </Style>
                             </ContentPresenter.Resources>
                         </ContentPresenter>
@@ -161,7 +153,7 @@
 
     <!-- Dark combo box: readable selected value, dark popup, hover highlight -->
     <Style TargetType="ComboBoxItem">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -171,10 +163,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource PanelHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource PanelHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -183,8 +175,8 @@
     </Style>
 
     <Style TargetType="ComboBox">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
-        <Setter Property="Background" Value="#FF2A251F"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBrush}"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -194,9 +186,9 @@
                                       Focusable="False" ClickMode="Press">
                             <ToggleButton.Template>
                                 <ControlTemplate TargetType="ToggleButton">
-                                    <Border Background="#FF2A251F" CornerRadius="5"
-                                            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1">
-                                        <TextBlock Text="&#x25BE;" Foreground="{StaticResource DimBrush}"
+                                    <Border Background="{DynamicResource ComboBoxBrush}" CornerRadius="5"
+                                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1">
+                                        <TextBlock Text="&#x25BE;" Foreground="{DynamicResource DimBrush}"
                                                    HorizontalAlignment="Right" VerticalAlignment="Center"
                                                    Margin="0,0,8,0"/>
                                     </Border>
@@ -210,8 +202,8 @@
                                           TextElement.Foreground="{TemplateBinding Foreground}"/>
                         <Popup IsOpen="{TemplateBinding IsDropDownOpen}" AllowsTransparency="True"
                                Placement="Bottom" StaysOpen="False">
-                            <Border Background="#FF262119" CornerRadius="6" Margin="0,2,0,0"
-                                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                            <Border Background="{DynamicResource PopupBrush}" CornerRadius="6" Margin="0,2,0,0"
+                                    BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                                     MinWidth="{TemplateBinding ActualWidth}"
                                     MaxHeight="{TemplateBinding MaxDropDownHeight}" Padding="4">
                                 <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -227,13 +219,13 @@
 
     <!-- Dark themed context menu -->
     <Style TargetType="ContextMenu">
-        <Setter Property="Background" Value="#FF262119"/>
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource PopupBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ContextMenu">
                     <Border Background="{TemplateBinding Background}" CornerRadius="8"
-                            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                             Padding="4">
                         <StackPanel IsItemsHost="True"/>
                     </Border>
@@ -243,7 +235,7 @@
     </Style>
 
     <Style TargetType="MenuItem">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -254,10 +246,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource PanelHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource PanelHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -269,7 +261,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Separator">
-                    <Border Height="1" Background="{StaticResource BorderBrush}" Margin="8,4"/>
+                    <Border Height="1" Background="{DynamicResource BorderBrush}" Margin="8,4"/>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -278,7 +270,7 @@
     <!-- Star: marks a stat for the mini dashboard -->
     <Style x:Key="StarToggle" TargetType="ToggleButton">
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Foreground" Value="{StaticResource DimBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource DimBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Cursor" Value="Hand"/>
         <Setter Property="FontSize" Value="12"/>
@@ -293,10 +285,10 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
                             <Setter TargetName="star" Property="Text" Value="&#x2605;"/>
-                            <Setter TargetName="star" Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                            <Setter TargetName="star" Property="Foreground" Value="{DynamicResource AccentBrush}"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="star" Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                            <Setter TargetName="star" Property="Foreground" Value="{DynamicResource AccentBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -329,13 +321,13 @@
                                     <Thumb.Template>
                                         <ControlTemplate TargetType="Thumb">
                                             <Border x:Name="Bar" Margin="2,0" CornerRadius="3"
-                                                    Background="#40FFD98C"/>
+                                                    Background="{DynamicResource ScrollThumbBrush}"/>
                                             <ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter TargetName="Bar" Property="Background" Value="#8CFFD98C"/>
+                                                    <Setter TargetName="Bar" Property="Background" Value="{DynamicResource ScrollThumbHoverBrush}"/>
                                                 </Trigger>
                                                 <Trigger Property="IsDragging" Value="True">
-                                                    <Setter TargetName="Bar" Property="Background" Value="{StaticResource AccentBrush}"/>
+                                                    <Setter TargetName="Bar" Property="Background" Value="{DynamicResource AccentBrush}"/>
                                                 </Trigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>

--- a/src/EQBuddy/ThemeManager.cs
+++ b/src/EQBuddy/ThemeManager.cs
@@ -1,0 +1,29 @@
+using System.Windows;
+
+namespace EQBuddy;
+
+/// <summary>
+/// Swaps the palette ResourceDictionary merged into Application.Resources. Theme.xaml's
+/// styles all reference brush keys via DynamicResource, so replacing the palette dictionary
+/// in place repaints every open window immediately — no window needs to be reloaded.
+/// </summary>
+public static class ThemeManager
+{
+    /// <summary>Index of the palette dictionary within App.xaml's MergedDictionaries
+    /// (index 0 — Theme.xaml, the styles, is index 1 and never swapped).</summary>
+    private const int PaletteIndex = 0;
+
+    /// <summary>Loads Themes/{key}.xaml and swaps it into the app's merged dictionaries.
+    /// An unrecognized key (e.g. from an older settings.json) falls back to the first
+    /// entry in <see cref="EQBuddy.UI.Shared.ThemeCatalog"/> rather than throwing.</summary>
+    public static void Apply(string themeKey)
+    {
+        var key = EQBuddy.UI.Shared.ThemeCatalog.Themes[
+            EQBuddy.UI.Shared.ThemeCatalog.IndexOf(themeKey)].Key;
+        var dictionary = new ResourceDictionary
+        {
+            Source = new Uri($"Themes/{key}.xaml", UriKind.Relative),
+        };
+        Application.Current.Resources.MergedDictionaries[PaletteIndex] = dictionary;
+    }
+}

--- a/src/EQBuddy/Themes/BlueGrey.xaml
+++ b/src/EQBuddy/Themes/BlueGrey.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Palette: cool dark slate/blue-grey -->
+    <SolidColorBrush x:Key="BgBrush" Color="#F2181C21"/>
+    <SolidColorBrush x:Key="PanelBrush" Color="#26FFFFFF"/>
+    <SolidColorBrush x:Key="PanelHoverBrush" Color="#335C8AC2"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#665C7A99"/>
+    <SolidColorBrush x:Key="TextBrush" Color="#FFE4E9EF"/>
+    <SolidColorBrush x:Key="DimBrush" Color="#FF8B96A3"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#FF5FA8D3"/>
+    <SolidColorBrush x:Key="GoodBrush" Color="#FF6FBF7F"/>
+    <SolidColorBrush x:Key="BadBrush" Color="#FFD9634F"/>
+    <SolidColorBrush x:Key="WarnBrush" Color="#FFE0A030"/>
+    <SolidColorBrush x:Key="PopupBrush" Color="#FF20242B"/>
+    <SolidColorBrush x:Key="ComboBoxBrush" Color="#FF242830"/>
+    <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#335C8AC2"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#405C8AC2"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8C5C8AC2"/>
+
+</ResourceDictionary>

--- a/src/EQBuddy/Themes/Grey.xaml
+++ b/src/EQBuddy/Themes/Grey.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Palette: neutral monochrome grey -->
+    <SolidColorBrush x:Key="BgBrush" Color="#F21A1A1A"/>
+    <SolidColorBrush x:Key="PanelBrush" Color="#26FFFFFF"/>
+    <SolidColorBrush x:Key="PanelHoverBrush" Color="#33BFBFBF"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#66808080"/>
+    <SolidColorBrush x:Key="TextBrush" Color="#FFEAEAEA"/>
+    <SolidColorBrush x:Key="DimBrush" Color="#FF9C9C9C"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#FFC0C0C0"/>
+    <SolidColorBrush x:Key="GoodBrush" Color="#FF7FBF5F"/>
+    <SolidColorBrush x:Key="BadBrush" Color="#FFD9634F"/>
+    <SolidColorBrush x:Key="WarnBrush" Color="#FFE0A030"/>
+    <SolidColorBrush x:Key="PopupBrush" Color="#FF232323"/>
+    <SolidColorBrush x:Key="ComboBoxBrush" Color="#FF272727"/>
+    <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33BFBFBF"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40BFBFBF"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8CBFBFBF"/>
+
+</ResourceDictionary>

--- a/src/EQBuddy/Themes/ParchmentBrass.xaml
+++ b/src/EQBuddy/Themes/ParchmentBrass.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Palette: dark parchment-and-brass fantasy (the original EQBuddy look) -->
+    <SolidColorBrush x:Key="BgBrush" Color="#F21C1917"/>
+    <SolidColorBrush x:Key="PanelBrush" Color="#26FFFFFF"/>
+    <SolidColorBrush x:Key="PanelHoverBrush" Color="#33FFD98C"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#66C9A227"/>
+    <SolidColorBrush x:Key="TextBrush" Color="#FFEDE4D3"/>
+    <SolidColorBrush x:Key="DimBrush" Color="#FF9C927F"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#FFE3B341"/>
+    <SolidColorBrush x:Key="GoodBrush" Color="#FF7FBF5F"/>
+    <SolidColorBrush x:Key="BadBrush" Color="#FFD9634F"/>
+    <SolidColorBrush x:Key="WarnBrush" Color="#FFE0A030"/>
+    <SolidColorBrush x:Key="PopupBrush" Color="#FF262119"/>
+    <SolidColorBrush x:Key="ComboBoxBrush" Color="#FF2A251F"/>
+    <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33E3B341"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40FFD98C"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8CFFD98C"/>
+
+</ResourceDictionary>

--- a/src/EQBuddy/Themes/Redish.xaml
+++ b/src/EQBuddy/Themes/Redish.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Palette: warm dark red/crimson accent -->
+    <SolidColorBrush x:Key="BgBrush" Color="#F21F1615"/>
+    <SolidColorBrush x:Key="PanelBrush" Color="#26FFFFFF"/>
+    <SolidColorBrush x:Key="PanelHoverBrush" Color="#33D96A55"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#66B34A3D"/>
+    <SolidColorBrush x:Key="TextBrush" Color="#FFF2E2DE"/>
+    <SolidColorBrush x:Key="DimBrush" Color="#FFA88A83"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#FFE0654A"/>
+    <SolidColorBrush x:Key="GoodBrush" Color="#FF7FBF5F"/>
+    <SolidColorBrush x:Key="BadBrush" Color="#FFD9345F"/>
+    <SolidColorBrush x:Key="WarnBrush" Color="#FFE0A030"/>
+    <SolidColorBrush x:Key="PopupBrush" Color="#FF251815"/>
+    <SolidColorBrush x:Key="ComboBoxBrush" Color="#FF291C18"/>
+    <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33D96A55"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40D96A55"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8CD96A55"/>
+
+</ResourceDictionary>

--- a/src/EQBuddy/Themes/Solarized.xaml
+++ b/src/EQBuddy/Themes/Solarized.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Palette: Solarized Light (Ethan Schoonover's base3/base2/base01/base00 scale) -->
+    <SolidColorBrush x:Key="BgBrush" Color="#F2FDF6E3"/>
+    <SolidColorBrush x:Key="PanelBrush" Color="#14002B36"/>
+    <SolidColorBrush x:Key="PanelHoverBrush" Color="#33268BD2"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#66586E75"/>
+    <SolidColorBrush x:Key="TextBrush" Color="#FF657B83"/>
+    <SolidColorBrush x:Key="DimBrush" Color="#FF93A1A1"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#FF268BD2"/>
+    <SolidColorBrush x:Key="GoodBrush" Color="#FF859900"/>
+    <SolidColorBrush x:Key="BadBrush" Color="#FFDC322F"/>
+    <SolidColorBrush x:Key="WarnBrush" Color="#FFCB4B16"/>
+    <SolidColorBrush x:Key="PopupBrush" Color="#FFEEE8D5"/>
+    <SolidColorBrush x:Key="ComboBoxBrush" Color="#FFEEE8D5"/>
+    <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33268BD2"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40586E75"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8C586E75"/>
+
+</ResourceDictionary>

--- a/src/EQBuddy/Themes/SolarizedDark.xaml
+++ b/src/EQBuddy/Themes/SolarizedDark.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Palette: Solarized Dark (Ethan Schoonover's base03/base02/base01/base0 scale) -->
+    <SolidColorBrush x:Key="BgBrush" Color="#F2002B36"/>
+    <SolidColorBrush x:Key="PanelBrush" Color="#26FFFFFF"/>
+    <SolidColorBrush x:Key="PanelHoverBrush" Color="#33268BD2"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#66586E75"/>
+    <SolidColorBrush x:Key="TextBrush" Color="#FF839496"/>
+    <SolidColorBrush x:Key="DimBrush" Color="#FF586E75"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#FF268BD2"/>
+    <SolidColorBrush x:Key="GoodBrush" Color="#FF859900"/>
+    <SolidColorBrush x:Key="BadBrush" Color="#FFDC322F"/>
+    <SolidColorBrush x:Key="WarnBrush" Color="#FFCB4B16"/>
+    <SolidColorBrush x:Key="PopupBrush" Color="#FF073642"/>
+    <SolidColorBrush x:Key="ComboBoxBrush" Color="#FF0A3C48"/>
+    <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33268BD2"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40268BD2"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8C268BD2"/>
+
+</ResourceDictionary>

--- a/src/EQBuddy/Themes/Turquoise.xaml
+++ b/src/EQBuddy/Themes/Turquoise.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Palette: dark teal with a turquoise accent -->
+    <SolidColorBrush x:Key="BgBrush" Color="#F2131C1C"/>
+    <SolidColorBrush x:Key="PanelBrush" Color="#26FFFFFF"/>
+    <SolidColorBrush x:Key="PanelHoverBrush" Color="#3340C7B8"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#6629A99A"/>
+    <SolidColorBrush x:Key="TextBrush" Color="#FFE0F2EF"/>
+    <SolidColorBrush x:Key="DimBrush" Color="#FF87A6A0"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#FF3FCFBE"/>
+    <SolidColorBrush x:Key="GoodBrush" Color="#FF6FBF7F"/>
+    <SolidColorBrush x:Key="BadBrush" Color="#FFD9634F"/>
+    <SolidColorBrush x:Key="WarnBrush" Color="#FFE0A030"/>
+    <SolidColorBrush x:Key="PopupBrush" Color="#FF16211F"/>
+    <SolidColorBrush x:Key="ComboBoxBrush" Color="#FF1A2725"/>
+    <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#3340C7B8"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#4040C7B8"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8C40C7B8"/>
+
+</ResourceDictionary>

--- a/src/EQBuddy/TutorialWindow.xaml
+++ b/src/EQBuddy/TutorialWindow.xaml
@@ -1,45 +1,45 @@
-<Window x:Class="EQBuddy.TutorialWindow"
+﻿<Window x:Class="EQBuddy.TutorialWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Welcome to EQBuddy" WindowStyle="None" AllowsTransparency="True"
         Background="Transparent" WindowStartupLocation="CenterScreen"
         SizeToContent="Height" Width="580" ShowInTaskbar="False" Topmost="True"
         ResizeMode="NoResize" MouseLeftButtonDown="OnDrag">
-    <Border Background="{StaticResource BgBrush}" BorderBrush="{StaticResource BorderBrush}"
+    <Border Background="{DynamicResource BgBrush}" BorderBrush="{DynamicResource BorderBrush}"
             BorderThickness="1" CornerRadius="10" Padding="20,16">
         <StackPanel>
             <Grid>
                 <TextBlock x:Name="PageTitle" FontSize="16" FontWeight="Bold"
-                           Foreground="{StaticResource AccentBrush}"/>
+                           Foreground="{DynamicResource AccentBrush}"/>
                 <TextBlock x:Name="PageDots" HorizontalAlignment="Right" VerticalAlignment="Center"
-                           FontSize="12" Foreground="{StaticResource DimBrush}"/>
+                           FontSize="12" Foreground="{DynamicResource DimBrush}"/>
             </Grid>
             <TextBlock x:Name="PageBody" TextWrapping="Wrap" FontSize="13"
-                       Foreground="{StaticResource TextBrush}" Margin="0,10,0,0" LineHeight="19"/>
+                       Foreground="{DynamicResource TextBrush}" Margin="0,10,0,0" LineHeight="19"/>
             <CheckBox x:Name="KeepLogsCheck" Margin="0,14,0,2" Visibility="Collapsed"
                       Checked="OnKeepLogsChanged" Unchecked="OnKeepLogsChanged">
                 <TextBlock Text="Keep my log files — disable auto-empty" FontSize="13"
-                           FontWeight="SemiBold" Foreground="{StaticResource TextBrush}"/>
+                           FontWeight="SemiBold" Foreground="{DynamicResource TextBrush}"/>
             </CheckBox>
             <Border x:Name="ImageFrame" Margin="0,14,0,0" HorizontalAlignment="Center"
-                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                    BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                     CornerRadius="6" Visibility="Collapsed">
                 <Image x:Name="PageImage" MaxHeight="320" MaxWidth="528" Stretch="Uniform"/>
             </Border>
             <Grid Margin="0,18,0,0">
                 <StackPanel Orientation="Horizontal">
                     <Button Content="Never show again" Style="{StaticResource IconButton}"
-                            FontSize="12" Click="OnNever" Foreground="{StaticResource DimBrush}"/>
+                            FontSize="12" Click="OnNever" Foreground="{DynamicResource DimBrush}"/>
                     <Button Content="Skip for now" Style="{StaticResource IconButton}"
                             FontSize="12" Click="OnSkip" Margin="10,0,0,0"
-                            Foreground="{StaticResource DimBrush}"/>
+                            Foreground="{DynamicResource DimBrush}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button x:Name="PrevBtn" Content="◀ Previous" Style="{StaticResource IconButton}"
                             FontSize="12" Click="OnPrev"/>
                     <Button x:Name="NextBtn" Content="Next ▶" Style="{StaticResource IconButton}"
                             FontSize="12" FontWeight="SemiBold" Click="OnNext" Margin="14,0,0,0"
-                            Foreground="{StaticResource AccentBrush}"/>
+                            Foreground="{DynamicResource AccentBrush}"/>
                 </StackPanel>
             </Grid>
         </StackPanel>


### PR DESCRIPTION
Split the palette out of Theme.xaml into swappable Themes/*.xaml dictionaries (Parchment & Brass, Blue Grey, Turquoise, Redish, Grey, Solarized, Solarized Dark) and convert brush references to DynamicResource so switching repaints already-open windows live. Options gets a Theme dropdown; the choice persists to settings.json.