### PR TITLE
Add a temporary Party DPS window, and fix a startup race that could crash on a second launch

### DIFF
--- a/src/EQBuddy.Core/LogWatcher.cs
+++ b/src/EQBuddy.Core/LogWatcher.cs
@@ -45,6 +45,13 @@ public sealed class LogWatcher : IDisposable
     /// pipeline (its entries are short-lived, so replay mostly proves them expired).</summary>
     public MezTracker? Mez { get; set; }
 
+    /// <summary>Optional fourth consumer: the experimental party-DPS tracker (temporary —
+    /// see PartyDpsTracker for why it's kept separate from SessionStats). Unlike the other
+    /// three consumers, it deliberately does NOT see the startup replay (below) — its whole
+    /// point is "what's happening right now," and a replay of the day's whole log would
+    /// dump hours of stale damage into it in one burst.</summary>
+    public PartyDpsTracker? PartyDps { get; set; }
+
     public LogWatcher(SessionStats stats)
     {
         _stats = stats;
@@ -180,6 +187,7 @@ public sealed class LogWatcher : IDisposable
                             _stats.Apply(evt);
                             Spawns?.Apply(evt);
                             Mez?.Apply(evt);
+                            if (InitialIngestDone) PartyDps?.Apply(evt);
                         }
                         // Every line, parsed or not: a Text watch rule matches the line's
                         // words, not whatever event we did or didn't make of it.

--- a/src/EQBuddy.Core/PartyDpsTracker.cs
+++ b/src/EQBuddy.Core/PartyDpsTracker.cs
@@ -9,7 +9,8 @@ namespace EQBuddy.Core;
 public enum AttackerCategory { Player, Pet, Enemy }
 
 /// <summary>Snapshot of party DPS for the current pull.</summary>
-/// <param name="Active">True while the 10-second idle gap hasn't elapsed since the last hit.</param>
+/// <param name="Active">True while the idle gap (PartyDpsTracker.PullGap) hasn't elapsed
+/// since the last hit.</param>
 /// <param name="DurationSeconds">Seconds since the pull's first hit (at least 1).</param>
 /// <param name="TotalDamage">Sum of every row's <see cref="SourceDamage.Total"/>.</param>
 /// <param name="Rows">Per-attacker totals, sorted by damage descending.</param>
