### PR TITLE
Track rune absorption: gain totals and hits-blocked streak

### DIFF
--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -858,7 +858,12 @@ public sealed class MainWindow : Window
                 _healFightList, healing: true, _settings.ShowHealFight);
             _healingSummary.Text = $"Done {s.HealingDone:N0} - received {s.HealingReceived:N0}" +
                 (s.Recent is { Hps: > 0 } rh ? $"\nLast {(int)rh.Window.TotalMinutes}m: {rh.Hps:0.#} hps" : "") +
-                (s.RegenTicks > 0 ? $"\n{s.RegenTicks} regen/hymn ticks (game logs no amounts for these)" : "");
+                (s.RegenTicks > 0 ? $"\n{s.RegenTicks} regen/hymn ticks (game logs no amounts for these)" : "") +
+                (s.RuneBlockCount > 0
+                    ? $"\nRune absorbed {s.RuneBlockCount} hit{(s.RuneBlockCount == 1 ? "" : "s")}" +
+                      $" (best streak {s.RuneBlockStreakMax}" +
+                      (s.RuneBlockStreak > 0 ? $", current {s.RuneBlockStreak}" : "") + ")"
+                    : "");
             var showSpells = s.HealsBySpell.Count > 0;
             _healSpellsLabel.IsVisible = showSpells;
             _healSortBar.IsVisible = showSpells;

