### PR TITLE
Auto-download and install updates from GitHub Releases

### DIFF
--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -1106,15 +1106,14 @@ public sealed class MainWindow : Window
         {
             var folder = UpdateChecker.FindUpdateFolder(_settings.UpdateFolder);
             var info = folder is null ? null : UpdateChecker.Check(folder);
-            if (info is null && await UpdateChecker.CheckGitHubAsync() is { } webLatest)
-                info = new UpdateInfo(webLatest, SetupPath: null);
+            info ??= await UpdateChecker.CheckGitHubAsync();
             Dispatcher.UIThread.Post(() =>
             {
                 if (_installingUpdate) return;
                 if (info is not null && UpdateChecker.IsNewer(info))
                 {
                     _pendingUpdate = info;
-                    _updateText.Text = info.SetupPath is not null
+                    _updateText.Text = info.SetupPath is not null || info.DownloadUrl is not null
                         ? $"Update v{info.Latest} is ready - click here to install."
                         : $"Update v{info.Latest} is available - click to open the download page.";
                     _updateBanner.IsVisible = true;
@@ -1205,7 +1204,14 @@ public sealed class MainWindow : Window
     {
         e.Handled = true;
         if (_pendingUpdate is not { } info || _installingUpdate) return;
-        if (info.SetupPath is null)
+
+        // The staged file is always a Windows EQBuddySetup.exe run with an Inno Setup
+        // /SILENT flag — there's nothing installable that way on Linux, so a GitHub-sourced
+        // update there always goes to the release page, same as when no installer asset
+        // is attached at all. OneDrive-sourced updates (SetupPath) predate this and are a
+        // Windows-only distribution channel already, so they're unaffected by this check.
+        var canAutoInstall = OperatingSystem.IsWindows() && (info.SetupPath is not null || info.DownloadUrl is not null);
+        if (!canAutoInstall)
         {
             try
             {
@@ -1222,12 +1228,14 @@ public sealed class MainWindow : Window
             return;
         }
         _installingUpdate = true;
-        _updateText.Text = "Installing update - EQBuddy will restart itself...";
-        Task.Run(() =>
+        _updateText.Text = info.DownloadUrl is not null
+            ? "Downloading update - EQBuddy will restart itself..."
+            : "Installing update - EQBuddy will restart itself...";
+        Task.Run(async () =>
         {
             try
             {
-                var staged = UpdateChecker.StageForInstall(info);
+                var staged = await UpdateChecker.StageForInstall(info);
                 Process.Start(staged, "/SILENT");
                 Dispatcher.UIThread.Post(Shutdown);
             }

--- a/src/EQBuddy.Core/UpdateChecker.cs
+++ b/src/EQBuddy.Core/UpdateChecker.cs
@@ -6,8 +6,10 @@ using System.Text.Json;
 
 namespace EQBuddy.Core;
 
-/// <summary>SetupPath is null for web (GitHub) updates — the banner links to the release page instead of installing.</summary>
-public sealed record UpdateInfo(Version Latest, string? SetupPath);
+/// <summary>SetupPath is a local file ready to install as-is (the OneDrive path). DownloadUrl
+/// is set instead for a GitHub-sourced update — StageForInstall fetches it over HTTP first,
+/// then installs the same way. Both null means no update is available.</summary>
+public sealed record UpdateInfo(Version Latest, string? SetupPath, string? DownloadUrl = null, string? Sha256Url = null);
 
 /// <summary>
 /// Local-first update checker: looks for a newer EQBuddySetup.exe in the family's
@@ -90,15 +92,28 @@ public static class UpdateChecker
 
     public static bool IsNewer(UpdateInfo info) => info.Latest > CurrentVersion;
 
-    /// <summary>Latest released version tag on GitHub, or null if unreachable/unparseable.</summary>
-    public static async Task<Version?> CheckGitHubAsync()
+    /// <summary>Latest GitHub release, including the installer asset's download URL when
+    /// the release publishes one (SetupName, optionally with a sibling .sha256 for
+    /// integrity checking) — null if unreachable, unparseable, or no installer is attached
+    /// (e.g. a release that only ships the Linux tarball).</summary>
+    public static async Task<UpdateInfo?> CheckGitHubAsync()
     {
         try
         {
             var json = await Http.GetStringAsync(GitHubLatestApi);
             using var doc = JsonDocument.Parse(json);
             var tag = doc.RootElement.GetProperty("tag_name").GetString() ?? "";
-            return Version.TryParse(tag.TrimStart('v', 'V'), out var v) ? Normalize(v) : null;
+            if (!Version.TryParse(tag.TrimStart('v', 'V'), out var v)) return null;
+
+            string? downloadUrl = null, sha256Url = null;
+            foreach (var asset in doc.RootElement.GetProperty("assets").EnumerateArray())
+            {
+                var name = asset.GetProperty("name").GetString() ?? "";
+                var url = asset.GetProperty("browser_download_url").GetString();
+                if (name.Equals(SetupName, StringComparison.OrdinalIgnoreCase)) downloadUrl = url;
+                else if (name.Equals(SetupName + ".sha256", StringComparison.OrdinalIgnoreCase)) sha256Url = url;
+            }
+            return new UpdateInfo(Normalize(v), SetupPath: null, downloadUrl, sha256Url);
         }
         catch
         {
@@ -107,22 +122,36 @@ public static class UpdateChecker
     }
 
     /// <summary>
-    /// Copy the setup out of OneDrive into %TEMP% (forces hydration of cloud-only files,
-    /// and survives OneDrive sync touching the original), then return the staged path.
-    /// When a sibling "EQBuddySetup.exe.sha256" exists (published by the release script),
-    /// the staged copy must match it — a corrupted or tampered installer is never run.
+    /// Stage the installer into %TEMP% and return its path, ready to run. From OneDrive
+    /// this is a local copy (forces hydration of cloud-only files, and survives OneDrive
+    /// sync touching the original); from GitHub it's an HTTP download of the release
+    /// asset. Either way, when a sibling "EQBuddySetup.exe.sha256" is published alongside
+    /// it, the staged copy must match it — a corrupted or tampered installer is never run.
     /// </summary>
-    public static string StageForInstall(UpdateInfo info)
+    public static async Task<string> StageForInstall(UpdateInfo info)
     {
-        if (info.SetupPath is null)
-            throw new InvalidOperationException("Web updates are installed via the browser, not staged.");
         var staged = Path.Combine(Path.GetTempPath(), SetupName);
-        File.Copy(info.SetupPath, staged, overwrite: true);
+        string? expected;
 
-        var shaFile = info.SetupPath + ".sha256";
-        if (File.Exists(shaFile))
+        if (info.SetupPath is { } localPath)
         {
-            var expected = File.ReadAllText(shaFile).Trim();
+            File.Copy(localPath, staged, overwrite: true);
+            var shaFile = localPath + ".sha256";
+            expected = File.Exists(shaFile) ? File.ReadAllText(shaFile).Trim() : null;
+        }
+        else if (info.DownloadUrl is { } url)
+        {
+            var bytes = await Http.GetByteArrayAsync(url);
+            await File.WriteAllBytesAsync(staged, bytes);
+            expected = info.Sha256Url is { } shaUrl ? (await Http.GetStringAsync(shaUrl)).Trim() : null;
+        }
+        else
+        {
+            throw new InvalidOperationException("Nothing to stage: no local setup path or download URL.");
+        }
+
+        if (expected is not null)
+        {
             using var stream = File.OpenRead(staged);
             var actual = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(stream));
             if (!actual.Equals(expected, StringComparison.OrdinalIgnoreCase))

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -864,8 +864,7 @@ public partial class MainWindow : Window
             // fall back to the GitHub Releases feed for public installs.
             var folder = UpdateChecker.FindUpdateFolder(_settings.UpdateFolder);
             var info = folder is null ? null : UpdateChecker.Check(folder);
-            if (info is null && await UpdateChecker.CheckGitHubAsync() is { } webLatest)
-                info = new UpdateInfo(webLatest, SetupPath: null);
+            info ??= await UpdateChecker.CheckGitHubAsync();
 
             Dispatcher.Invoke(() =>
             {
@@ -873,7 +872,7 @@ public partial class MainWindow : Window
                 if (info is not null && UpdateChecker.IsNewer(info))
                 {
                     _pendingUpdate = info;
-                    UpdateText.Text = info.SetupPath is not null
+                    UpdateText.Text = info.SetupPath is not null || info.DownloadUrl is not null
                         ? $"Update v{info.Latest} is ready — click here to install."
                         : $"Update v{info.Latest} is available — click to open the download page.";
                     UpdateBanner.Visibility = Visibility.Visible;
@@ -896,9 +895,10 @@ public partial class MainWindow : Window
         e.Handled = true;
         if (_pendingUpdate is not { } info || _installingUpdate) return;
 
-        if (info.SetupPath is null)
+        if (info.SetupPath is null && info.DownloadUrl is null)
         {
-            // Web update: send the user to the GitHub release page.
+            // No installer to fetch (e.g. a release that shipped without one) — send the
+            // user to the GitHub release page instead.
             try
             {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(
@@ -916,12 +916,14 @@ public partial class MainWindow : Window
         }
 
         _installingUpdate = true;
-        UpdateText.Text = "Installing update — EQBuddy will restart itself…";
-        Task.Run(() =>
+        UpdateText.Text = info.DownloadUrl is not null
+            ? "Downloading update — EQBuddy will restart itself…"
+            : "Installing update — EQBuddy will restart itself…";
+        Task.Run(async () =>
         {
             try
             {
-                var staged = UpdateChecker.StageForInstall(info);
+                var staged = await UpdateChecker.StageForInstall(info);
                 System.Diagnostics.Process.Start(staged, "/SILENT");
                 Dispatcher.Invoke(() => Application.Current.Shutdown());
             }

--- a/tests/EQBuddy.Tests/UpdateCheckerTests.cs
+++ b/tests/EQBuddy.Tests/UpdateCheckerTests.cs
@@ -15,30 +15,109 @@ public class UpdateCheckerTests : IDisposable
     private UpdateInfo Info => new(new Version(9, 9, 9), SetupPath);
 
     [Fact]
-    public void StagesWithoutHashFile()
+    public async Task StagesWithoutHashFile()
     {
-        var staged = UpdateChecker.StageForInstall(Info);
+        var staged = await UpdateChecker.StageForInstall(Info);
         Assert.True(File.Exists(staged));
     }
 
     [Fact]
-    public void StagesWhenHashMatches()
+    public async Task StagesWhenHashMatches()
     {
         using var s = File.OpenRead(SetupPath);
         File.WriteAllText(SetupPath + ".sha256", Convert.ToHexString(SHA256.HashData(s)));
-        var staged = UpdateChecker.StageForInstall(Info);
+        var staged = await UpdateChecker.StageForInstall(Info);
         Assert.True(File.Exists(staged));
     }
 
     [Fact]
-    public void RefusesWhenHashMismatches()
+    public async Task RefusesWhenHashMismatches()
     {
         File.WriteAllText(SetupPath + ".sha256", new string('A', 64));
-        Assert.Throws<InvalidOperationException>(() => UpdateChecker.StageForInstall(Info));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => UpdateChecker.StageForInstall(Info));
     }
 
     [Fact]
-    public void WebUpdateCannotBeStaged() =>
-        Assert.Throws<InvalidOperationException>(() =>
+    public async Task NothingToStageCannotBeStaged() =>
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
             UpdateChecker.StageForInstall(new UpdateInfo(new Version(9, 9, 9), null)));
+
+    [Fact]
+    public async Task DownloadsAndStagesFromGitHub()
+    {
+        var bytes = new byte[] { 9, 8, 7, 6, 5 };
+        var hash = Convert.ToHexString(SHA256.HashData(bytes));
+        using var server = new StubAssetServer(bytes, hash);
+
+        var info = new UpdateInfo(new Version(9, 9, 9), SetupPath: null, server.SetupUrl, server.Sha256Url);
+        var staged = await UpdateChecker.StageForInstall(info);
+
+        Assert.Equal(bytes, await File.ReadAllBytesAsync(staged));
+    }
+
+    [Fact]
+    public async Task RefusesWhenDownloadedHashMismatches()
+    {
+        var bytes = new byte[] { 9, 8, 7, 6, 5 };
+        using var server = new StubAssetServer(bytes, new string('A', 64));
+
+        var info = new UpdateInfo(new Version(9, 9, 9), SetupPath: null, server.SetupUrl, server.Sha256Url);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => UpdateChecker.StageForInstall(info));
+    }
+
+    /// <summary>Minimal local HTTP server standing in for a GitHub release's download
+    /// assets, so StageForInstall's HTTP path gets real network round-trips in tests
+    /// rather than only the local-file (OneDrive) path.</summary>
+    private sealed class StubAssetServer : IDisposable
+    {
+        private readonly System.Net.HttpListener _listener = new();
+        private readonly CancellationTokenSource _cts = new();
+
+        public string SetupUrl { get; }
+        public string Sha256Url { get; }
+
+        public StubAssetServer(byte[] setupBytes, string sha256Hex)
+        {
+            var port = GetFreePort();
+            var prefix = $"http://127.0.0.1:{port}/";
+            _listener.Prefixes.Add(prefix);
+            _listener.Start();
+            SetupUrl = prefix + "EQBuddySetup.exe";
+            Sha256Url = prefix + "EQBuddySetup.exe.sha256";
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    while (!_cts.IsCancellationRequested)
+                    {
+                        var ctx = await _listener.GetContextAsync();
+                        var body = ctx.Request.Url!.AbsolutePath.EndsWith(".sha256")
+                            ? System.Text.Encoding.ASCII.GetBytes(sha256Hex)
+                            : setupBytes;
+                        ctx.Response.ContentLength64 = body.Length;
+                        await ctx.Response.OutputStream.WriteAsync(body);
+                        ctx.Response.OutputStream.Close();
+                    }
+                }
+                catch (Exception) { /* listener stopped */ }
+            }, _cts.Token);
+        }
+
+        private static int GetFreePort()
+        {
+            using var socket = new System.Net.Sockets.Socket(
+                System.Net.Sockets.AddressFamily.InterNetwork,
+                System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
+            socket.Bind(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 0));
+            return ((System.Net.IPEndPoint)socket.LocalEndPoint!).Port;
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            _listener.Close();
+        }
+    }
 }


### PR DESCRIPTION
Public (non-OneDrive) installs only ever got a link to the release page and had to download EQBuddySetup.exe by hand. The release already publishes that installer plus a .sha256 alongside it, so extend UpdateChecker to fetch the release asset URLs, download and verify the installer the same way the OneDrive path already does, then run it silently and restart — no browser trip required. Falls back to opening the release page when no installer asset is attached, or on Linux where there's nothing to silently install.