### PR TITLE
Theme the log/update banner tints

### DIFF
--- a/src/EQBuddy/MainWindow.xaml
+++ b/src/EQBuddy/MainWindow.xaml
@@ -77,7 +77,7 @@
             </Grid>
 
             <!-- Logging-off reminder -->
-            <Border x:Name="LogBanner" Background="#33E0A030" CornerRadius="6" Padding="8,6"
+            <Border x:Name="LogBanner" Background="{DynamicResource WarnWashBrush}" CornerRadius="6" Padding="8,6"
                     Margin="0,8,0,0" Visibility="Collapsed">
                 <TextBlock TextWrapping="Wrap" FontSize="12">
                     <Run Foreground="{DynamicResource WarnBrush}" FontWeight="SemiBold" Text="Logging looks off."/>
@@ -87,7 +87,7 @@
             </Border>
 
             <!-- Update available -->
-            <Border x:Name="UpdateBanner" Background="#337FBF5F" CornerRadius="6" Padding="8,6"
+            <Border x:Name="UpdateBanner" Background="{DynamicResource GoodWashBrush}" CornerRadius="6" Padding="8,6"
                     Margin="0,8,0,0" Visibility="Collapsed" Cursor="Hand"
                     MouseLeftButtonDown="OnUpdateBannerClick">
                 <TextBlock x:Name="UpdateText" TextWrapping="Wrap" FontSize="12"

--- a/src/EQBuddy/Themes/BlueGrey.xaml
+++ b/src/EQBuddy/Themes/BlueGrey.xaml
@@ -17,5 +17,7 @@
     <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#335C8AC2"/>
     <SolidColorBrush x:Key="ScrollThumbBrush" Color="#405C8AC2"/>
     <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8C5C8AC2"/>
+    <SolidColorBrush x:Key="GoodWashBrush" Color="#336FBF7F"/>
+    <SolidColorBrush x:Key="WarnWashBrush" Color="#33E0A030"/>
 
 </ResourceDictionary>

--- a/src/EQBuddy/Themes/Grey.xaml
+++ b/src/EQBuddy/Themes/Grey.xaml
@@ -17,5 +17,7 @@
     <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33BFBFBF"/>
     <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40BFBFBF"/>
     <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8CBFBFBF"/>
+    <SolidColorBrush x:Key="GoodWashBrush" Color="#337FBF5F"/>
+    <SolidColorBrush x:Key="WarnWashBrush" Color="#33E0A030"/>
 
 </ResourceDictionary>

--- a/src/EQBuddy/Themes/ParchmentBrass.xaml
+++ b/src/EQBuddy/Themes/ParchmentBrass.xaml
@@ -17,5 +17,7 @@
     <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33E3B341"/>
     <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40FFD98C"/>
     <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8CFFD98C"/>
+    <SolidColorBrush x:Key="GoodWashBrush" Color="#337FBF5F"/>
+    <SolidColorBrush x:Key="WarnWashBrush" Color="#33E0A030"/>
 
 </ResourceDictionary>

--- a/src/EQBuddy/Themes/Redish.xaml
+++ b/src/EQBuddy/Themes/Redish.xaml
@@ -17,5 +17,7 @@
     <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33D96A55"/>
     <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40D96A55"/>
     <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8CD96A55"/>
+    <SolidColorBrush x:Key="GoodWashBrush" Color="#337FBF5F"/>
+    <SolidColorBrush x:Key="WarnWashBrush" Color="#33E0A030"/>
 
 </ResourceDictionary>

--- a/src/EQBuddy/Themes/Solarized.xaml
+++ b/src/EQBuddy/Themes/Solarized.xaml
@@ -17,5 +17,7 @@
     <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33268BD2"/>
     <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40586E75"/>
     <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8C586E75"/>
+    <SolidColorBrush x:Key="GoodWashBrush" Color="#33859900"/>
+    <SolidColorBrush x:Key="WarnWashBrush" Color="#33CB4B16"/>
 
 </ResourceDictionary>

--- a/src/EQBuddy/Themes/SolarizedDark.xaml
+++ b/src/EQBuddy/Themes/SolarizedDark.xaml
@@ -17,5 +17,7 @@
     <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#33268BD2"/>
     <SolidColorBrush x:Key="ScrollThumbBrush" Color="#40268BD2"/>
     <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8C268BD2"/>
+    <SolidColorBrush x:Key="GoodWashBrush" Color="#33859900"/>
+    <SolidColorBrush x:Key="WarnWashBrush" Color="#33CB4B16"/>
 
 </ResourceDictionary>

--- a/src/EQBuddy/Themes/Turquoise.xaml
+++ b/src/EQBuddy/Themes/Turquoise.xaml
@@ -17,5 +17,7 @@
     <SolidColorBrush x:Key="ToggleHighlightBrush" Color="#3340C7B8"/>
     <SolidColorBrush x:Key="ScrollThumbBrush" Color="#4040C7B8"/>
     <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#8C40C7B8"/>
+    <SolidColorBrush x:Key="GoodWashBrush" Color="#336FBF7F"/>
+    <SolidColorBrush x:Key="WarnWashBrush" Color="#33E0A030"/>
 
 </ResourceDictionary>


### PR DESCRIPTION
The warn/good banner washes in MainWindow.xaml were still fixed hex colors independent of the active theme, flagged as a loose end when the theme picker PR merged. Add GoodWashBrush/WarnWashBrush to every palette and switch the banners to DynamicResource.