@@ -42,7 +43,13 @@ public record PartyDpsSnapshot(bool Active, double DurationSeconds, long TotalDa
 /// </summary>
 public sealed class PartyDpsTracker
 {
-    private static readonly TimeSpan PullGap = TimeSpan.FromSeconds(10);
+    // Short on purpose (was 10s): every attacker sharing this ONE global clock means a
+    // groupmate's charmed pet fighting on its own schedule could keep a fight alive
+    // indefinitely, and a narrower window also shrinks the odds that a charmed pet and a
+    // same-named hostile mob are both mid-swing in the same pull, which is what actually
+    // causes their damage to merge into one row (categorization only sorts a name into a
+    // section — it can't split one name's row apart). Field report 2026-08-05.
+    private static readonly TimeSpan PullGap = TimeSpan.FromSeconds(3);
 
     private sealed class Row
     {
@@ -163,8 +170,14 @@ public sealed class PartyDpsTracker
         if (hasArticle) _hasArticle.Add(key);
         // Only a generic-named attacker fighting a confirmed enemy is pet evidence — a real
         // player fighting alongside you is, by definition, also attacking things you've
-        // confirmed hostile, and must not be swept into this bucket too.
-        if (hasArticle && _confirmedEnemies.Contains(normalizedTarget)) _confirmedPets.Add(key);
+        // confirmed hostile, and must not be swept into this bucket too. Also gated on NOT
+        // already being independently confirmed hostile itself: hostile mobs occasionally
+        // clip each other in the log (fear/confusion effects, AI pathing bumping into a
+        // neighbor) without either one being charmed — that's noise, not a charm tell, and
+        // must never override direct evidence (field report 2026-08-06: several named
+        // "Innoruuk" adds swinging at their own leader all read as pets).
+        if (hasArticle && !_confirmedEnemies.Contains(key) && _confirmedEnemies.Contains(normalizedTarget))
+            _confirmedPets.Add(key);
         if (_confirmedEnemies.Contains(key)) _attackedByConfirmedEnemy.Add(normalizedTarget);
     }
 
@@ -186,8 +199,12 @@ public sealed class PartyDpsTracker
         {
             var key = LogParser.Normalize(name);
             if (string.Equals(key, "You", StringComparison.OrdinalIgnoreCase)) return AttackerCategory.Player;
-            if (_confirmedPets.Contains(key)) return AttackerCategory.Pet;
+            // Direct evidence (it hit you, or you hit it) always wins over the pet-detection
+            // rule, checked first here because the two can be added in either order — e.g. a
+            // hostile add clips another hostile early in the fight (flagging it as a
+            // "pet") and only later hits the player directly (confirming it hostile).
             if (_confirmedEnemies.Contains(key)) return AttackerCategory.Enemy;
+            if (_confirmedPets.Contains(key)) return AttackerCategory.Pet;
             // A known hostile chose to attack this name — likely a person, unless it's
             // ALSO a generic creature name, in which case it reads more like a pet caught
             // in the crossfire than a player.

--- a/src/EQBuddy.Core/PartyDpsTracker.cs
+++ b/src/EQBuddy.Core/PartyDpsTracker.cs
@@ -1,5 +1,13 @@
 namespace EQBuddy.Core;
 
+/// <summary>Best-effort classification of an attacker name — see PartyDpsTracker's
+/// CategoryOf for the heuristic. Not a verified roster; a same-named collision (a charmed
+/// pet sharing a hostile mob's exact name) can still misclassify, and an attacker with no
+/// positive evidence either way defaults to Enemy (most named EQ raid/group mobs — "Elite
+/// dragoon", "Knight of Innoruuk" — carry no leading article, so "no article" alone isn't a
+/// safe signal for Player; unrecognized names are far more often mobs than people).</summary>
+public enum AttackerCategory { Player, Pet, Enemy }
+
 /// <summary>Snapshot of party DPS for the current pull.</summary>
 /// <param name="Active">True while the 10-second idle gap hasn't elapsed since the last hit.</param>
 /// <param name="DurationSeconds">Seconds since the pull's first hit (at least 1).</param>
@@ -18,8 +26,12 @@ public record PartyDpsSnapshot(bool Active, double DurationSeconds, long TotalDa
 /// attacker, whether it's landing hits on you or a groupmate. Treat this as "nearby damage,"
 /// not a roster feature.
 ///
-/// A charmed pet is not special-cased (that state lives inside SessionStats's own charm
-/// tracking) — it simply shows up under its own creature name like any other attacker.
+/// Your own client's charm state (SessionStats's own tracking) isn't consulted here — a
+/// GROUPMATE's charmed pet is invisible to that anyway. Instead, <see cref="CategoryOf"/>
+/// gives a best-effort Player/Pet/Enemy grouping from log evidence alone (field report
+/// 2026-08-05: a global pull clock that never idled out because a groupmate's charmed pet
+/// kept fighting on its own schedule) — see the AttackerCategory doc and the private fields
+/// below for exactly what evidence drives it.
 ///
 /// Pull boundary: any hit more than <see cref="PullGap"/> after the previous one starts a
 /// fresh pull, clearing the live per-pull rows — the same idle-gap rule EncounterGrouping
@@ -59,6 +71,32 @@ public sealed class PartyDpsTracker
     private double _totalsActiveSeconds;
     private DateTime? _totalsSegmentStart;
 
+    // Best-effort Player/Pet/Enemy classification (see CategoryOf).
+    //
+    // _hasArticle: EQ creature names conventionally carry a leading article ("a shadowed
+    // man", "an orc pawn") that real player names never do — captured from the RAW attacker
+    // text before Normalize() strips it. Many named mobs (raid adds, unique NPCs) DON'T use
+    // an article though, so this alone only ever helps confirm "generic creature," never
+    // "definitely a player" — see CategoryOf's default.
+    //
+    // _confirmedEnemies: unambiguous hostiles only — something that hit you, or something
+    // you hit. Never populated from a Third* event's target, since that could just as
+    // easily be a groupmate.
+    //
+    // _confirmedPets: the field-reported tell — an article-style name caught attacking
+    // something already in _confirmedEnemies is a charmed pet, not a second hostile mob
+    // (real mobs essentially never fight each other). Gated on the attacker ALSO being
+    // article-style, or a real player fighting alongside you (who is, by definition,
+    // attacking the same confirmed enemies you are) would land here too.
+    //
+    // _attackedByConfirmedEnemy: a weak positive signal for Player — something a known
+    // hostile chose to attack that ISN'T itself article-style is very likely a person (mobs
+    // predominantly aggro onto players, not other mobs' pets).
+    private readonly HashSet<string> _hasArticle = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _confirmedEnemies = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _confirmedPets = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _attackedByConfirmedEnemy = new(StringComparer.OrdinalIgnoreCase);
+
     // LogWatcher calls Apply() from its background polling timer/thread, while the window
     // reads Snapshot()/TotalsSnapshot() from its own UI-thread DispatcherTimer — same
     // cross-thread shape SessionStats and MezTracker already guard with a lock.
@@ -71,15 +109,21 @@ public sealed class PartyDpsTracker
             switch (evt)
             {
                 case DamageDealtEvent d:
+                    // You hit it, so it's unambiguously hostile — feeds the pet-detection
+                    // rule below, not just display.
+                    _confirmedEnemies.Add(LogParser.Normalize(d.Target));
                     Add("You", d.Time, d.Amount, d.Critical);
                     break;
                 case ThirdMeleeEvent tm:
+                    NoteThirdPartyAttacker(tm.Attacker, tm.Target);
                     Add(tm.Attacker, tm.Time, tm.Amount, tm.Critical);
                     break;
                 case ThirdDotEvent td:
+                    NoteThirdPartyAttacker(td.Caster, td.Target);
                     Add(td.Caster, td.Time, td.Amount, td.Critical);
                     break;
                 case ThirdSchoolEvent ts:
+                    NoteThirdPartyAttacker(ts.Attacker, ts.Target);
                     Add(ts.Attacker, ts.Time, ts.Amount, ts.Critical);
                     break;
                 case ThirdMissEvent tmiss:
@@ -101,9 +145,58 @@ public sealed class PartyDpsTracker
                 // source that's non-melee with no Ability set; every other source
                 // (melee, or spell/DoT with a known caster) keeps one or the other.
                 case DamageTakenEvent { Self: false } dt when dt.Melee || dt.Ability.Length > 0:
+                    // It hit you, so it's unambiguously hostile.
+                    _confirmedEnemies.Add(dt.Attacker); // already Normalize()-d by LogParser
                     Add(dt.Attacker, dt.Time, dt.Amount, false);
                     break;
             }
+        }
+    }
+
+    /// <summary>Records the leading-article tell and checks the pet-detection and
+    /// attacked-by-enemy rules for a Third* attacker. Must run before Add() normalizes the
+    /// name away.</summary>
+    private void NoteThirdPartyAttacker(string rawAttacker, string normalizedTarget)
+    {
+        var key = LogParser.Normalize(rawAttacker);
+        var hasArticle = StartsWithArticle(rawAttacker);
+        if (hasArticle) _hasArticle.Add(key);
+        // Only a generic-named attacker fighting a confirmed enemy is pet evidence — a real
+        // player fighting alongside you is, by definition, also attacking things you've
+        // confirmed hostile, and must not be swept into this bucket too.
+        if (hasArticle && _confirmedEnemies.Contains(normalizedTarget)) _confirmedPets.Add(key);
+        if (_confirmedEnemies.Contains(key)) _attackedByConfirmedEnemy.Add(normalizedTarget);
+    }
+
+    private static bool StartsWithArticle(string raw)
+    {
+        var t = raw.TrimStart();
+        foreach (var article in (string[])["a ", "an ", "the "])
+            if (t.Length > article.Length && t.StartsWith(article, StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
+    }
+
+    /// <summary>Best-effort Player/Pet/Enemy classification for the window's grouped
+    /// display — see the class remarks on <see cref="_hasArticle"/> and friends for the
+    /// heuristic. Not a verified roster.</summary>
+    public AttackerCategory CategoryOf(string name)
+    {
+        lock (_lock)
+        {
+            var key = LogParser.Normalize(name);
+            if (string.Equals(key, "You", StringComparison.OrdinalIgnoreCase)) return AttackerCategory.Player;
+            if (_confirmedPets.Contains(key)) return AttackerCategory.Pet;
+            if (_confirmedEnemies.Contains(key)) return AttackerCategory.Enemy;
+            // A known hostile chose to attack this name — likely a person, unless it's
+            // ALSO a generic creature name, in which case it reads more like a pet caught
+            // in the crossfire than a player.
+            if (_attackedByConfirmedEnemy.Contains(key))
+                return _hasArticle.Contains(key) ? AttackerCategory.Pet : AttackerCategory.Player;
+            // No positive evidence either way: default to Enemy. Most unrecognized names in
+            // group/raid combat are mobs, named or not (see AttackerCategory's remarks) —
+            // "no article" alone isn't reliable enough to default to Player.
+            return AttackerCategory.Enemy;
         }
     }
 

--- a/src/EQBuddy.Core/PartyDpsTracker.cs
+++ b/src/EQBuddy.Core/PartyDpsTracker.cs
@@ -1,0 +1,208 @@
+namespace EQBuddy.Core;
+
+/// <summary>Snapshot of party DPS for the current pull.</summary>
+/// <param name="Active">True while the 10-second idle gap hasn't elapsed since the last hit.</param>
+/// <param name="DurationSeconds">Seconds since the pull's first hit (at least 1).</param>
+/// <param name="TotalDamage">Sum of every row's <see cref="SourceDamage.Total"/>.</param>
+/// <param name="Rows">Per-attacker totals, sorted by damage descending.</param>
+public record PartyDpsSnapshot(bool Active, double DurationSeconds, long TotalDamage,
+    IReadOnlyList<SourceDamage> Rows);
+
+/// <summary>
+/// Best-effort live DPS by attacker for the current pull, kept deliberately separate from
+/// <see cref="SessionStats"/>. Tracks damage dealt by anyone visible in your own log — your
+/// own hits, "third-party" lines (&lt;attacker&gt; hits &lt;target&gt; for N...) for whoever else is
+/// fighting near you, AND whatever's hitting you directly — there's no group/raid roster
+/// anywhere in this codebase, so every visible attacker is included, not just verified group
+/// members. This is also how a mob's own dps ends up in the list: it's just another
+/// attacker, whether it's landing hits on you or a groupmate. Treat this as "nearby damage,"
+/// not a roster feature.
+///
+/// A charmed pet is not special-cased (that state lives inside SessionStats's own charm
+/// tracking) — it simply shows up under its own creature name like any other attacker.
+///
+/// Pull boundary: any hit more than <see cref="PullGap"/> after the previous one starts a
+/// fresh pull, clearing the live per-pull rows — the same idle-gap rule EncounterGrouping
+/// uses to split pulls (EncounterTypes.cs), applied locally so this tracker doesn't depend
+/// on it. Alongside that, a second set of totals accumulates across pulls (never auto-reset,
+/// only <see cref="ResetTotals"/>) for whichever names the window's user has chosen to
+/// track — see <see cref="TotalsSnapshot"/>.
+/// </summary>
+public sealed class PartyDpsTracker
+{
+    private static readonly TimeSpan PullGap = TimeSpan.FromSeconds(10);
+
+    private sealed class Row
+    {
+        public int Hits;
+        public long Total;
+        public int Crits;
+        public DateTime First;
+        public DateTime Last;
+    }
+
+    private readonly Dictionary<string, Row> _rows = new(StringComparer.OrdinalIgnoreCase);
+    private DateTime? _pullStart;
+    private DateTime? _lastActivity;
+
+    // Running totals: cumulative damage since the tracker was created or ResetTotals() was
+    // last called. Never cleared by the pull-gap Reset().
+    private readonly Dictionary<string, Row> _totals = new(StringComparer.OrdinalIgnoreCase);
+
+    // Seconds actually spent fighting, summed across every pull since the last
+    // ResetTotals() — NOT wall-clock time since then, which would keep diluting the dps
+    // number every second you're standing around between pulls. Closed-out pulls land here
+    // when Reset() fires; TotalsSnapshot adds whatever's accrued in _totalsSegmentStart (the
+    // still-open pull) on top. Tracked separately from _pullStart so that clicking Reset
+    // mid-fight doesn't leave the pre-reset portion of the current pull still counting
+    // toward the new denominator.
+    private double _totalsActiveSeconds;
+    private DateTime? _totalsSegmentStart;
+
+    // LogWatcher calls Apply() from its background polling timer/thread, while the window
+    // reads Snapshot()/TotalsSnapshot() from its own UI-thread DispatcherTimer — same
+    // cross-thread shape SessionStats and MezTracker already guard with a lock.
+    private readonly object _lock = new();
+
+    public void Apply(GameEvent evt)
+    {
+        lock (_lock)
+        {
+            switch (evt)
+            {
+                case DamageDealtEvent d:
+                    Add("You", d.Time, d.Amount, d.Critical);
+                    break;
+                case ThirdMeleeEvent tm:
+                    Add(tm.Attacker, tm.Time, tm.Amount, tm.Critical);
+                    break;
+                case ThirdDotEvent td:
+                    Add(td.Caster, td.Time, td.Amount, td.Critical);
+                    break;
+                case ThirdSchoolEvent ts:
+                    Add(ts.Attacker, ts.Time, ts.Amount, ts.Critical);
+                    break;
+                case ThirdMissEvent tmiss:
+                    Touch(tmiss.Time);
+                    break;
+                // A mob hitting a groupmate is a Third* event above, but EQ logs a mob
+                // hitting YOU specifically as a completely different line/event ("Orc
+                // centurion hits YOU for..."). Without this, the enemy's own dps would
+                // silently drop out of Current Pull the moment it's attacking you instead
+                // of someone else — exactly the gap a field report caught (2026-08-05:
+                // "mixture of me getting hit and my friend"). Self-inflicted damage (HP-cost
+                // casting, falling, drowning) isn't an attacker at all, so it's excluded.
+                //
+                // One more exclusion: LogParser's NonMeleeInRx is a catch-all for lines EQ
+                // doesn't cleanly separate attacker from effect ("YOU are burned by orc
+                // centurion's flames...") — its Attacker field is really a descriptive label,
+                // not a name (field report 2026-08-05: "Burned by a gust of wind's flames"
+                // showing up as if it were an attacker). It's the only DamageTakenEvent
+                // source that's non-melee with no Ability set; every other source
+                // (melee, or spell/DoT with a known caster) keeps one or the other.
+                case DamageTakenEvent { Self: false } dt when dt.Melee || dt.Ability.Length > 0:
+                    Add(dt.Attacker, dt.Time, dt.Amount, false);
+                    break;
+            }
+        }
+    }
+
+    private void Touch(DateTime t)
+    {
+        if (_lastActivity is { } last && t - last > PullGap)
+            Reset();
+        _pullStart ??= t;
+        _totalsSegmentStart ??= t;
+        _lastActivity = t;
+    }
+
+    private void Add(string name, DateTime t, int amount, bool crit)
+    {
+        Touch(t);
+        var key = LogParser.Normalize(name);
+        AddTo(_rows, key, t, amount, crit);
+        AddTo(_totals, key, t, amount, crit);
+    }
+
+    private static void AddTo(Dictionary<string, Row> dict, string key, DateTime t, int amount, bool crit)
+    {
+        if (!dict.TryGetValue(key, out var row))
+            dict[key] = row = new Row { First = t };
+        row.Hits++;
+        row.Total += amount;
+        if (crit) row.Crits++;
+        row.Last = t;
+    }
+
+    private void Reset()
+    {
+        // The pull that's ending banks its combat-active seconds before its rows are
+        // cleared. _totalsSegmentStart is only non-null while a pull is actually open, so a
+        // Reset() triggered by a second idle Snapshot() call in the same quiet stretch
+        // (nothing new to close) is a no-op here.
+        if (_totalsSegmentStart is { } start && _lastActivity is { } last)
+            _totalsActiveSeconds += (last - start).TotalSeconds;
+        _rows.Clear();
+        _pullStart = null;
+        _totalsSegmentStart = null;
+    }
+
+    /// <summary>Clears the running totals (not the live per-pull view) — the window's
+    /// "Reset" button.</summary>
+    public void ResetTotals()
+    {
+        lock (_lock)
+        {
+            _totals.Clear();
+            _totalsActiveSeconds = 0;
+            // If a pull is still going, restart its segment here rather than leaving
+            // _totalsSegmentStart pointing at the pull's original (pre-reset) start —
+            // otherwise the next TotalsSnapshot would count time that happened before
+            // the reset.
+            if (_pullStart is not null) _totalsSegmentStart = _lastActivity;
+        }
+    }
+
+    public PartyDpsSnapshot Snapshot(DateTime now)
+    {
+        lock (_lock)
+        {
+            // Combat's been quiet for a full gap — the pull is over; clear stale numbers
+            // before rendering rather than waiting for the next hit to trigger Reset().
+            if (_lastActivity is { } last && now - last > PullGap)
+                Reset();
+
+            var active = _lastActivity is { } l && now - l <= PullGap;
+            var start = _pullStart ?? now;
+            var elapsed = Math.Max(1, (now - start).TotalSeconds);
+            var rows = _rows
+                .Select(kv => new SourceDamage(kv.Key, kv.Value.Hits, kv.Value.Total, kv.Value.Crits,
+                    Math.Max(1, (kv.Value.Last - kv.Value.First).TotalSeconds)))
+                .OrderByDescending(r => r.Total)
+                .ToList();
+            return new PartyDpsSnapshot(active, elapsed, rows.Sum(r => r.Total), rows);
+        }
+    }
+
+    /// <summary>Running totals for just the given roster (normalized names, case-insensitive)
+    /// — everyone else seen is still tallied internally (so checking a name later doesn't
+    /// lose what they already did) but left out of the returned rows. DurationSeconds is
+    /// combat-active time only (closed-out pulls' banked seconds plus whatever the still-open
+    /// one has racked up so far) — wall-clock time spent idle between pulls doesn't count,
+    /// so dps doesn't quietly drain away while nothing is happening.</summary>
+    public PartyDpsSnapshot TotalsSnapshot(DateTime now, IReadOnlySet<string> roster)
+    {
+        lock (_lock)
+        {
+            var ongoing = _totalsSegmentStart is { } start ? (now - start).TotalSeconds : 0;
+            var elapsed = Math.Max(1, _totalsActiveSeconds + ongoing);
+            var rows = _totals
+                .Where(kv => roster.Contains(kv.Key))
+                .Select(kv => new SourceDamage(kv.Key, kv.Value.Hits, kv.Value.Total, kv.Value.Crits,
+                    Math.Max(1, (kv.Value.Last - kv.Value.First).TotalSeconds)))
+                .OrderByDescending(r => r.Total)
+                .ToList();
+            return new PartyDpsSnapshot(true, elapsed, rows.Sum(r => r.Total), rows);
+        }
+    }
+}

--- a/src/EQBuddy/App.xaml
+++ b/src/EQBuddy/App.xaml
@@ -1,7 +1,6 @@
 <Application x:Class="EQBuddy.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/EQBuddy/App.xaml.cs
+++ b/src/EQBuddy/App.xaml.cs
@@ -85,8 +85,12 @@ public partial class App : Application
             Shutdown();
             return;
         }
-        // Applied before the StartupUri window is created (that happens after OnStartup
-        // returns), so the saved theme is already live for the very first frame.
+        // Applied before MainWindow is constructed, so the saved theme is already live for
+        // the very first frame. There's no StartupUri (App.xaml) creating that window for
+        // us — WPF queues a StartupUri window's construction independently of OnStartup, so
+        // it could still land even after the ClaimSingleInstance() bailout above, crashing
+        // on a theme that was never applied. Building it explicitly here, only on the
+        // success path, closes that race.
         try { ThemeManager.Apply(Core.AppSettings.Load()); }
         catch (Exception ex) { LogError(ex); }
         DispatcherUnhandledException += (_, args) =>
@@ -100,5 +104,7 @@ public partial class App : Application
             LogError(args.Exception);
             args.SetObserved();
         };
+        MainWindow = new MainWindow();
+        MainWindow.Show();
     }
 }

