### PR TITLE
Bring theme support to the Avalonia UI

### DIFF
--- a/src/EQBuddy.Avalonia/AlertWindow.cs
+++ b/src/EQBuddy.Avalonia/AlertWindow.cs
@@ -42,7 +42,7 @@ public sealed class AlertWindow : Window
         };
         Content = new Border
         {
-            Background = new SolidColorBrush(Color.FromArgb(0xF0, 0x1E, 0x1A, 0x14)),
+            Background = AppTheme.BgBrush,
             BorderBrush = AppTheme.AccentBrush,
             BorderThickness = new Thickness(1),
             CornerRadius = new CornerRadius(8),

--- a/src/EQBuddy.Avalonia/App.cs
+++ b/src/EQBuddy.Avalonia/App.cs
@@ -31,6 +31,11 @@ public sealed class App : Application
             args.SetObserved();
         };
 
+        // Applied before MainWindow is constructed so the saved theme is already live
+        // for the very first frame (mirrors the WPF app's App.xaml.cs).
+        try { AppTheme.Apply(Core.AppSettings.Load().Theme); }
+        catch (Exception ex) { LogError(ex); }
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             desktop.MainWindow = new MainWindow();
 

--- a/src/EQBuddy.Avalonia/AppTheme.cs
+++ b/src/EQBuddy.Avalonia/AppTheme.cs
@@ -4,24 +4,96 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
+using EQBuddy.UI.Shared;
 
 namespace EQBuddy.Avalonia;
 
 internal static class AppTheme
 {
-    public static readonly IBrush PanelBrush = Brush("#26FFFFFF");
-    public static readonly IBrush PanelHoverBrush = Brush("#33FFD98C");
-    public static readonly IBrush BorderBrush = Brush("#66C9A227");
-    public static readonly IBrush TextBrush = Brush("#FFEDE4D3");
-    public static readonly IBrush DimBrush = Brush("#FF9C927F");
-    public static readonly IBrush AccentBrush = Brush("#FFE3B341");
-    public static readonly IBrush GoodBrush = Brush("#FF7FBF5F");
-    public static readonly IBrush BadBrush = Brush("#FFD9634F");
-    public static readonly IBrush WarnBrush = Brush("#FFE0A030");
-    public static readonly IBrush BgBrush = Brush("#F21C1917");
+    // Every theme color is a single, never-replaced SolidColorBrush instance. Controls
+    // hold a reference to these (not a copy), so Apply() mutating .Color repaints
+    // everything already on screen — Avalonia brushes raise Invalidated on change, no
+    // resource-dictionary lookup or rebuild required. Values must stay in sync with the
+    // WPF app's Themes/*.xaml palettes (see Palette below) — same keys, same hex.
+    public static readonly SolidColorBrush BgBrush = new();
+    public static readonly SolidColorBrush PanelBrush = new();
+    public static readonly SolidColorBrush PanelHoverBrush = new();
+    public static readonly SolidColorBrush BorderBrush = new();
+    public static readonly SolidColorBrush TextBrush = new();
+    public static readonly SolidColorBrush DimBrush = new();
+    public static readonly SolidColorBrush AccentBrush = new();
+    public static readonly SolidColorBrush GoodBrush = new();
+    public static readonly SolidColorBrush BadBrush = new();
+    public static readonly SolidColorBrush WarnBrush = new();
+    public static readonly SolidColorBrush PopupBrush = new();
+    public static readonly SolidColorBrush ComboBoxBrush = new();
+    public static readonly SolidColorBrush GoodWashBrush = new();
+    public static readonly SolidColorBrush WarnWashBrush = new();
 
-    public static IBrush BgWithOpacity(double opacity) =>
-        new SolidColorBrush(Color.FromArgb((byte)(Math.Clamp(opacity, 0.15, 1.0) * 255), 0x1C, 0x19, 0x17));
+    private sealed record Palette(
+        string Bg, string Panel, string PanelHover, string Border, string Text, string Dim,
+        string Accent, string Good, string Bad, string Warn, string Popup, string ComboBox,
+        string GoodWash, string WarnWash);
+
+    private static readonly Dictionary<string, Palette> Palettes = new()
+    {
+        ["ParchmentBrass"] = new("#F21C1917", "#26FFFFFF", "#33FFD98C", "#66C9A227", "#FFEDE4D3",
+            "#FF9C927F", "#FFE3B341", "#FF7FBF5F", "#FFD9634F", "#FFE0A030", "#FF262119",
+            "#FF2A251F", "#337FBF5F", "#33E0A030"),
+        ["BlueGrey"] = new("#F2181C21", "#26FFFFFF", "#335C8AC2", "#665C7A99", "#FFE4E9EF",
+            "#FF8B96A3", "#FF5FA8D3", "#FF6FBF7F", "#FFD9634F", "#FFE0A030", "#FF20242B",
+            "#FF242830", "#336FBF7F", "#33E0A030"),
+        ["Turquoise"] = new("#F2131C1C", "#26FFFFFF", "#3340C7B8", "#6629A99A", "#FFE0F2EF",
+            "#FF87A6A0", "#FF3FCFBE", "#FF6FBF7F", "#FFD9634F", "#FFE0A030", "#FF16211F",
+            "#FF1A2725", "#336FBF7F", "#33E0A030"),
+        ["Redish"] = new("#F21F1615", "#26FFFFFF", "#33D96A55", "#66B34A3D", "#FFF2E2DE",
+            "#FFA88A83", "#FFE0654A", "#FF7FBF5F", "#FFD9345F", "#FFE0A030", "#FF251815",
+            "#FF291C18", "#337FBF5F", "#33E0A030"),
+        ["Grey"] = new("#F21A1A1A", "#26FFFFFF", "#33BFBFBF", "#66808080", "#FFEAEAEA",
+            "#FF9C9C9C", "#FFC0C0C0", "#FF7FBF5F", "#FFD9634F", "#FFE0A030", "#FF232323",
+            "#FF272727", "#337FBF5F", "#33E0A030"),
+        ["Solarized"] = new("#F2FDF6E3", "#14002B36", "#33268BD2", "#66586E75", "#FF657B83",
+            "#FF93A1A1", "#FF268BD2", "#FF859900", "#FFDC322F", "#FFCB4B16", "#FFEEE8D5",
+            "#FFEEE8D5", "#33859900", "#33CB4B16"),
+        ["SolarizedDark"] = new("#F2002B36", "#26FFFFFF", "#33268BD2", "#66586E75", "#FF839496",
+            "#FF586E75", "#FF268BD2", "#FF859900", "#FFDC322F", "#FFCB4B16", "#FF073642",
+            "#FF0A3C48", "#33859900", "#33CB4B16"),
+    };
+
+    static AppTheme() => Apply("ParchmentBrass");
+
+    /// <summary>Repaints every control holding one of the brushes above. An unrecognized
+    /// key (e.g. from an older settings.json) falls back to the first theme rather than
+    /// throwing — same behavior as the WPF app's ThemeManager.</summary>
+    public static void Apply(string themeKey)
+    {
+        var key = ThemeCatalog.Themes[ThemeCatalog.IndexOf(themeKey)].Key;
+        var p = Palettes[key];
+        BgBrush.Color = Color.Parse(p.Bg);
+        PanelBrush.Color = Color.Parse(p.Panel);
+        PanelHoverBrush.Color = Color.Parse(p.PanelHover);
+        BorderBrush.Color = Color.Parse(p.Border);
+        TextBrush.Color = Color.Parse(p.Text);
+        DimBrush.Color = Color.Parse(p.Dim);
+        AccentBrush.Color = Color.Parse(p.Accent);
+        GoodBrush.Color = Color.Parse(p.Good);
+        BadBrush.Color = Color.Parse(p.Bad);
+        WarnBrush.Color = Color.Parse(p.Warn);
+        PopupBrush.Color = Color.Parse(p.Popup);
+        ComboBoxBrush.Color = Color.Parse(p.ComboBox);
+        GoodWashBrush.Color = Color.Parse(p.GoodWash);
+        WarnWashBrush.Color = Color.Parse(p.WarnWash);
+    }
+
+    // Tint comes from the current theme's BgBrush rather than a fixed color, so this
+    // still reads right after a theme switch — only the alpha is opacity's to control.
+    // Returns a fresh brush each call (opacity is a slider, not a theme), so callers that
+    // want it to track a live theme switch must re-invoke this after AppTheme.Apply.
+    public static IBrush BgWithOpacity(double opacity)
+    {
+        var c = BgBrush.Color;
+        return new SolidColorBrush(Color.FromArgb((byte)(Math.Clamp(opacity, 0.15, 1.0) * 255), c.R, c.G, c.B));
+    }
 
     public static Button IconButton(AppIcon icon, string tip)
     {

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -32,8 +32,8 @@ public sealed class MainWindow : Window
     private readonly Ellipse _statusDot = Dot();
     private readonly TextBlock _charLabel = AppTheme.DimText("looking for a character...");
     private readonly ScrollViewer _sectionScroll = new();
-    private readonly Border _logBanner = Banner(AppTheme.WarnBrush);
-    private readonly Border _updateBanner = Banner(AppTheme.GoodBrush);
+    private readonly Border _logBanner = Banner(AppTheme.WarnWashBrush);
+    private readonly Border _updateBanner = Banner(AppTheme.GoodWashBrush);
     private readonly TextBlock _updateText = new() { FontSize = 12, Foreground = AppTheme.GoodBrush, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap };
     private readonly TextBlock _zoneText = AppTheme.DimText("-");
     private readonly TextBlock _sessionText = AppTheme.DimText("session 0:00");
@@ -583,6 +583,17 @@ public sealed class MainWindow : Window
     }
 
     private void ApplyBackgroundOpacity(double opacity) => _root.Background = AppTheme.BgWithOpacity(opacity);
+
+    /// <summary>Re-applies visual state that AppTheme.Apply's brush mutation can't reach
+    /// on its own: BgWithOpacity returns a fresh, non-live brush each call, and stat rows
+    /// built from AccentBarBrush() bake in a color snapshot rather than a live reference.
+    /// Everything else (borders, banners, headings) repaints on its own because it holds
+    /// a reference to the same AppTheme brush instance that just got mutated.</summary>
+    public void RefreshTheme()
+    {
+        ApplyBackgroundOpacity(_settings.BackgroundOpacity);
+        RefreshUi();
+    }
 
     private async void OnChooseLogFolder(object? sender, EventArgs e)
     {
@@ -1456,9 +1467,12 @@ public sealed class MainWindow : Window
         VerticalAlignment = VerticalAlignment.Center,
     };
 
+    // Takes an already-translucent wash brush (AppTheme.GoodWashBrush/WarnWashBrush)
+    // directly rather than deriving one, so a live theme switch repaints it — the brush
+    // reference is the same instance AppTheme.Apply mutates in place.
     private static Border Banner(IBrush brush) => new()
     {
-        Background = new SolidColorBrush(((SolidColorBrush)brush).Color, 0.20),
+        Background = brush,
         CornerRadius = new CornerRadius(6),
         Padding = new Thickness(8, 6),
         IsVisible = false,

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -23,6 +23,7 @@ public sealed class OptionsWindow : Window
     private readonly CheckBox _truncateCheck = new() { Margin = new Thickness(0, 12, 0, 0) };
     private readonly CheckBox _tutorialCheck = new() { Margin = new Thickness(0, 10, 0, 0) };
     private readonly CheckBox _pinChipsCheck = new() { Margin = new Thickness(0, 6, 0, 0) };
+    private readonly ComboBox _themeCombo = new() { Width = 130, FontSize = 12 };
     private readonly ComboBox _windowCombo = new() { Width = 90, FontSize = 12 };
     private readonly ComboBox _soundCombo = new() { Width = 120, FontSize = 12 };
     private readonly TextBlock _soundFileNote = AppTheme.DimText("");
@@ -100,6 +101,10 @@ public sealed class OptionsWindow : Window
             _main.PersistSettings();
         };
 
+        foreach (var label in OptionsViewModel.ThemeLabels) _themeCombo.Items.Add(label);
+        _themeCombo.SelectedIndex = ThemeCatalog.IndexOf(main.Settings.Theme);
+        _themeCombo.SelectionChanged += OnThemeChanged;
+
         foreach (var m in (int[])[5, 15, 30]) _windowCombo.Items.Add($"{m} min");
         _windowCombo.SelectedIndex = main.Settings.RecentWindowMinutes switch { 5 => 0, 30 => 2, _ => 1 };
         _windowCombo.SelectionChanged += (_, _) =>
@@ -146,6 +151,8 @@ public sealed class OptionsWindow : Window
         close.Click += (_, _) => Close();
         title.Children.Add(close);
         panel.Children.Add(title);
+
+        panel.Children.Add(Row("Theme", _themeCombo, new Thickness(0, 0, 0, 12)));
 
         AddSlider(panel, "Widget size", _scaleLabel, _scaleSlider);
         AddSlider(panel, "Background see-through", _bgOpacityLabel, _bgOpacitySlider,
@@ -334,6 +341,15 @@ public sealed class OptionsWindow : Window
         BuildCardsEditor();
     }
 
+    private void OnThemeChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (!_ready || _themeCombo.SelectedIndex < 0) return;
+        _main.Settings.Theme = ThemeCatalog.Themes[_themeCombo.SelectedIndex].Key;
+        _main.PersistSettings();
+        AppTheme.Apply(_main.Settings.Theme);
+        _main.RefreshTheme();
+    }
+
     private async void OnSoundChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (!_ready) return;
@@ -375,7 +391,7 @@ public sealed class OptionsWindow : Window
         {
             Text = text,
             FontSize = 12,
-            Background = new SolidColorBrush(Color.FromRgb(0x2A, 0x25, 0x1F)),
+            Background = AppTheme.ComboBoxBrush,
             Foreground = AppTheme.TextBrush,
             BorderBrush = AppTheme.BorderBrush,
             Padding = new Thickness(4, 2),


### PR DESCRIPTION
The Avalonia port had no theming at all — a single hardcoded AppTheme palette. Since it builds its whole UI in code rather than XAML resource dictionaries, use a different mechanism than the WPF app's DynamicResource: AppTheme's colors are now persistent, mutable SolidColorBrush singletons, so AppTheme.Apply() mutating .Color repaints anything already holding a reference to one, no rebuild needed. Options gets the same Theme dropdown as the WPF app, backed by the same EQBuddy.UI.Shared.ThemeCatalog, so the setting round-trips between both UIs. Also fixes three colors that were still hardcoded independent of any theme (the alert popup background, the options text-box background, and BgWithOpacity's background tint) — the same class of gap the WPF PR's reviewer found and fixed there.