### PR TITLE
Ask the pet who it works for: /pet leader claims it too

### DIFF
--- a/src/EQBuddy.Core/GameEvent.cs
+++ b/src/EQBuddy.Core/GameEvent.cs
@@ -97,8 +97,16 @@ public record FizzleEvent(DateTime Time, string Spell = "") : GameEvent(Time);
 public record SpellCastEvent(DateTime Time, string Spell, bool Song = false) : GameEvent(Time);
 /// <summary>"Your X spell is interrupted." — a started cast that never landed.</summary>
 public record SpellInterruptedEvent(DateTime Time, string Spell) : GameEvent(Time);
-/// <summary>The player's pet announced itself ("<Pet> told you, 'Attacking X Master.'").</summary>
-public record PetClaimEvent(DateTime Time, string PetName) : GameEvent(Time);
+/// <summary>The player's pet announced itself — the attack order ("<Pet> told you,
+/// 'Attacking X Master.'") or the leader query ("<Pet> says, 'My leader is Vataro.'").
+/// Only pet lines that prove ownership are parsed into this event.</summary>
+/// <param name="Leader">The owner the pet named, from the leader query only; null for
+/// the attack order, which is a tell addressed to us and so needs no name. When present
+/// it must be checked: a name that isn't the watched character disproves the claim.</param>
+/// <param name="Fighting">False for the leader query: it answers a question in or out of
+/// combat, so unlike the attack order it is no evidence that a fight is underway.</param>
+public record PetClaimEvent(DateTime Time, string PetName, string? Leader = null,
+    bool Fighting = true) : GameEvent(Time);
 /// <summary>A creature blinked ("an asp blinks.") — the charm-spell tell; treated as a provisional pet claim.</summary>
 /// <param name="Weak">"X moans." — the necro charm landing (eqlwiki, all three undead
 /// charms). Unlike blinks, moaning is plausible ambient flavor, so a weak signal acts

--- a/src/EQBuddy.Core/LogParser.cs
+++ b/src/EQBuddy.Core/LogParser.cs
@@ -287,10 +287,32 @@ public static partial class LogParser
     [GeneratedRegex(@"^(?<target>.+?) has taken (?<dmg>\d+) damage from (?<spell>.+?) by (?<caster>.+?)\.(?: \((?<note>[^)]+)\))?$")]
     private static partial Regex ThirdDotRx();
 
+    // Pet responses split across two channels, and the split is by which response it is,
+    // not by content (David's log, 2026-08-10): the attack order comes back as a directed
+    // tell, EVERY other pet response comes back on say. Only two of them can prove the pet
+    // is ours, and only those two are parsed:
+    //
+    //   - the attack order is a tell, addressed to us — a bystander's pet never tells us
+    //     anything, so the speaker is ours by construction;
+    //   - the leader response names its owner outright, which holds up even on say.
+    //
+    // "Following you, Master." is deliberately NOT parsed. It would be the most useful of
+    // the three (out of combat, macro-able into the summon) but it names nobody and rides
+    // the broadcast channel, so a nearby player's pet ordered to follow is indistinguishable
+    // from our own — and _petName is a single slot, so honouring it could swap our pet's
+    // damage out for a stranger's.
+    //
     // Jibekn told you, 'Attacking orc centurion Master.'
     // A puma told you, 'Attacking a ghoul Master.'   (charmed creatures have multi-word names)
     [GeneratedRegex(@"^(?<pet>.+?) (?:tells|told) you, 'Attacking .+ Master\.'$")]
     private static partial Regex PetClaimRx();
+
+    // Genektik says, 'My leader is Vataro.'
+    // Both channels parse — the log writes this one on say, but a client that tells it
+    // instead is no less ours. Leader is a player name: one word, no spaces. SessionStats
+    // claims only when that name is the watched character.
+    [GeneratedRegex(@"^(?<pet>.+?) (?:(?:tells|told) you|says), 'My leader is (?<leader>[A-Za-z]+)\.'$")]
+    private static partial Regex PetLeaderRx();
 
     // "an asp blinks." — the landing line for every druid/shaman animal charm AND
     // Beguile Plants (eqlwiki msg_cast_on_other, verified 2026-08-04); provisional
@@ -621,6 +643,12 @@ public static partial class LogParser
         // Pet announcement and third-party combat (checked last — specific patterns above win).
         if ((r = PetClaimRx().Match(msg)).Success)
             return new PetClaimEvent(ts, r.Groups["pet"].Value);