--- a/src/EQBuddy/MainWindow.xaml
+++ b/src/EQBuddy/MainWindow.xaml
@@ -21,6 +21,7 @@
                 <MenuItem Header="Quick tutorial…" Click="OnTutorial"/>
                 <MenuItem Header="Drop camp marker" Click="OnCampMarker"/>
                 <MenuItem Header="Session history…" Click="OnHistory"/>
+                <MenuItem Header="Party DPS…" Click="OnPartyDps"/>
                 <MenuItem Header="Spawn timers…" Click="OnSpawnsWindow"/>
                 <MenuItem x:Name="TrackSpawnsItem" Header="Track spawns (named respawn timers)"
                           IsCheckable="True" Click="OnTrackSpawns"/>

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -48,6 +48,7 @@ public partial class MainWindow : Window
         _mezTracker.AttachStore(System.IO.Path.Combine(Core.AppPaths.Dir, "mez-durations.json"));
         _watcher = new LogWatcher(_stats);
         _watcher.Mez = _mezTracker;
+        _watcher.PartyDps = _partyDpsTracker;
         // Spawn timers ride the watcher's event stream — wired before the first Select so
         // the startup replay re-derives countdowns from kills already in the log.
         var spawnCatalog = SpawnCatalog.LoadEmbedded();