--- a/src/EQBuddy.Core/GameEvent.cs
+++ b/src/EQBuddy.Core/GameEvent.cs
@@ -24,6 +24,11 @@ public record DamageDealtEvent(DateTime Time, string Target, int Amount, DamageK
 public record DamageTakenEvent(DateTime Time, string Attacker, int Amount, bool Melee, bool Self = false, string Ability = "", bool OverTime = false) : GameEvent(Time);
 public record MissEvent(DateTime Time, bool Outgoing) : GameEvent(Time);
 public record HealEvent(DateTime Time, string Target, int Amount, string Spell, bool Outgoing, string Healer = "", bool OverTime = false) : GameEvent(Time);
+/// <summary>"X tries to hit YOU, but YOUR magical skin absorbs the blow!" — an incoming
+/// melee attack fully absorbed by the player's own rune (not the generic dodge/parry
+/// text a plain <see cref="MissEvent"/> carries, and not a mob's OWN rune blocking the
+/// player's outgoing attack, which names the mob's skin instead of "YOUR").</summary>
+public record RuneBlockEvent(DateTime Time, string Attacker) : GameEvent(Time);
 /// <summary>"Your wounds begin to heal." — a regen/hymn tick; the log gives no amount, so we can only count them.</summary>
 public record RegenTickEvent(DateTime Time) : GameEvent(Time);
 /// <summary>A /consider line — deliberate targeting, so it can drive the target-drops

--- a/src/EQBuddy.Core/LogParser.cs
+++ b/src/EQBuddy.Core/LogParser.cs
@@ -82,6 +82,14 @@ public static partial class LogParser
     [GeneratedRegex(@"^(?<attacker>.+?) tries to (?:\w+)(?: on)? YOU, but (?<reason>.+)!(?: \([^)]+\))?$")]
     private static partial Regex MeleeInMissRx();
 
+    // A froglok shin knight tries to hit YOU, but YOUR magical skin absorbs the blow!
+    // Checked ahead of MeleeInMissRx: "YOUR magical skin absorbs" is the player's own
+    // rune blocking an incoming hit, distinct from a mob's OWN skin absorbing the
+    // player's outgoing attack ("... but a froglok tactician's magical skin absorbs
+    // the blow!", which MeleeMissRx already covers as an ordinary outgoing miss).
+    [GeneratedRegex(@"^(?<attacker>.+?) tries to \w+(?: on)? YOU, but YOUR magical skin absorbs the blow!(?: \([^)]+\))?$")]
+    private static partial Regex RuneBlockInRx();
+
     // YOU are burned by orc centurion's flames for 6 points of non-melee damage!
     [GeneratedRegex(@"^YOU are (?<how>.+?) for (?<dmg>\d+) points? of non-melee damage!$")]
     private static partial Regex NonMeleeInRx();
@@ -131,6 +139,11 @@ public static partial class LogParser
     // "(Lvl: N)" tail so a chat line can't satisfy it.)
     [GeneratedRegex(@"^(?<name>.+?) (?:scowls at you|regards you|glares at you|glowers at you|judges you|kindly considers you|looks upon you|looks your way).*\(Lvl: (?<level>\d+)\)$")]
     private static partial Regex ConsiderRx();
+
+    // You gain a rune for 8 points of absorption. — a berserker/rune buff building its
+    // absorption pool; functions as self-mitigation, so it's tracked as a self-heal.
+    [GeneratedRegex(@"^You gain a rune for (?<amount>\d+) points? of absorption\.$")]
+    private static partial Regex RuneAbsorbRx();
 
     // You assume a ranged stance. / You assume an offensive stance.
     [GeneratedRegex(@"^You assume an? (?<stance>.+?) stance\.$")]
@@ -423,6 +436,9 @@ public static partial class LogParser
         if ((r = MeleeMissRx().Match(msg)).Success)
             return new MissEvent(ts, Outgoing: true);
 
+        if ((r = RuneBlockInRx().Match(msg)).Success)
+            return new RuneBlockEvent(ts, Normalize(r.Groups["attacker"].Value));
+
         if ((r = MeleeInMissRx().Match(msg)).Success)
             return new MissEvent(ts, Outgoing: false);
 
@@ -437,6 +453,10 @@ public static partial class LogParser
 
         if (RegenTickRx().IsMatch(msg))
             return new RegenTickEvent(ts);
+
+        if ((r = RuneAbsorbRx().Match(msg)).Success)
+            return new HealEvent(ts, "You", int.Parse(r.Groups["amount"].Value), "Rune",
+                Outgoing: false, Healer: "Rune");
 
         if ((r = HealInByRx().Match(msg)).Success)
             return new HealEvent(ts, "You", int.Parse(r.Groups["amount"].Value),

--- a/src/EQBuddy.Core/SessionStats.cs
+++ b/src/EQBuddy.Core/SessionStats.cs
@@ -99,6 +99,11 @@ public sealed class SessionStats
     /// same "your number wins" rule the spawn timers use.</summary>
     public int RegenPerTickOverride { get; set; }
 
+    private int _runeGainCount; private long _runeGainPoints;
+    /// <summary>Consecutive incoming melee attacks fully absorbed by the rune since the
+    /// last one that actually landed. Resets to 0 the moment melee damage gets through,
+    /// so it answers "how many hits did the rune eat before it broke."</summary>
+    private int _runeBlockStreak, _runeBlockStreakMax, _runeBlockCount;
     private string? _characterName;
 
     /// <summary>The watched character's name — needed to recognize self-heals
@@ -353,8 +358,9 @@ public sealed class SessionStats
                 _journalAppendsSincePrune = 0;
                 var cutoff = e.Time - CombatJournalRetention;
                 _journal.RemoveAll(j => j.Time < cutoff && j is DamageDealtEvent
-                    or DamageTakenEvent or MissEvent or ThirdMeleeEvent or ThirdDotEvent
-                    or ThirdSchoolEvent or ThirdMissEvent or HealEvent or RegenTickEvent);
+                    or DamageTakenEvent or MissEvent or RuneBlockEvent or ThirdMeleeEvent
+                    or ThirdDotEvent or ThirdSchoolEvent or ThirdMissEvent or HealEvent
+                    or RegenTickEvent);
             }
 
             SweepStaleFights(e.Time);
@@ -591,6 +597,12 @@ public sealed class SessionStats
                     _avoidedIncoming++;
                     TrackCombat(m.Time);
                     break;
+                case RuneBlockEvent rb:
+                    _avoidedIncoming++;
+                    _runeBlockCount++;
+                    if (++_runeBlockStreak > _runeBlockStreakMax) _runeBlockStreakMax = _runeBlockStreak;
+                    TrackCombat(rb.Time);
+                    break;
                 case DamageTakenEvent { Self: true } sdt:
                     // HP-cost casting, falls, drowning. Counted as damage taken so the
                     // Taken number is honest, but deliberately NOT a combat signal: no
@@ -605,7 +617,7 @@ public sealed class SessionStats
                     // A "pet" attacking us means the charm broke — stop crediting it.
                     if (IsPet(dt.Attacker)) _petName = null;
                     _damageTaken += dt.Amount;