+
+        // The leader response answers a question, in or out of combat — no attack happened,
+        // so it is no evidence of a fight.
+        if ((r = PetLeaderRx().Match(msg)).Success)
+            return new PetClaimEvent(ts, r.Groups["pet"].Value,
+                Leader: r.Groups["leader"].Value, Fighting: false);
 
         if ((r = CharmedRx().Match(msg)).Success)
             return new CharmedEvent(ts, r.Groups["name"].Value);

--- a/src/EQBuddy.Core/SessionStats.cs
+++ b/src/EQBuddy.Core/SessionStats.cs
@@ -474,10 +474,20 @@ public sealed class SessionStats
                     }
                     break;
                 case PetClaimEvent pc:
+                    // "My leader is X." rides the broadcast say channel, so a nearby player's
+                    // pet answering THEIR /pet leader lands in our log too — the name is what
+                    // separates them, and it has to be ours. An unknown character name can't
+                    // check it, and an unverifiable claim is not one we take: _petName is a
+                    // single slot, so a wrong one swaps our pet's damage out for a stranger's.
+                    // (The attack order names nobody and needs none — it is a tell addressed
+                    // to us, which no bystander's pet ever sends.)
+                    if (pc.Leader is { } leader
+                        && !string.Equals(leader, _characterName, StringComparison.OrdinalIgnoreCase))
+                        break;
                     // A blink/charmed line that followed an unrecognised cast, now proven
                     // ours: that cast was a charm spell, so remember it — permanently, via
-                    // the attached store. The tell must name the same creature the line
-                    // did; a tell about a different pet proves nothing about that cast.
+                    // the attached store. The claim must name the same creature the line
+                    // did; a claim about a different pet proves nothing about that cast.
                     var claimed = LogParser.Normalize(pc.PetName);
                     if (_charmCandidate is { } cand && pc.Time - cand.Time <= BlinkToClaim
                         && string.Equals(cand.Pet, claimed, StringComparison.OrdinalIgnoreCase))
@@ -486,7 +496,9 @@ public sealed class SessionStats
                         _charmCandidate = null;
                     }
                     ConfirmPet(claimed);
-                    TrackCombat(pc.Time);
+                    // Only the attack order proves a fight; the leader response would
+                    // otherwise open a combat span while camped.
+                    if (pc.Fighting) TrackCombat(pc.Time);
                     break;
                 case PetBlinkEvent pb:
                     // Charm just landed. If one of our charm casts is still in flight the

--- a/tests/EQBuddy.Tests/LogParserTests.cs
+++ b/tests/EQBuddy.Tests/LogParserTests.cs
@@ -136,7 +136,32 @@ public class LogParserTests
     {
         var e = Parse<PetClaimEvent>(msg);
         Assert.Equal(pet, e.PetName);
+        Assert.True(e.Fighting);
+        Assert.Null(e.Leader);
     }
+
+    /// <summary>The leader response is the only pet line that names its owner, and the only
+    /// one usable out of combat — the game writes it on say, but a client that tells it is
+    /// no less ours.</summary>
+    [Theory]
+    [InlineData("Genektik says, 'My leader is Vataro.'")]
+    [InlineData("Genektik tells you, 'My leader is Vataro.'")]
+    public void PetLeaderNamesOwner(string msg)
+    {
+        var e = Parse<PetClaimEvent>(msg);
+        Assert.Equal(("Genektik", "Vataro", false), (e.PetName, e.Leader, e.Fighting));
+    }
+
+    /// <summary>Only pet lines that prove ownership are claims. "Following you, Master."
+    /// names nobody and the game writes it on the broadcast channel, so a nearby player's
+    /// pet ordered to follow is indistinguishable from ours; the attack order proves
+    /// ownership only by being a tell, so a say-channel copy proves nothing either.</summary>
+    [Theory]
+    [InlineData("Genektik says, 'Following you, Master.'")]
+    [InlineData("Genektik tells you, 'Following you, Master.'")]
+    [InlineData("Genektik says, 'Attacking orc centurion Master.'")]
+    public void UnprovenPetChatterIsNotAClaim(string msg) =>
+        Assert.Null(LogParser.Parse($"[Sat Jul 18 15:00:00 2026] {msg}"));
 
     [Fact]
     public void CharmBlink()

--- a/tests/EQBuddy.Tests/SessionStatsTests.cs
+++ b/tests/EQBuddy.Tests/SessionStatsTests.cs
@@ -161,6 +161,54 @@ public class SessionStatsTests
         Assert.Equal(23, pet.Total);
     }
 