@@ -380,6 +381,8 @@ public partial class MainWindow : Window
     private SpawnChipsWindow? _chipsWindow;
     private MezChipsWindow? _mezWindow;
     private readonly MezTracker _mezTracker = new();
+    private readonly PartyDpsTracker _partyDpsTracker = new();
+    private PartyDpsWindow? _partyDpsWindow;
 
     private readonly EqlWikiItemService _wikiItems =
         new(System.IO.Path.Combine(Core.AppPaths.Dir, "wiki-cache", "items"));
@@ -1270,6 +1273,17 @@ public partial class MainWindow : Window
         }
         _historyWindow = new HistoryWindow(_repo);
         _historyWindow.Show();
+    }
+
+    private void OnPartyDps(object sender, RoutedEventArgs e)
+    {
+        if (_partyDpsWindow is { IsLoaded: true })
+        {
+            _partyDpsWindow.Activate();
+            return;
+        }
+        _partyDpsWindow = new PartyDpsWindow(this, _partyDpsTracker);
+        _partyDpsWindow.Show();
     }
 
     private void DropCampMarker()

--- a/src/EQBuddy/PartyDpsWindow.xaml
+++ b/src/EQBuddy/PartyDpsWindow.xaml
@@ -1,0 +1,77 @@
+<Window x:Class="EQBuddy.PartyDpsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="EQBuddy Party DPS" SizeToContent="WidthAndHeight"
+        WindowStyle="None" AllowsTransparency="True" Background="Transparent"
+        Topmost="True" ShowInTaskbar="False" ResizeMode="NoResize"
+        WindowStartupLocation="Manual">
+    <!-- Same Mini/Normal split as the main widget: SizeToContent="WidthAndHeight" lets the
+         window shrink to fit whichever root is visible, rather than a fixed width. -->
+    <Border x:Name="RootBorderElement" Background="{DynamicResource BgBrush}" CornerRadius="10"
+            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+            MouseLeftButtonDown="OnDrag">
+      <StackPanel Margin="16,14,16,14">
+
+        <!-- ============ MINI MODE ============ -->
+        <Grid x:Name="MiniRoot" Visibility="Collapsed">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <!-- One attacker per line, always — a wrap panel packed short entries onto the
+                 same line, which read as one combined chip rather than two people. Width
+                 gives BreakdownRows.Row's proportional bar something concrete to size
+                 against (same reason NormalRoot below has a fixed Width). -->
+            <StackPanel x:Name="MiniChips" Grid.Column="0" Width="200" VerticalAlignment="Top"/>
+            <Button Grid.Column="1" Style="{StaticResource IconButton}" Content="&#x2922;"
+                    ToolTip="Expand (or double-click)" Click="OnRestore" Margin="8,0,0,0"
+                    VerticalAlignment="Top"/>
+            <Button Grid.Column="2" Style="{StaticResource IconButton}" Content="&#x2715;"
+                    ToolTip="Close" Click="OnClose" VerticalAlignment="Top"/>
+        </Grid>
+
+        <!-- ============ FULL MODE ============ -->
+        <StackPanel x:Name="NormalRoot" Width="380">
+
+            <Grid x:Name="TitleRow" Margin="0,0,0,4">
+                <TextBlock x:Name="TitleText" Text="Party DPS" FontWeight="Bold" FontSize="14"
+                           Foreground="{DynamicResource AccentBrush}"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource IconButton}" Content="&#x2013;"
+                            ToolTip="Minimize to dashboard (dps only)" Click="OnMinimize"/>
+                    <Button Style="{StaticResource IconButton}" Content="&#x2715;"
+                            ToolTip="Close" Click="OnClose"/>
+                </StackPanel>
+            </Grid>
+
+            <ScrollViewer x:Name="BodyScroll" VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled" PanningMode="VerticalOnly">
+                <StackPanel x:Name="Body">
+                    <TextBlock TextWrapping="Wrap" FontSize="10" Opacity="0.65" Margin="0,0,0,8"
+                               Text="Best-effort: shows every attacker visible in your own log, not a verified group roster."/>
+
+                    <Grid Margin="0,0,0,0">
+                        <TextBlock Text="Current pull" FontSize="11" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
+                        <TextBlock Text="Click or right-click a name to track it below"
+                                   FontSize="10" Opacity="0.6" HorizontalAlignment="Right"/>
+                    </Grid>
+                    <TextBlock x:Name="PullSummaryText" FontSize="11" Opacity="0.8" Margin="0,1,0,3"/>
+                    <ItemsControl x:Name="PullRowsList" Margin="0,0,0,10"/>
+
+                    <Grid Margin="0,0,0,2">
+                        <TextBlock Text="Running totals" FontSize="11" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
+                        <Button Content="Reset" Style="{StaticResource IconButton}" FontSize="11"
+                                HorizontalAlignment="Right" Click="OnResetTotals"
+                                ToolTip="Clear the running totals (the current-pull view above is unaffected)"/>
+                    </Grid>
+                    <TextBlock x:Name="TotalsSummaryText" FontSize="11" Opacity="0.8" Margin="0,1,0,3"/>
+                    <ItemsControl x:Name="TotalsRowsList"/>
+                </StackPanel>
+            </ScrollViewer>
+        </StackPanel>
+      </StackPanel>
+    </Border>
+</Window>