-                    if (dt.Melee) _meleeHitsTaken++;
+                    if (dt.Melee) { _meleeHitsTaken++; _runeBlockStreak = 0; }
                     TouchFight(dt.Attacker, dt.Time, dmgIn: dt.Amount);
                     if (_activeFights.TryGetValue(dt.Attacker, out var inFight))
                         Ability(inFight.ByIncoming,
@@ -644,6 +656,7 @@ public sealed class SessionStats
                         var hv = _healsByHealer.TryGetValue(h.Healer, out var hc) ? hc : (0, 0L);
                         _healsByHealer[h.Healer] = (hv.Item1 + 1, hv.Item2 + h.Amount);
                     }
+                    if (h.Spell == "Rune") { _runeGainCount++; _runeGainPoints += h.Amount; }
                     // Incoming heals name the spell too ("healed you ... by Echoing
                     // Light") — a HoT someone keeps on you teaches the catalog even if
                     // you never cast one.
@@ -1178,6 +1191,8 @@ public sealed class SessionStats
         _healingDone = 0; _healCount = 0; _healingReceived = 0;
         _healsByHealer.Clear(); _healsBySpell.Clear(); _regenTicks = 0;
         _regenEstimated = 0; _regenSpell = null; _lastRegenCast = null; _lastConsider = null;
+        _runeGainCount = 0; _runeGainPoints = 0;
+        _runeBlockStreak = 0; _runeBlockStreakMax = 0; _runeBlockCount = 0;
         _loot.Clear(); _lootCount = 0; _crafted.Clear();
         _copper = 0; _coinDrops = 0; _biggestDrop = 0;
         _vendorCopper = 0; _salesCount = 0; _soldItems.Clear();
@@ -1407,6 +1422,11 @@ public sealed class SessionStats
                 RegenTicks = _regenTicks,
                 RegenEstimatedHealed = _regenEstimated,
                 RegenSpell = _regenSpell ?? "",
+                RuneGainCount = _runeGainCount,
+                RuneGainPoints = _runeGainPoints,
+                RuneBlockCount = _runeBlockCount,
+                RuneBlockStreak = _runeBlockStreak,
+                RuneBlockStreakMax = _runeBlockStreakMax,
                 LootTotal = _lootCount,
                 Loot = _loot.OrderByDescending(kv => kv.Value.Count)
                     .Select(kv => new LootDetail(kv.Key, kv.Value.Count, kv.Value.LastSource)).ToList(),
@@ -1566,6 +1586,16 @@ public sealed class StatsSnapshot
     public long RegenEstimatedHealed { get; init; }
     /// <summary>The regen spell the ticks were attributed to ("" when no own cast seen).</summary>
     public string RegenSpell { get; init; } = "";
+    /// <summary>How many times the rune buff built its absorption pool ("You gain a rune
+    /// for N points of absorption."), and the total points gained — already folded into
+    /// HealingReceived/HealsByHealer["Rune"], broken out here for a dedicated readout.</summary>
+    public int RuneGainCount { get; init; }
+    public long RuneGainPoints { get; init; }
+    /// <summary>Incoming melee attacks the rune fully absorbed. Streak is the current run
+    /// since the last hit that actually landed; StreakMax is the longest run this session.</summary>
+    public int RuneBlockCount { get; init; }
+    public int RuneBlockStreak { get; init; }
+    public int RuneBlockStreakMax { get; init; }
     public int LootTotal { get; init; }
     public List<LootDetail> Loot { get; init; } = [];
     public List<NameCount> Crafted { get; init; } = [];

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -955,7 +955,12 @@ public partial class MainWindow : Window
                 (s.Recent is { Hps: > 0 } rh
                     ? $"\nLast {(int)rh.Window.TotalMinutes}m: {rh.Hps:0.#} hps"
                     : "") +
-                (s.RegenTicks > 0 ? "\n" + RegenLine(s) : "");
+                (s.RegenTicks > 0 ? "\n" + RegenLine(s) : "") +
+                (s.RuneBlockCount > 0
+                    ? $"\nRune absorbed {s.RuneBlockCount} hit{(s.RuneBlockCount == 1 ? "" : "s")}" +
+                      $" (best streak {s.RuneBlockStreakMax}" +
+                      (s.RuneBlockStreak > 0 ? $", current {s.RuneBlockStreak}" : "") + ")"
+                    : "");
             var showSpells = s.HealsBySpell.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
             HealSpellsLabel.Visibility = showSpells;
             HealSortBar.Visibility = showSpells;

--- a/tests/EQBuddy.Tests/LogParserTests.cs
+++ b/tests/EQBuddy.Tests/LogParserTests.cs
@@ -211,6 +211,39 @@ public class LogParserTests
     public void RegenTickHasNoAmount() =>
         Parse<RegenTickEvent>("Your wounds begin to heal.");
 
