### PR TITLE
Add Sky Quest checklist scrolling

### DIFF
--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -1486,7 +1486,15 @@ public partial class MainWindow : Window
             {
                 Header = $"{ClassAbbrev(classGroup.Key)} {classDone}/{classTotal}",
                 Tag = classGroup.Key,
-                Content = panel,
+                Content = new ScrollViewer
+                {
+                    Content = panel,
+                    MaxHeight = SkyQuestListMaxHeight(),
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                    PanningMode = PanningMode.VerticalOnly,
+                    Padding = new Thickness(0, 0, 4, 0),
+                },
                 ToolTip = classGroup.Key,
             };
             SkyQuestTabs.Items.Add(tab);
@@ -1496,6 +1504,12 @@ public partial class MainWindow : Window
 
         if (SkyQuestTabs.SelectedIndex < 0 && SkyQuestTabs.Items.Count > 0)
             SkyQuestTabs.SelectedIndex = 0;
+    }
+
+    private double SkyQuestListMaxHeight()
+    {
+        var available = SectionScroll.MaxHeight > 0 ? SectionScroll.MaxHeight - 220 : 260;
+        return Math.Clamp(available, 180, 320);
     }
 
     private static string SkyRewardKey(string className, string reward) => className + "|" + reward;


### PR DESCRIPTION
﻿## Summary
Adds a bounded vertical scroll area inside each Sky Quest class tab so longer quest lists remain reachable in the overlay.

- wraps each class checklist panel in a vertical `ScrollViewer`
- keeps horizontal scrolling disabled and touch/mouse panning vertical-only
- caps the list height so the tab body scrolls instead of growing past the visible card

## Validation
- `dotnet build src/EQBuddy/EQBuddy.csproj -c Release --no-restore -v:minimal`
- `dotnet test tests/EQBuddy.Tests/EQBuddy.Tests.csproj -c Release --logger "console;verbosity=minimal"` - 727 passed