--- a/src/EQBuddy/PartyDpsWindow.xaml.cs
+++ b/src/EQBuddy/PartyDpsWindow.xaml.cs
@@ -1,0 +1,190 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
+using EQBuddy.Core;
+using EQBuddy.UI.Shared;
+
+namespace EQBuddy;
+
+/// <summary>
+/// Live per-attacker breakdown for whatever pull is currently in progress, plus running
+/// totals for a user-picked roster that survive across pulls until Reset is clicked. Click
+/// or right-click a name in the current-pull list to track/untrack it. Mini/Normal split
+/// mirrors MainWindow's own dashboard-minimize feature (same icons, same
+/// SizeToContent="WidthAndHeight" shrink-to-fit behavior). Fed by
+/// <see cref="PartyDpsTracker"/> — own timer, own window, no changes to SessionStats or the
+/// History pipeline. See PartyDpsTracker for why "party" here means "everyone visible in
+/// your log," not a verified group roster.
+/// </summary>
+public partial class PartyDpsWindow : Window
+{
+    private readonly PartyDpsTracker _tracker;
+    private readonly AppSettings _settings;
+    private readonly DispatcherTimer _tick;
+    private readonly HashSet<string> _tracked = new(StringComparer.OrdinalIgnoreCase);
+    private bool _mini;
+
+    public PartyDpsWindow(MainWindow main, PartyDpsTracker tracker)
+    {
+        InitializeComponent();
+        _tracker = tracker;
+        _settings = main.Settings;
+        // Running totals are scoped to "since this window has been open" — the tracker
+        // itself lives for the whole app session (and gets fed the full startup replay of
+        // today's log), so without this a first open could show totals inflated by
+        // everything that happened before you ever looked.
+        _tracker.ResetTotals();
+
+        MaxHeight = SystemParameters.WorkArea.Height - 40;
+        BodyScroll.MaxHeight = SystemParameters.WorkArea.Height - 140;
+        // ActualWidth isn't known until after the first layout pass (SizeToContent means
+        // there's no fixed Width to read at construction time), so position once loaded.
+        Loaded += (_, _) => PositionNextTo(main);
+
+        _tick = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _tick.Tick += (_, _) => Refresh();
+        _tick.Start();
+        Refresh();
+
+        Closed += (_, _) => _tick.Stop();
+    }
+
+    private void Refresh()
+    {
+        var now = DateTime.Now;
+
+        // Matches the main widget's own background opacity (Options → widget transparency)
+        // instead of the theme's fixed panel alpha, and stays live if it's changed there
+        // while this window is open.
+        var tint = ((SolidColorBrush)FindResource("BgBrush")).Color;
+        RootBorderElement.Background = new SolidColorBrush(
+            Color.FromArgb((byte)(_settings.BackgroundOpacity * 255), tint.R, tint.G, tint.B));
+
+        var pull = _tracker.Snapshot(now);
+
+        if (_mini)
+        {
+            UpdateMiniChips(pull);
+            return;
+        }
+
+        PullSummaryText.Text = pull.Rows.Count == 0
+            ? "No combat seen yet."
+            : $"{pull.TotalDamage:N0} total dmg · {pull.TotalDamage / pull.DurationSeconds:0.#} dps · " +
+              $"{pull.DurationSeconds:0}s{(pull.Active ? "" : " (pull ended)")}";
+        FillTrackablePullRows(pull.Rows, pull.DurationSeconds);
+
+        var totals = _tracker.TotalsSnapshot(now, _tracked);
+        TotalsSummaryText.Text = _tracked.Count == 0
+            ? "Right-click (or click) a name above to start tracking it."
+            : totals.Rows.Count == 0
+                ? "Tracked, but no damage seen from them yet."
+                : $"{totals.TotalDamage:N0} total dmg · {totals.TotalDamage / totals.DurationSeconds:0.#} dps · " +
+                  $"{SpawnDurationText.Format(totals.DurationSeconds)} in combat";
+        BreakdownRows.FillAbilityRows(this, TotalsRowsList, totals.Rows, totals.DurationSeconds, "dps");
+    }
+
+    /// <summary>Top attackers as bar rows — same BreakdownRows.Row style (and same highest-
+    /// first order, since pull.Rows is already sorted by total damage) as the full view,
+    /// just condensed to a bare dps number instead of the full stat line.</summary>
+    private void UpdateMiniChips(PartyDpsSnapshot pull)
+    {
+        MiniChips.Children.Clear();
+        if (pull.Rows.Count == 0)
+        {
+            MiniChips.Children.Add(new TextBlock
+            {
+                Text = "No combat seen yet.", FontSize = 12,
+                Foreground = (Brush)FindResource("DimBrush"),
+            });
+            return;
+        }
+        var secs = Math.Max(1, pull.DurationSeconds);
+        var top = Math.Max(1, pull.Rows.Max(d => d.Total));
+        var barBrush = BreakdownRows.BarBrush(this);
+        foreach (var d in pull.Rows.Take(4))
+        {
+            var value = $"{d.Total / secs:0.#} dps";
+            MiniChips.Children.Add(BreakdownRows.Row(this, d.Name, value, (double)d.Total / top, barBrush, null));
+        }
+    }
+
+    /// <summary>Same row rendering as BreakdownRows.FillAbilityRows (total/hits/avg/rate/
+    /// crit%, share bar), built locally instead of through that shared helper so each row
+    /// can carry a track/untrack click and context menu, and a ✓ prefix once tracked.</summary>
+    private void FillTrackablePullRows(IReadOnlyList<SourceDamage> stats, double combatSeconds)
+    {
+        PullRowsList.Items.Clear();
+        if (stats.Count == 0) return;
+        var top = Math.Max(1, stats.Max(d => d.Total));
+        var secs = Math.Max(1, combatSeconds);
+        var barBrush = BreakdownRows.BarBrush(this);
+        foreach (var d in stats)
+        {
+            var tracked = _tracked.Contains(d.Name);
+            var critPart = d.Crits > 0 ? $" · {100.0 * d.Crits / Math.Max(1, d.Hits):0}% crit" : "";
+            var value = $"{d.Total:N0} · ×{d.Hits} · avg {(double)d.Total / Math.Max(1, d.Hits):0.#}" +
+                        $" · {d.Total / secs:0.#} dps{critPart}";
+            var tooltip = (tracked ? "Tracked — click to stop. " : "Click to track. ") +
+                $"dps = total ÷ {secs:0}s in combat";
+            var name = (tracked ? "✓ " : "") + d.Name;
+            var row = BreakdownRows.Row(this, name, value, (double)d.Total / top, barBrush, tooltip);
+            row.Cursor = Cursors.Hand;
+            // Stop this from bubbling to the Border's OnDrag (MouseLeftButtonDown) — otherwise
+            // a click here starts a DragMove and the click never reaches MouseLeftButtonUp below.
+            row.MouseLeftButtonDown += (_, e2) => e2.Handled = true;
+            row.MouseLeftButtonUp += (_, _) => ToggleTracked(d.Name);
+            var menu = new ContextMenu();
+            var item = new MenuItem { Header = tracked ? $"Stop tracking {d.Name}" : $"Track {d.Name}" };
+            item.Click += (_, _) => ToggleTracked(d.Name);
+            menu.Items.Add(item);
+            row.ContextMenu = menu;
+            PullRowsList.Items.Add(row);
+        }
+    }
+
+    private void ToggleTracked(string name)
+    {
+        if (!_tracked.Remove(name)) _tracked.Add(name);
+        Refresh();
+    }
+
+    /// <summary>Opens beside the main widget — to its right if there's room on the primary
+    /// work area, otherwise its left — rather than defaulting to screen-center where it'd
+    /// land nowhere near what you're actually tracking.</summary>
+    private void PositionNextTo(MainWindow main)
+    {
+        const double gap = 10;
+        var work = SystemParameters.WorkArea;
+        var rightOf = main.Left + main.ActualWidth + gap;
+        Left = rightOf + ActualWidth <= work.Right ? rightOf : Math.Max(work.Left, main.Left - ActualWidth - gap);
+        Top = main.Top;
+    }
+
+    private void SetMode(bool mini)
+    {
+        _mini = mini;
+        MiniRoot.Visibility = mini ? Visibility.Visible : Visibility.Collapsed;
+        NormalRoot.Visibility = mini ? Visibility.Collapsed : Visibility.Visible;
+        Refresh();
+    }
+
+    private void OnMinimize(object sender, RoutedEventArgs e) => SetMode(true);
+    private void OnRestore(object sender, RoutedEventArgs e) => SetMode(false);
+
+    private void OnResetTotals(object sender, RoutedEventArgs e) => _tracker.ResetTotals();
+
+    private void OnDrag(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ClickCount == 2 && _mini)
+        {
+            SetMode(false);
+            return;
+        }
+        if (e.ChangedButton == MouseButton.Left && e.OriginalSource is not TextBox) DragMove();
+    }
+
+    private void OnClose(object sender, RoutedEventArgs e) => Close();
+}

--- a/src/EQBuddy/PartyDpsWindow.xaml.cs
+++ b/src/EQBuddy/PartyDpsWindow.xaml.cs
@@ -113,7 +113,10 @@ public partial class PartyDpsWindow : Window
 
     /// <summary>Same row rendering as BreakdownRows.FillAbilityRows (total/hits/avg/rate/
     /// crit%, share bar), built locally instead of through that shared helper so each row