+    /// <summary>"You gain a rune for N points of absorption." — a berserker/rune buff
+    /// building its absorption pool. Tracked as a self-heal so it shows on Healing
+    /// rather than vanishing entirely.</summary>
+    [Fact]
+    public void RuneAbsorptionIsHealing()
+    {
+        var e = Parse<HealEvent>("You gain a rune for 8 points of absorption.");
+        Assert.Equal(("You", 8, "Rune", false, "Rune"), (e.Target, e.Amount, e.Spell, e.Outgoing, e.Healer));
+    }
+
+    /// <summary>"YOUR magical skin absorbs the blow!" — an incoming melee attack fully
+    /// blocked by the player's own rune. Must NOT fall through to a generic MissEvent
+    /// (which would blur "absorbed by rune" into ordinary dodges/parries).</summary>
+    [Fact]
+    public void RuneBlocksIncomingHit()
+    {
+        var e = Parse<RuneBlockEvent>("A froglok shin knight tries to hit YOU, but YOUR magical skin absorbs the blow!");
+        Assert.Equal("Froglok shin knight", e.Attacker);
+    }
+
+    [Fact]
+    public void RuneBlocksIncomingHitWithNote()
+    {
+        var e = Parse<RuneBlockEvent>("A vampire bat tries to bite YOU, but YOUR magical skin absorbs the blow! (Riposte)");
+        Assert.Equal("Vampire bat", e.Attacker);
+    }
+
+    /// <summary>A mob's OWN rune blocking the player's outgoing attack is an ordinary
+    /// outgoing miss, not the player's rune — must not be mistaken for a block.</summary>
+    [Fact]
+    public void TargetsOwnRuneIsOrdinaryOutgoingMiss() =>
+        Parse<MissEvent>("You try to strike a froglok tactician, but a froglok tactician's magical skin absorbs the blow!");
+
     [Fact]
     public void ThirdPartyHealsIgnored() =>
         AssertIgnored("Guard Meadom healed Guard Legver for 0 (63) hit points by Center.");

--- a/tests/EQBuddy.Tests/SessionStatsTests.cs
+++ b/tests/EQBuddy.Tests/SessionStatsTests.cs
@@ -116,6 +116,31 @@ public class SessionStatsTests
         Assert.Equal(16, s.HealingReceived);
     }
 
+    /// <summary>Rune gains show up as healing received under "Rune", and the block
+    /// counter tracks how many incoming melee hits the rune ate in a row before one got
+    /// through — the streak resets the moment real melee damage lands, and the running
+    /// max remembers the best streak of the session.</summary>
+    [Fact]
+    public void RuneGainsAndBlockStreakAreTracked()
+    {
+        var s = Replay("Tickel",
+            At(0, 0, "You gain a rune for 8 points of absorption."),
+            At(0, 1, "You gain a rune for 5 points of absorption."),
+            At(0, 2, "A froglok shin knight tries to hit YOU, but YOUR magical skin absorbs the blow!"),
+            At(0, 3, "A froglok shin knight tries to bash YOU, but YOUR magical skin absorbs the blow!"),
+            At(0, 4, "A froglok shin knight hits YOU for 4 points of damage."),
+            At(0, 5, "A froglok shin knight tries to hit YOU, but YOUR magical skin absorbs the blow!")).Snapshot();
+
+        Assert.Equal((2, 13), (s.RuneGainCount, s.RuneGainPoints));
+        Assert.Equal(13, s.HealingReceived);
+        var rune = Assert.Single(s.HealsByHealer, h => h.Name == "Rune");
+        Assert.Equal((2, 13), (rune.Hits, rune.Total));
+
+        Assert.Equal(3, s.RuneBlockCount);
+        Assert.Equal(2, s.RuneBlockStreakMax);   // two blocks before the hit landed
+        Assert.Equal(1, s.RuneBlockStreak);      // one block since
+    }
+
     [Fact]
     public void PetDamageAndKillsCreditedToPlayer()
     {


### PR DESCRIPTION
"You gain a rune for N points of absorption." and the incoming "YOUR magical skin absorbs the blow!" lines were both unparsed, so a berserker's rune mitigation was invisible everywhere. Now rune gains post as self-heals under Healing, and blocked hits accumulate a streak (reset by the next melee hit that actually lands) shown next to the regen-tick note.