+    /// <summary>The leader response claims the pet before it ever swings — the point of
+    /// parsing it, since it can be macro'd into the summon — but it is not a fight, so it
+    /// must not open a combat window and dilute DPS with idle seconds.</summary>
+    [Fact]
+    public void PetLeaderClaimsTheDamageWithoutStartingCombat()
+    {
+        var stats = Replay("Vataro", At(0, 0, "Genektik says, 'My leader is Vataro.'"));
+        Assert.Equal(0, stats.Snapshot().CombatSeconds);   // claimed, but nothing is fighting
+
+        stats.Apply(LogParser.Parse(At(0, 30, "Genektik hits orc centurion for 12 points of damage."))!);
+        var s = stats.Snapshot();
+        var pet = Assert.Single(s.DamageBySource, d => d.Name == "Pet (Genektik)");
+        Assert.Equal(12, pet.Total);
+        Assert.Equal(1, s.CombatSeconds);   // the swing, not the half-minute back to the claim
+    }
+
+    /// <summary>The leader line rides the broadcast say channel, so a nearby player's pet
+    /// answering their own /pet leader lands in our log too — the owner's name is the only
+    /// thing separating them. _petName is a single slot: honouring a stranger's line would
+    /// swap our pet's damage out for theirs.</summary>
+    [Fact]
+    public void PetLeaderClaimsOnlyForTheWatchedCharacter()
+    {
+        var s = Replay("Vataro",
+            At(0, 0, "Genektik says, 'My leader is Vataro.'"),
+            At(0, 2, "Genektik hits orc centurion for 12 points of damage."),
+            At(0, 4, "Xykon says, 'My leader is Kaybek.'"),   // a groupmate's pet
+            At(0, 6, "Xykon hits a gnoll for 99 points of damage."),
+            At(0, 8, "Genektik hits orc centurion for 8 points of damage.")).Snapshot();
+
+        var pet = Assert.Single(s.DamageBySource, d => d.Name == "Pet (Genektik)");
+        Assert.Equal(20, pet.Total);
+        Assert.DoesNotContain(s.DamageBySource, d => d.Name.Contains("Xykon"));
+        Assert.Equal(20, s.DamageDealt);   // the stranger's 99 stayed out
+    }
+
+    /// <summary>Without a character name to check against there is nothing to verify, and
+    /// an unverifiable claim is not one we take.</summary>
+    [Fact]
+    public void PetLeaderIsIgnoredWhenTheCharacterIsUnknown()
+    {
+        var s = Replay(null,
+            At(0, 0, "Genektik says, 'My leader is Vataro.'"),
+            At(0, 2, "Genektik hits orc centurion for 12 points of damage.")).Snapshot();
+
+        Assert.DoesNotContain(s.DamageBySource, d => d.Name.Contains("Genektik"));
+    }
+
     [Fact]
     public void CharmBlinkIsProvisionalUntilMasterTellThenMerges()
     {

--- a/tests/EQBuddy.Tests/SpellTrackingTests.cs
+++ b/tests/EQBuddy.Tests/SpellTrackingTests.cs
@@ -377,6 +377,25 @@ public class SpellTrackingTests
         Assert.Single(stats.Snapshot().DamageBySource, d => d.Name == "Pet (Scorched zombie)");
     }
 
+    /// <summary>The leader response teaches the catalog the same way the attack tell does,
+    /// and it arrives without waiting for the attack button — which is the whole point of
+    /// parsing it. Naming the watched character is what makes it safe to write something
+    /// this durable on a bystander-audible channel.</summary>
+    [Fact]
+    public void AnUnknownCharmSpellIsLearnedFromTheCharmedLinePlusLeaderResponse()
+    {
+        var stats = Replay(
+            At(0, 0, "You begin casting Word of Submission."),   // not in any seed/family
+            At(0, 2, "an orc legionnaire has been charmed."),    // records the candidate only
+            At(0, 9, "An orc legionnaire says, 'My leader is Douglas.'"),   // teaches
+            At(1, 0, "Your Word of Submission spell has worn off of an orc legionnaire."),
+            At(2, 0, "You begin casting Word of Submission."),
+            At(2, 2, "a scorched zombie has been charmed."),     // now instant — no tell yet
+            At(2, 4, "A scorched zombie hits gnoll for 15 points of damage."));
+
+        Assert.Single(stats.Snapshot().DamageBySource, d => d.Name == "Pet (Scorched zombie)");
+    }
+
     /// <summary>A tell about a DIFFERENT creature proves nothing about the held cast —
     /// without the name match, a bystander's charm near our unknown cast plus our real
     /// (summoned) pet's tell would poison the catalog.</summary>


### PR DESCRIPTION
This is a proposal to add a second way to claim a pet - for people who don't like to manually issue attack commands. This can be done out of combat as well, so it can be macro'd along with pet summon.