-    /// can carry a track/untrack click and context menu, and a ✓ prefix once tracked.</summary>
+    /// can carry a track/untrack click and context menu, and a ✓ prefix once tracked. Grouped
+    /// into Players/Pets/NPCs (PartyDpsTracker.CategoryOf's best-effort read of the log) so a
+    /// long fight against several named mobs doesn't read as one flat undifferentiated list —
+    /// field request 2026-08-05.</summary>
     private void FillTrackablePullRows(IReadOnlyList<SourceDamage> stats, double combatSeconds)
     {
         PullRowsList.Items.Clear();
@@ -121,28 +124,46 @@ public partial class PartyDpsWindow : Window
         var top = Math.Max(1, stats.Max(d => d.Total));
         var secs = Math.Max(1, combatSeconds);
         var barBrush = BreakdownRows.BarBrush(this);
-        foreach (var d in stats)
+
+        void Section(string title, AttackerCategory category)
         {
-            var tracked = _tracked.Contains(d.Name);
-            var critPart = d.Crits > 0 ? $" · {100.0 * d.Crits / Math.Max(1, d.Hits):0}% crit" : "";
-            var value = $"{d.Total:N0} · ×{d.Hits} · avg {(double)d.Total / Math.Max(1, d.Hits):0.#}" +
-                        $" · {d.Total / secs:0.#} dps{critPart}";
-            var tooltip = (tracked ? "Tracked — click to stop. " : "Click to track. ") +
-                $"dps = total ÷ {secs:0}s in combat";
-            var name = (tracked ? "✓ " : "") + d.Name;
-            var row = BreakdownRows.Row(this, name, value, (double)d.Total / top, barBrush, tooltip);
-            row.Cursor = Cursors.Hand;
-            // Stop this from bubbling to the Border's OnDrag (MouseLeftButtonDown) — otherwise
-            // a click here starts a DragMove and the click never reaches MouseLeftButtonUp below.
-            row.MouseLeftButtonDown += (_, e2) => e2.Handled = true;
-            row.MouseLeftButtonUp += (_, _) => ToggleTracked(d.Name);
-            var menu = new ContextMenu();
-            var item = new MenuItem { Header = tracked ? $"Stop tracking {d.Name}" : $"Track {d.Name}" };
-            item.Click += (_, _) => ToggleTracked(d.Name);
-            menu.Items.Add(item);
-            row.ContextMenu = menu;
-            PullRowsList.Items.Add(row);
+            // Order within a section is preserved from `stats`, which is already sorted by
+            // total damage descending — so each group stays highest-first too.
+            var rows = stats.Where(d => _tracker.CategoryOf(d.Name) == category).ToList();
+            if (rows.Count == 0) return;
+            PullRowsList.Items.Add(new TextBlock
+            {
+                Text = title, FontSize = 10, FontWeight = FontWeights.SemiBold, Opacity = 0.6,
+                Margin = new Thickness(0, 4, 0, 1),
+            });
+            foreach (var d in rows)
+            {
+                var tracked = _tracked.Contains(d.Name);
+                var critPart = d.Crits > 0 ? $" · {100.0 * d.Crits / Math.Max(1, d.Hits):0}% crit" : "";
+                var value = $"{d.Total:N0} · ×{d.Hits} · avg {(double)d.Total / Math.Max(1, d.Hits):0.#}" +
+                            $" · {d.Total / secs:0.#} dps{critPart}";
+                var tooltip = (tracked ? "Tracked — click to stop. " : "Click to track. ") +
+                    $"dps = total ÷ {secs:0}s in combat";
+                var name = (tracked ? "✓ " : "") + d.Name;
+                var row = BreakdownRows.Row(this, name, value, (double)d.Total / top, barBrush, tooltip);
+                row.Cursor = Cursors.Hand;
+                // Stop this from bubbling to the Border's OnDrag (MouseLeftButtonDown) —
+                // otherwise a click here starts a DragMove and the click never reaches
+                // MouseLeftButtonUp below.
+                row.MouseLeftButtonDown += (_, e2) => e2.Handled = true;
+                row.MouseLeftButtonUp += (_, _) => ToggleTracked(d.Name);
+                var menu = new ContextMenu();
+                var item = new MenuItem { Header = tracked ? $"Stop tracking {d.Name}" : $"Track {d.Name}" };
+                item.Click += (_, _) => ToggleTracked(d.Name);
+                menu.Items.Add(item);
+                row.ContextMenu = menu;
+                PullRowsList.Items.Add(row);
+            }
         }
+
+        Section("Players", AttackerCategory.Player);
+        Section("Pets", AttackerCategory.Pet);
+        Section("NPCs", AttackerCategory.Enemy);
     }
 
     private void ToggleTracked(string name)

--- a/tests/EQBuddy.Tests/PartyDpsTrackerTests.cs
+++ b/tests/EQBuddy.Tests/PartyDpsTrackerTests.cs
@@ -125,25 +125,25 @@ public class PartyDpsTrackerTests
     {
         var tracker = Replay(
             At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
-            At(0, 9, "A puma tries to slash a ghoul, but misses!"),
-            At(0, 17, "Lizzid reaves orc legionnaire for 5 points of damage."));
+            At(0, 2, "A puma tries to slash a ghoul, but misses!"),
+            At(0, 4, "Lizzid reaves orc legionnaire for 5 points of damage."));
 
-        // 17s separates the two damage hits, but the miss at 9s bridges the gap
-        // (9s and 8s, both under the 10s pull boundary) — same pull, totals accumulate.
-        var snap = tracker.Snapshot(T(0, 17));
+        // 4s separates the two damage hits, but the miss at 2s bridges the gap
+        // (2s and 2s, both under the 3s pull boundary) — same pull, totals accumulate.
+        var snap = tracker.Snapshot(T(0, 4));
         var lizzid = Assert.Single(snap.Rows);
         Assert.Equal(2, lizzid.Hits);
         Assert.Equal(12, lizzid.Total);
     }
 
     [Fact]
-    public void AGapOverTenSecondsStartsAFreshPull()
+    public void AGapOverThePullWindowStartsAFreshPull()
     {
         var tracker = Replay(
             At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
-            At(0, 15, "Lizzid reaves orc legionnaire for 5 points of damage."));
+            At(0, 5, "Lizzid reaves orc legionnaire for 5 points of damage."));
 
-        var snap = tracker.Snapshot(T(0, 15));
+        var snap = tracker.Snapshot(T(0, 5));
         var lizzid = Assert.Single(snap.Rows);
         // Only the second hit survives — the first pull's total was cleared at the gap.
         Assert.Equal(1, lizzid.Hits);
@@ -155,8 +155,8 @@ public class PartyDpsTrackerTests
     {
         var tracker = Replay(At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."));
 
-        // Nothing else ever happens — 11 quiet seconds later the pull is over.
-        var snap = tracker.Snapshot(T(0, 11));
+        // Nothing else ever happens — 4 quiet seconds later the pull is over.
+        var snap = tracker.Snapshot(T(0, 4));
         Assert.False(snap.Active);
         Assert.Empty(snap.Rows);
     }
@@ -169,16 +169,16 @@ public class PartyDpsTrackerTests
     {
         var tracker = Replay(
             At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
-            At(0, 15, "Lizzid reaves orc legionnaire for 5 points of damage."));
+            At(0, 5, "Lizzid reaves orc legionnaire for 5 points of damage."));
 
         var roster = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Lizzid" };
-        var totals = tracker.TotalsSnapshot(T(0, 15), roster);
+        var totals = tracker.TotalsSnapshot(T(0, 5), roster);
         var lizzid = Assert.Single(totals.Rows);
         Assert.Equal(2, lizzid.Hits);
         Assert.Equal(12, lizzid.Total);
 
         // Meanwhile the live per-pull view did reset at the gap.
-        var pull = tracker.Snapshot(T(0, 15));
+        var pull = tracker.Snapshot(T(0, 5));
         Assert.Equal(1, Assert.Single(pull.Rows).Hits);
     }
 
@@ -189,17 +189,17 @@ public class PartyDpsTrackerTests
     {
         var tracker = Replay(
             At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
-            At(0, 5, "Lizzid reaves orc legionnaire for 3 points of damage."),
-            // 20s of nothing — past the 10s pull gap — then a second pull.
-            At(0, 25, "Lizzid reaves orc legionnaire for 7 points of damage."),
-            At(0, 30, "Lizzid reaves orc legionnaire for 3 points of damage."));
+            At(0, 2, "Lizzid reaves orc legionnaire for 3 points of damage."),
+            // 8s of nothing — past the 3s pull gap — then a second pull.
+            At(0, 10, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 12, "Lizzid reaves orc legionnaire for 3 points of damage."));
 
         var roster = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Lizzid" };
-        var totals = tracker.TotalsSnapshot(T(0, 30), roster);
+        var totals = tracker.TotalsSnapshot(T(0, 12), roster);
 
-        // Two 5-second pulls = 10s of actual combat, not the 30s of wall-clock time
+        // Two 2-second pulls = 4s of actual combat, not the 12s of wall-clock time
         // that elapsed between the first hit and the last.
-        Assert.Equal(10, totals.DurationSeconds, 3);
+        Assert.Equal(4, totals.DurationSeconds, 3);
         Assert.Equal(20, totals.TotalDamage);
     }
 
@@ -305,5 +305,33 @@ public class PartyDpsTrackerTests
             At(0, 0, "Orc centurion hits YOU for 4 points of damage."),   // confirms the enemy
             At(0, 1, "Orc centurion hits Lizzid for 6 points of damage.")); // it also hits a groupmate
         Assert.Equal(AttackerCategory.Player, tracker.CategoryOf("Lizzid"));
+    }
+
+    /// <summary>Field report 2026-08-06: several named raid adds ("Knight of Innoruuk",
+    /// "Sage of Innoruuk"...) all read as Pets of their own leader ("Champion of Innoruuk").
+    /// EQ mobs occasionally clip each other via fear/confusion/pathing without either one
+    /// being charmed — that must never override direct evidence that an attacker is
+    /// independently hostile, regardless of which order the two facts arrive in. This case:
+    /// clip happens BEFORE the independent confirmation.</summary>
+    [Fact]
+    public void HostileAddThatClipsAnotherHostileIsStillEnemyWhenLaterConfirmedDirectly()
+    {
+        var tracker = Replay(
+            At(0, 0, "Champion of Innoruuk hits YOU for 4 points of damage."),           // confirms Champion
+            At(0, 1, "Knight of Innoruuk reaves Champion of Innoruuk for 5 points of damage."), // Knight clips Champion
+            At(0, 2, "Knight of Innoruuk hits YOU for 3 points of damage."));            // Knight independently confirmed too
+        Assert.Equal(AttackerCategory.Enemy, tracker.CategoryOf("Knight of Innoruuk"));
+    }
+
+    /// <summary>Same scenario, reversed order: the independent confirmation happens BEFORE
+    /// the clip, exercising the add-time gate instead of the read-time priority.</summary>
+    [Fact]
+    public void HostileAddThatClipsAnotherHostileIsStillEnemyWhenAlreadyConfirmedDirectly()
+    {
+        var tracker = Replay(
+            At(0, 0, "Champion of Innoruuk hits YOU for 4 points of damage."),           // confirms Champion
+            At(0, 1, "Knight of Innoruuk hits YOU for 3 points of damage."),             // Knight confirmed hostile first
+            At(0, 2, "Knight of Innoruuk reaves Champion of Innoruuk for 5 points of damage.")); // then clips Champion
+        Assert.Equal(AttackerCategory.Enemy, tracker.CategoryOf("Knight of Innoruuk"));
     }
 }

--- a/tests/EQBuddy.Tests/PartyDpsTrackerTests.cs
+++ b/tests/EQBuddy.Tests/PartyDpsTrackerTests.cs
@@ -1,0 +1,246 @@
+using EQBuddy.Core;
+
+namespace EQBuddy.Tests;
+
+/// <summary>
+/// Replay tests: feed raw log lines through the parser into PartyDpsTracker and assert the
+/// resulting snapshot — same path live tailing uses (mirrors SessionStatsTests).
+/// </summary>
+public class PartyDpsTrackerTests
+{
+    private static DateTime T(int mm, int ss) => new(2026, 7, 18, 15, mm, ss);
+
+    private static string At(int mm, int ss, string msg) =>
+        $"[Sat Jul 18 15:{mm:D2}:{ss:D2} 2026] {msg}";
+
+    private static PartyDpsTracker Replay(params string[] lines)
+    {
+        var tracker = new PartyDpsTracker();
+        foreach (var line in lines)
+        {
+            var evt = LogParser.Parse(line);
+            if (evt is not null) tracker.Apply(evt);
+        }
+        return tracker;
+    }
+
+    [Fact]
+    public void SelfDamageIsAttributedToYou()
+    {
+        var tracker = Replay(
+            At(0, 0, "You slash orc pawn for 10 points of damage."),
+            At(0, 1, "You slash orc pawn for 15 points of damage. (Critical)"));
+
+        var snap = tracker.Snapshot(T(0, 1));
+        var you = Assert.Single(snap.Rows);
+        Assert.Equal("You", you.Name);
+        Assert.Equal(2, you.Hits);
+        Assert.Equal(25, you.Total);
+        Assert.Equal(1, you.Crits);
+    }
+
+    /// <summary>EQ logs a mob hitting a groupmate as a Third* line, but a mob hitting YOU
+    /// specifically is a totally different line ("Orc centurion hits YOU for..."). Without
+    /// picking up DamageTakenEvent too, the enemy's own dps would vanish from Current Pull
+    /// the moment it started attacking you instead of someone else (field report
+    /// 2026-08-05).</summary>
+    [Fact]
+    public void EnemyDamageAgainstYouIsAttributedToTheAttacker()
+    {
+        var tracker = Replay(
+            At(0, 0, "Orc centurion hits YOU for 4 points of damage."),
+            At(0, 1, "Orc centurion hits YOU for 6 points of damage."));
+
+        var snap = tracker.Snapshot(T(0, 1));
+        var orc = Assert.Single(snap.Rows);
+        Assert.Equal("Orc centurion", orc.Name);
+        Assert.Equal(2, orc.Hits);
+        Assert.Equal(10, orc.Total);
+    }
+
+    /// <summary>HP-cost casting, falls, drowning — self-inflicted, not an attacker.</summary>
+    [Fact]
+    public void SelfInflictedDamageTakenIsNotAttributedToAnAttacker()
+    {
+        var tracker = Replay(At(0, 0, "You hurt yourself for 27 points."));
+
+        var snap = tracker.Snapshot(T(0, 0));
+        Assert.Empty(snap.Rows);
+    }
+
+    /// <summary>LogParser's catch-all for non-melee lines EQ doesn't cleanly separate
+    /// attacker from effect ("YOU are burned by orc centurion's flames...") puts a whole
+    /// descriptive phrase in the Attacker field — not a name fit for a Track menu (field
+    /// report 2026-08-05: "Burned by a gust of wind's flames" showing up as an attacker).
+    /// It must not create a row.</summary>
+    [Fact]
+    public void AmbiguousNonMeleeDamageLabelIsNotTrackedAsAnAttacker()
+    {
+        var tracker = Replay(
+            At(0, 0, "YOU are burned by orc centurion's flames for 6 points of non-melee damage!"));
+
+        var snap = tracker.Snapshot(T(0, 0));
+        Assert.Empty(snap.Rows);
+    }
+
+    /// <summary>Spell damage taken from a known caster is a clean, trackable attacker name —
+    /// unlike the ambiguous label case above, this one has a real name and a known ability.</summary>
+    [Fact]
+    public void SpellDamageTakenFromAKnownCasterIsAttributedToTheCaster()
+    {
+        var tracker = Replay(
+            At(0, 0, "ice boned skeleton hit you for 20 points of cold damage by Ice Bone Frost Burst."));
+
+        var snap = tracker.Snapshot(T(0, 0));
+        var attacker = Assert.Single(snap.Rows);
+        Assert.Equal("Ice boned skeleton", attacker.Name);
+        Assert.Equal(20, attacker.Total);
+    }
+
+    [Fact]
+    public void ThirdPartyMeleeDotAndSchoolDamageAreSummedPerAttacker()
+    {
+        var tracker = Replay(
+            At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 2, "Orc centurion has taken 3 damage from Disease Cloud by Lizzid."),
+            At(0, 4, "Jibekn hit orc centurion for 11 points of magic damage by Lifespike."));
+
+        var snap = tracker.Snapshot(T(0, 4));
+        Assert.Equal(21, snap.TotalDamage);
+
+        var lizzid = Assert.Single(snap.Rows, r => r.Name == "Lizzid");
+        Assert.Equal(2, lizzid.Hits);
+        Assert.Equal(10, lizzid.Total);
+
+        var jibekn = Assert.Single(snap.Rows, r => r.Name == "Jibekn");
+        Assert.Equal(1, jibekn.Hits);
+        Assert.Equal(11, jibekn.Total);
+    }
+
+    /// <summary>A miss carries no damage but is still combat activity — it must keep the
+    /// pull alive the same way a hit does, or a quiet-but-still-swinging attacker would
+    /// wrongly reset everyone else's totals.</summary>
+    [Fact]
+    public void MissesCarryNoDamageButKeepThePullAlive()
+    {
+        var tracker = Replay(
+            At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 9, "A puma tries to slash a ghoul, but misses!"),
+            At(0, 17, "Lizzid reaves orc legionnaire for 5 points of damage."));
+
+        // 17s separates the two damage hits, but the miss at 9s bridges the gap
+        // (9s and 8s, both under the 10s pull boundary) — same pull, totals accumulate.
+        var snap = tracker.Snapshot(T(0, 17));
+        var lizzid = Assert.Single(snap.Rows);
+        Assert.Equal(2, lizzid.Hits);
+        Assert.Equal(12, lizzid.Total);
+    }
+
+    [Fact]
+    public void AGapOverTenSecondsStartsAFreshPull()
+    {
+        var tracker = Replay(
+            At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 15, "Lizzid reaves orc legionnaire for 5 points of damage."));
+
+        var snap = tracker.Snapshot(T(0, 15));
+        var lizzid = Assert.Single(snap.Rows);
+        // Only the second hit survives — the first pull's total was cleared at the gap.
+        Assert.Equal(1, lizzid.Hits);
+        Assert.Equal(5, lizzid.Total);
+    }
+
+    [Fact]
+    public void SnapshotClearsStaleRowsAfterTheGapEvenWithoutANewEvent()
+    {
+        var tracker = Replay(At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."));
+
+        // Nothing else ever happens — 11 quiet seconds later the pull is over.
+        var snap = tracker.Snapshot(T(0, 11));
+        Assert.False(snap.Active);
+        Assert.Empty(snap.Rows);
+    }
+
+    /// <summary>Running totals are a separate ledger from the live per-pull view — a
+    /// pull-ending gap must not erase them, or "running totals" would just be the pull
+    /// view with extra steps.</summary>
+    [Fact]
+    public void RunningTotalsSurviveAPullGapThatClearsTheLiveView()
+    {
+        var tracker = Replay(
+            At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 15, "Lizzid reaves orc legionnaire for 5 points of damage."));
+
+        var roster = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Lizzid" };
+        var totals = tracker.TotalsSnapshot(T(0, 15), roster);
+        var lizzid = Assert.Single(totals.Rows);
+        Assert.Equal(2, lizzid.Hits);
+        Assert.Equal(12, lizzid.Total);
+
+        // Meanwhile the live per-pull view did reset at the gap.
+        var pull = tracker.Snapshot(T(0, 15));
+        Assert.Equal(1, Assert.Single(pull.Rows).Hits);
+    }
+
+    /// <summary>The whole point of tracking combat-active seconds instead of wall-clock time
+    /// since the totals started: standing around between pulls must not dilute dps.</summary>
+    [Fact]
+    public void RunningTotalsDurationExcludesIdleTimeBetweenPulls()
+    {
+        var tracker = Replay(
+            At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 5, "Lizzid reaves orc legionnaire for 3 points of damage."),
+            // 20s of nothing — past the 10s pull gap — then a second pull.
+            At(0, 25, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 30, "Lizzid reaves orc legionnaire for 3 points of damage."));
+
+        var roster = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Lizzid" };
+        var totals = tracker.TotalsSnapshot(T(0, 30), roster);
+
+        // Two 5-second pulls = 10s of actual combat, not the 30s of wall-clock time
+        // that elapsed between the first hit and the last.
+        Assert.Equal(10, totals.DurationSeconds, 3);
+        Assert.Equal(20, totals.TotalDamage);
+    }
+
+    /// <summary>Clicking Reset mid-fight must not leave the pre-reset portion of the
+    /// still-open pull counting toward the new duration.</summary>
+    [Fact]
+    public void ResetTotalsMidFightDoesNotCountTimeBeforeTheReset()
+    {
+        var tracker = Replay(
+            At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 5, "Lizzid reaves orc legionnaire for 3 points of damage."));
+        tracker.ResetTotals();
+        var roster = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Lizzid" };
+
+        // Still mid-pull 4s after the reset, with no new hit yet.
+        var totals = tracker.TotalsSnapshot(T(0, 9), roster);
+        Assert.Equal(4, totals.DurationSeconds, 3);
+        Assert.Empty(totals.Rows);
+    }
+
+    [Fact]
+    public void TotalsSnapshotOnlyIncludesTheGivenRoster()
+    {
+        var tracker = Replay(
+            At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."),
+            At(0, 1, "Jibekn hit orc centurion for 11 points of magic damage by Lifespike."));
+
+        var roster = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Lizzid" };
+        var totals = tracker.TotalsSnapshot(T(0, 1), roster);
+        var row = Assert.Single(totals.Rows);
+        Assert.Equal("Lizzid", row.Name);
+    }
+
+    [Fact]
+    public void ResetTotalsClearsRunningTotalsOnly()
+    {
+        var tracker = Replay(At(0, 0, "Lizzid reaves orc legionnaire for 7 points of damage."));
+        tracker.ResetTotals();
+
+        var roster = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Lizzid" };
+        var totals = tracker.TotalsSnapshot(T(0, 1), roster);
+        Assert.Empty(totals.Rows);
+    }
+}

--- a/tests/EQBuddy.Tests/PartyDpsTrackerTests.cs
+++ b/tests/EQBuddy.Tests/PartyDpsTrackerTests.cs
@@ -243,4 +243,67 @@ public class PartyDpsTrackerTests
         var totals = tracker.TotalsSnapshot(T(0, 1), roster);
         Assert.Empty(totals.Rows);
     }
+
+    [Fact]
+    public void YouIsAlwaysClassifiedAsPlayer()
+    {
+        var tracker = Replay(At(0, 0, "You slash orc pawn for 10 points of damage."));
+        Assert.Equal(AttackerCategory.Player, tracker.CategoryOf("You"));
+    }
+
+    /// <summary>Something that hit you directly is unambiguously hostile, regardless of
+    /// whether its name carries EQ's "a/an/the" creature article.</summary>
+    [Fact]
+    public void AttackerThatHitYouDirectlyIsClassifiedAsEnemy()
+    {
+        var tracker = Replay(At(0, 0, "Orc centurion hits YOU for 4 points of damage."));
+        Assert.Equal(AttackerCategory.Enemy, tracker.CategoryOf("Orc centurion"));
+    }
+
+    /// <summary>Many named EQ raid/group mobs ("Elite dragoon", "Knight of Innoruuk") carry
+    /// no leading article — with no other evidence, an unrecognized attacker must default to
+    /// Enemy, not Player, or every named add in a raid reads as a person (field report
+    /// 2026-08-05).</summary>
+    [Fact]
+    public void UnrecognizedArticleLessAttackerDefaultsToEnemyNotPlayer()
+    {
+        var tracker = Replay(
+            At(0, 0, "Knight of Innoruuk reaves Lizzid for 7 points of damage."));
+        Assert.Equal(AttackerCategory.Enemy, tracker.CategoryOf("Knight of Innoruuk"));
+    }
+
+    /// <summary>The field-reported tell: an article-style ("generic creature") name caught
+    /// attacking something already confirmed hostile is a charmed pet, not a second wild
+    /// mob — real mobs essentially never fight each other.</summary>
+    [Fact]
+    public void ArticleStyleAttackerOfAConfirmedEnemyIsClassifiedAsPet()
+    {
+        var tracker = Replay(
+            At(0, 0, "Orc centurion hits YOU for 4 points of damage."), // confirms the enemy
+            At(0, 1, "a shadowed man reaves orc centurion for 5 points of damage."));
+        Assert.Equal(AttackerCategory.Pet, tracker.CategoryOf("a shadowed man"));
+    }
+
+    /// <summary>Regression guard: a real player fighting alongside you is, by definition,
+    /// also attacking whatever you've confirmed hostile — that must not by itself land them
+    /// in the Pet bucket (the article gate on pet-detection is what prevents it).</summary>
+    [Fact]
+    public void RealPlayerFightingAConfirmedEnemyIsNotClassifiedAsPet()
+    {
+        var tracker = Replay(
+            At(0, 0, "Orc centurion hits YOU for 4 points of damage."), // confirms the enemy
+            At(0, 1, "Lizzid reaves orc centurion for 7 points of damage."));
+        Assert.NotEqual(AttackerCategory.Pet, tracker.CategoryOf("Lizzid"));
+    }
+
+    /// <summary>A confirmed hostile choosing to attack a no-article (proper-named) target is
+    /// good positive evidence that target is a real player, not just "unrecognized."</summary>
+    [Fact]
+    public void ArticleLessTargetOfAConfirmedEnemyIsClassifiedAsPlayer()
+    {
+        var tracker = Replay(
+            At(0, 0, "Orc centurion hits YOU for 4 points of damage."),   // confirms the enemy
+            At(0, 1, "Orc centurion hits Lizzid for 6 points of damage.")); // it also hits a groupmate
+        Assert.Equal(AttackerCategory.Player, tracker.CategoryOf("Lizzid"));
+    }
 }


### PR DESCRIPTION
Party DPS: a beta, deliberately standalone window showing live per-attacker damage for the current pull plus click-to-track running totals, fed by a new PartyDpsTracker riding the existing LogWatcher event stream (same pattern as MezTracker/SpawnTimers) rather than touching SessionStats. It matches the main widget's background opacity, opens beside it, and has a compact view for just names and dps. Running-totals dps is computed from combat-active seconds (summed across pulls) so idle time between fights doesn't dilute it, and the tracker is gated off the startup log replay so opening the window doesn't show hours of stale history.

Also fixed App.xaml.cs: StartupUri queued MainWindow's construction independently of OnStartup, so a second instance losing the single-instance mutex could still have MainWindow built (and crash reaching for a theme brush that was never applied) even after OnStartup called Shutdown(). Now MainWindow is only created explicitly, after the single-instance check and theme apply both succeed.