### PR TITLE
Window improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 dist/
 *.user
 .vs/
+.DS_Store

--- a/src/EQBuddy.Avalonia/MacOverlayLevel.cs
+++ b/src/EQBuddy.Avalonia/MacOverlayLevel.cs
@@ -1,0 +1,297 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+
+namespace EQBuddy.Avalonia;
+
+/// <summary>
+/// Window-level control for every EQBuddy window on macOS. Avalonia maps <c>Topmost</c> to
+/// NSFloatingWindowLevel (3), but winemac.drv — the driver behind CrossOver — hands a
+/// fullscreen game a level above that (26, one past the status level, on the bottle this
+/// was measured against). Every EQBuddy window loses that comparison, which is why the
+/// overlay, the alerts, and the Options window all vanish behind the game.
+///
+/// The raise therefore covers all open windows rather than the overlay alone — a settings
+/// window you cannot see is as broken as a hidden overlay — and it outranks
+/// CGShieldingWindowLevel so it still holds if a bottle picks the shield level instead.
+/// </summary>
+[SupportedOSPlatform("macos")]
+internal static class MacOverlayLevel
+{
+    private const string Objc = "/usr/lib/libobjc.A.dylib";
+    private const string CoreGraphics =
+        "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
+
+    /// <summary>kCGFloatingWindowLevel — what Avalonia already assigns a Topmost window,
+    /// and what such a window drops back to when there is nothing to outrank.</summary>
+    private const nint FloatingLevel = 3;
+
+    /// <summary>NSNormalWindowLevel, the resting level for a window that never asked to
+    /// float — History, for one. Restoring this rather than the floating level matters:
+    /// leaving it at 3 would park an ordinary dialog over every other app.</summary>
+    private const nint NormalLevel = 0;
+
+    /// <summary>NSPopUpMenuWindowLevel — where Avalonia rests its menus and tooltips. Above
+    /// an ordinary window normally, which is exactly why raising windows without raising
+    /// popups inverts the two.</summary>
+    private const nint PopupLevel = 101;
+
+    /// <summary>One above what a fullscreen Wine window claims. The shielding level sits
+    /// a little below the maximum window level, so the increments cannot overflow.</summary>
+    private static readonly Lazy<nint> AboveShield = new(() => CGShieldingWindowLevel() + 1);
+
+    /// <summary>Popups keep their place above their own windows while raised — the whole
+    /// stack shifts up together rather than collapsing onto one level, where ordering would
+    /// be left to whichever window was fronted last.</summary>
+    private static readonly Lazy<nint> AboveShieldPopup = new(() => CGShieldingWindowLevel() + 2);
+
+    /// <summary>Fallback identification for a Wine host whose executable is not itself a
+    /// .exe — a bare wineloader, or CrossOver fronting the bottle on the game's behalf.
+    /// Matched against both the bundle identifier and the executable path.</summary>
+    private static readonly string[] WineMarkers = ["crossover", "codeweavers", "wine", "whisky"];
+
+    /// <summary>Ensure runs on a timer, so a permanent failure must not append to the log
+    /// once a second.</summary>
+    private static bool _loggedLevelFailure;
+
+    private static readonly HashSet<string> LoggedFrontmost = [];
+
+    private static bool _raised;
+
+    /// <summary>
+    /// Re-evaluates whether EQBuddy should be outranking the game and applies the answer to
+    /// every open window. Called on a tick, because a window opened since the last pass —
+    /// Options, History, an alert — starts at whatever level Avalonia gave it.
+    /// </summary>
+    public static void Update()
+    {
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+            return;
+
+        // Reaching for one of our own windows makes EQBuddy frontmost, which must not be
+        // read as "the game is gone": the game holds its raised level while merely
+        // deactivated, so lowering here would drop the Options window the user just opened
+        // straight back behind it. Any window counts, not just the overlay — editing
+        // settings leaves the main window inactive. An unidentifiable frontmost app holds
+        // the current state too.
+        if (IsWineHostFrontmost() is { } wineFront)
+            _raised = wineFront || (_raised && desktop.Windows.Any(w => w.IsActive));
+
+        HashSet<IntPtr> handled = [];
+        foreach (var window in desktop.Windows)
+        {
+            Ensure(window, _raised);
+            if (NativeWindow(window) is { } nsWindow) handled.Add(nsWindow);
+        }
+
+        EnsurePopups(_raised, handled);
+    }
+
+    /// <summary>
+    /// Puts one window above a fullscreen CrossOver game, or back at its resting level.
+    /// Safe to call repeatedly — the current level is read back rather than assumed, so a
+    /// window Avalonia has re-levelled behind our back is repaired on the next pass.
+    /// </summary>
+    public static bool Ensure(Window window, bool aboveShield)
+    {
+        if (NativeWindow(window) is not { } nsWindow) return false;
+        var resting = window.Topmost ? FloatingLevel : NormalLevel;
+        return ApplyLevel(nsWindow, aboveShield ? AboveShield.Value : resting);
+    }
+
+    /// <summary>
+    /// Raises the popup windows — context menus, tooltips, dropdowns — that Avalonia opens
+    /// outside the <c>Window</c> list. Each is a standalone NSWindow at NSPopUpMenuWindowLevel
+    /// with no parent to inherit from, so raising a window without raising its popups leaves
+    /// the gear menu opening *behind* the window that owns it.
+    /// </summary>
+    /// <param name="known">NSWindows already handled as ordinary windows.</param>
+    private static void EnsurePopups(bool aboveShield, HashSet<IntPtr> known)
+    {
+        try
+        {
+            var app = objc_msgSend_Ptr(objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
+            if (app == IntPtr.Zero) return;
+            var windows = objc_msgSend_Ptr(app, sel_registerName("windows"));
+            if (windows == IntPtr.Zero) return;
+
+            var count = objc_msgSend_GetLong(windows, sel_registerName("count"));
+            var itemAt = sel_registerName("objectAtIndex:");
+            for (nint i = 0; i < count; i++)
+            {
+                var nsWindow = objc_msgSend_PtrLong(windows, itemAt, i);
+                if (nsWindow == IntPtr.Zero || known.Contains(nsWindow)) continue;
+                // The process also owns windows that are none of our business — an offscreen
+                // TUINSWindow for text input, for one. Only Avalonia's own subclass is ours
+                // to re-level; KVO swizzling shows up as NSKVONotifying_AvnWindow.
+                if (!IsAvaloniaWindow(nsWindow)) continue;
+
+                ApplyLevel(nsWindow, aboveShield ? AboveShieldPopup.Value : PopupLevel);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogLevelFailureOnce(ex);
+        }
+    }
+
+    private static bool IsAvaloniaWindow(IntPtr nsWindow)
+    {
+        var name = class_getName(object_getClass(nsWindow));
+        return name != IntPtr.Zero
+            && Marshal.PtrToStringUTF8(name) is { } text
+            && text.Contains("AvnWindow", StringComparison.Ordinal);
+    }
+
+    /// <summary>Reads the level back before writing: cheaper than an unconditional set on a
+    /// once-a-second sweep, and it repairs a window something else has re-levelled.</summary>
+    private static bool ApplyLevel(IntPtr nsWindow, nint desired)
+    {
+        try
+        {
+            var readLevel = sel_registerName("level");
+            var writeLevel = sel_registerName("setLevel:");
+            // A wrong selector on the wrong object is an unrecognized-selector abort, which
+            // kills the process rather than throwing — so ask before sending.
+            var cls = object_getClass(nsWindow);
+            if (!class_respondsToSelector(cls, readLevel) || !class_respondsToSelector(cls, writeLevel))
+            {
+                LogLevelFailureOnce("NSWindow does not respond to level/setLevel:.");
+                return false;
+            }
+
+            if (objc_msgSend_GetLong(nsWindow, readLevel) == desired) return true;
+            objc_msgSend_SetLong(nsWindow, writeLevel, desired);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LogLevelFailureOnce(ex);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Whether the frontmost application is hosting a Windows game — the only situation
+    /// worth outranking the shield for. Raising the level unconditionally would also park
+    /// EQBuddy over every other app's fullscreen.
+    /// </summary>
+    /// <returns><c>null</c> when the frontmost application cannot be identified, so the
+    /// caller can hold its current state rather than drop the overlay on a momentary nil.</returns>
+    public static bool? IsWineHostFrontmost()
+    {
+        try
+        {
+            var workspace = objc_msgSend_Ptr(objc_getClass("NSWorkspace"), sel_registerName("sharedWorkspace"));
+            if (workspace == IntPtr.Zero) return null;
+
+            // nil during app switching, and for anything without a UI process.
+            var app = objc_msgSend_Ptr(workspace, sel_registerName("frontmostApplication"));
+            if (app == IntPtr.Zero) return null;
+
+            var bundleId = NSStringToString(objc_msgSend_Ptr(app, sel_registerName("bundleIdentifier")));
+            var executable = NSStringToString(objc_msgSend_Ptr(
+                objc_msgSend_Ptr(app, sel_registerName("executableURL")), sel_registerName("path")));
+            if (bundleId is null && executable is null) return null;
+
+            // A frontmost app running a .exe is under a translation layer by definition, and
+            // it is the only signal that survives reality: CrossOver fronts the game with a
+            // nil bundle identifier and an executable copied to a temp path
+            // (/var/folders/.../winetemp-.../eqgame.exe), so neither the identifier nor the
+            // bottle path can be relied on to name Wine at all.
+            var matched = IsWindowsExecutable(executable) || Matches(bundleId) || Matches(executable);
+            if (!matched) LogFrontmostOnce(bundleId, executable);
+            return matched;
+        }
+        catch (Exception ex)
+        {
+            App.LogError(ex);
+            return null;
+        }
+    }
+
+    private static bool IsWindowsExecutable(string? path) =>
+        path is { Length: > 0 } && path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase);
+
+    private static bool Matches(string? identity) => identity is { Length: > 0 }
+        && WineMarkers.Any(marker => identity.Contains(marker, StringComparison.OrdinalIgnoreCase));
+
+    private static IntPtr? NativeWindow(Window window)
+    {
+        // No handle before the window is shown, which is ordinary rather than a fault —
+        // the caller's next tick finds one.
+        if (window.TryGetPlatformHandle() is not { } handle || handle.Handle == IntPtr.Zero)
+            return null;
+
+        // Avalonia reports "NSWindow" for its Cocoa windows and hands back the NSWindow*
+        // itself (not the content NSView), which is what owns the window level.
+        if (handle.HandleDescriptor is not { Length: > 0 } descriptor ||
+            !descriptor.Contains("NSWindow", StringComparison.OrdinalIgnoreCase))
+        {
+            LogLevelFailureOnce($"native handle '{handle.HandleDescriptor}' is not an NSWindow.");
+            return null;
+        }
+
+        return handle.Handle;
+    }
+
+    private static string? NSStringToString(IntPtr nsString)
+    {
+        if (nsString == IntPtr.Zero) return null;
+        var utf8 = objc_msgSend_Ptr(nsString, sel_registerName("UTF8String"));
+        return utf8 == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(utf8);
+    }
+
+    private static void LogLevelFailureOnce(object? detail)
+    {
+        if (_loggedLevelFailure) return;
+        _loggedLevelFailure = true;
+        App.LogError($"Overlay window level unavailable: {detail}");
+    }
+
+    /// <summary>Records each unrecognised frontmost app once, so a CrossOver build this
+    /// matcher does not know about is diagnosable from the log instead of just failing
+    /// to raise. Bounded, because the set of apps a user switches to is not.</summary>
+    private static void LogFrontmostOnce(string? bundleId, string? executable)
+    {
+        var identity = $"{bundleId ?? "(no bundle id)"} | {executable ?? "(no executable)"}";
+        if (LoggedFrontmost.Count >= 20 || !LoggedFrontmost.Add(identity)) return;
+        App.LogError($"Overlay level: frontmost app not treated as a Wine host: {identity}");
+    }
+
+    [DllImport(CoreGraphics)]
+    private static extern int CGShieldingWindowLevel();
+
+    [DllImport(Objc)]
+    private static extern IntPtr sel_registerName(string name);
+
+    [DllImport(Objc)]
+    private static extern IntPtr objc_getClass(string name);
+
+    [DllImport(Objc)]
+    private static extern IntPtr object_getClass(IntPtr obj);
+
+    [DllImport(Objc)]
+    private static extern IntPtr class_getName(IntPtr cls);
+
+    [DllImport(Objc)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    private static extern bool class_respondsToSelector(IntPtr cls, IntPtr selector);
+
+    /// <summary>Every objc_msgSend signature needs its own declaration: the call is not
+    /// variadic on arm64, so the argument and return shapes have to be exact.</summary>
+    [DllImport(Objc, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr objc_msgSend_Ptr(IntPtr receiver, IntPtr selector);
+
+    [DllImport(Objc, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr objc_msgSend_PtrLong(IntPtr receiver, IntPtr selector, nint index);
+
+    /// <summary>NSWindow's level is an NSInteger — pointer-width, not int.</summary>
+    [DllImport(Objc, EntryPoint = "objc_msgSend")]
+    private static extern nint objc_msgSend_GetLong(IntPtr receiver, IntPtr selector);
+
+    [DllImport(Objc, EntryPoint = "objc_msgSend")]
+    private static extern void objc_msgSend_SetLong(IntPtr receiver, IntPtr selector, nint value);
+}

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -763,6 +763,10 @@ public sealed class MainWindow : Window
     private ContextMenu BuildContextMenu()
     {
         var menu = new ContextMenu();
+        // A menu is a window of its own on macOS, and a raised main window outranks it —
+        // the gear menu opens behind the widget. Opened fires with the popup already
+        // realized, so correcting here beats waiting for the tick on something this brief.
+        menu.Opened += (_, _) => EnsureOverlayLevel();
         // Clickable since 1.48 (#76): downloads, guides, and a shareable link.
         var version = new MenuItem { Header = $"EQBuddy v{UpdateChecker.CurrentVersion}" };
         version.Click += (_, _) => System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(
@@ -900,6 +904,7 @@ public sealed class MainWindow : Window
 
     private void RefreshUi()
     {
+        EnsureOverlayLevel();
         if (_settings.TrackSpawns)
         {
             // Sound only: the chip changing to DUE is already the visual notification.
@@ -1468,6 +1473,10 @@ public sealed class MainWindow : Window
         _miniRoot.IsVisible = mini;
         _normalRoot.IsVisible = !mini;
         Topmost = true;
+        // Switching modes opens and closes the breakout windows, and a new window starts at
+        // whatever level Avalonia gave it — raise them now rather than leaving them behind
+        // the game until the next tick.
+        EnsureOverlayLevel();
         _settings.Save();
         if (!mini) _dismissedBreakouts.Clear();
         var snapshot = CurrentSnapshot();
@@ -1688,6 +1697,16 @@ public sealed class MainWindow : Window
         {
             _unlockChip?.Hide();
         }
+    }
+
+    /// <summary>
+    /// Keeps every EQBuddy window above a fullscreen CrossOver game on macOS. Topmost alone
+    /// is not enough — see <see cref="MacOverlayLevel"/> — and the raise is scoped to the
+    /// game being frontmost so EQBuddy does not sit over every other app's fullscreen.
+    /// </summary>
+    private static void EnsureOverlayLevel()
+    {
+        if (OperatingSystem.IsMacOS()) MacOverlayLevel.Update();
     }
 
     private void OnGear(object? sender, EventArgs e) => _root.ContextMenu?.Open(_root);

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -50,6 +50,16 @@ public sealed class OptionsWindow : Window
     private readonly StackPanel _cardsPanel = new();
     private bool _ready;
 
+    /// <summary>Below this the rule editor's Name and Match boxes collapse to a character
+    /// or two; the same floor and ceiling the WPF window uses.</summary>
+    private const double MinOptionsWidth = 390;
+    private const double MaxOptionsWidth = 900;
+
+    private bool _resizing;
+    private double _resizeStartWidth;
+    private int _resizeStartLeft;      // screen pixels — the space Position lives in
+    private int _resizeStartPointerX;  // ditto
+
     private static readonly string[] SoundNames = Array.ConvertAll(MainWindow.AlertSounds, x => x.Name);
 
     public OptionsWindow(MainWindow main)
@@ -57,24 +67,40 @@ public sealed class OptionsWindow : Window
         _main = main;
         _main.RegisterOptionsWindow(this);
         Title = "EQBuddy Options";
-        SizeToContent = SizeToContent.WidthAndHeight;
+        // Height follows the content, width is the user's — as on Windows. Sizing to
+        // content in both directions is what made this window unresizable: the width was
+        // whatever the panel measured, and turning CanResize on would not have helped,
+        // because custom chrome leaves no native resize border to drag. The side grips
+        // below are the affordance on both platforms.
+        SizeToContent = SizeToContent.Height;
         WindowDecorations = global::Avalonia.Controls.WindowDecorations.None;
         TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
         Background = Brushes.Transparent;
         Topmost = true;
         ShowInTaskbar = false;
         CanResize = false;
+        MinWidth = MinOptionsWidth;
+        MaxWidth = MaxOptionsWidth;
+        Width = Math.Clamp(main.Settings.OptionsWidth, MinOptionsWidth, MaxOptionsWidth);
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
         _contentScroll.Content = BuildContent();
-        Content = new Border
+        Content = new Grid
         {
-            Background = AppTheme.BgBrush,
-            CornerRadius = new CornerRadius(10),
-            BorderBrush = AppTheme.BorderBrush,
-            BorderThickness = new Thickness(1),
-            Child = _contentScroll,
+            Children =
+            {
+                new Border
+                {
+                    Background = AppTheme.BgBrush,
+                    CornerRadius = new CornerRadius(10),
+                    BorderBrush = AppTheme.BorderBrush,
+                    BorderThickness = new Thickness(1),
+                    Child = _contentScroll,
+                },
+                Grip(leftEdge: true),
+                Grip(leftEdge: false),
+            },
         };
-        Opened += (_, _) => UpdateHeightLimit();
+        Opened += (_, _) => ClampToScreen();
         PointerPressed += OnDrag;
         _scaleSlider.Value = main.UiScale;
         _opacitySlider.Value = main.WidgetOpacity;
@@ -194,7 +220,7 @@ public sealed class OptionsWindow : Window
         _ready = true;
     }
 
-    private void UpdateHeightLimit()
+    private void ClampToScreen()
     {
         var screen = Screens.ScreenFromWindow(this);
         if (screen is null) return;
@@ -206,11 +232,79 @@ public sealed class OptionsWindow : Window
         var availableHeight = Math.Max(240, workingHeight - 40);
         MaxHeight = availableHeight;
         _contentScroll.MaxHeight = availableHeight - 2; // outer border
+
+        // Width needs the same treatment for a different reason: a width saved on a wide
+        // monitor would otherwise open wider than a narrow one, putting one or both grips
+        // off-screen where they cannot be grabbed to bring it back.
+        var workingWidth = screen.WorkingArea.Width / screen.Scaling;
+        MaxWidth = Math.Max(MinOptionsWidth + 1, Math.Min(MaxOptionsWidth, workingWidth - 24));
+        if (Bounds.Width > MaxWidth) Width = MaxWidth;
     }
+
+    /// <summary>An invisible strip down one side of the window. It renders as bare edge —
+    /// the cursor is the whole affordance — matching the WPF grips.</summary>
+    private Border Grip(bool leftEdge)
+    {
+        var grip = new Border
+        {
+            Width = 8,
+            Background = Brushes.Transparent,
+            HorizontalAlignment = leftEdge ? HorizontalAlignment.Left : HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Cursor = new Cursor(StandardCursorType.SizeWestEast),
+        };
+        ToolTip.SetTip(grip, "Drag to resize");
+        grip.PointerPressed += (_, e) => BeginResize(grip, e);
+        grip.PointerMoved += (_, e) => ResizeTo(e, leftEdge);
+        grip.PointerReleased += (_, e) => EndResize(e);
+        return grip;
+    }
+
+    private void BeginResize(Control grip, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(grip).Properties.IsLeftButtonPressed) return;
+        _resizing = true;
+        _resizeStartWidth = Bounds.Width;
+        _resizeStartLeft = Position.X;
+        _resizeStartPointerX = PointerScreenX(e);
+        e.Pointer.Capture(grip);
+        // Without this the window-wide handler also sees the press and starts a move drag,
+        // so the window would walk off with the pointer instead of resizing.
+        e.Handled = true;
+    }
+
+    private void ResizeTo(PointerEventArgs e, bool leftEdge)
+    {
+        if (!_resizing) return;
+        var moved = (PointerScreenX(e) - _resizeStartPointerX) / RenderScaling;
+        var width = Math.Clamp(leftEdge ? _resizeStartWidth - moved : _resizeStartWidth + moved,
+            MinWidth, MaxWidth);
+        // Growing leftwards has to move the window as well, or the left edge would stay put
+        // and the window would grow out of its right side, away from the pointer.
+        if (leftEdge)
+            Position = Position.WithX(
+                _resizeStartLeft + (int)Math.Round((_resizeStartWidth - width) * RenderScaling));
+        Width = width;
+    }
+
+    private void EndResize(PointerReleasedEventArgs e)
+    {
+        if (!_resizing) return;
+        _resizing = false;
+        e.Pointer.Capture(null);
+        _main.Settings.OptionsWidth = Bounds.Width;
+        _main.PersistSettings();
+    }
+
+    /// <summary>Pointer X in screen pixels. The window moves and resizes under the pointer
+    /// mid-drag, so a window-relative position is a moving ruler; the screen is a fixed one.</summary>
+    private int PointerScreenX(PointerEventArgs e) => this.PointToScreen(e.GetPosition(this)).X;
 
     private Control BuildContent()
     {
-        var panel = new StackPanel { Margin = new Thickness(16), Width = 520 };
+        // No fixed width: the panel fills whatever the window is dragged to, and the rule
+        // rows' star column absorbs the difference.
+        var panel = new StackPanel { Margin = new Thickness(16) };
         var title = new Grid { Margin = new Thickness(0, 0, 0, 10) };
         title.Children.Add(new TextBlock
         {
@@ -287,7 +381,8 @@ public sealed class OptionsWindow : Window
 
         panel.Children.Add(Heading("Overlay cards", new Thickness(0, 14, 0, 2)));
         panel.Children.Add(_cardsPanel);
-        panel.Children.Add(AppTheme.DimText("Size also scales all text. Changes apply instantly and are saved.",
+        panel.Children.Add(AppTheme.DimText(
+            "Size also scales all text. Changes apply instantly and are saved. Drag either side edge to widen this window.",
             new Thickness(0, 8, 0, 0)));
         return panel;
     }

--- a/tests/EQBuddy.Avalonia.Tests/OptionsRenderTests.cs
+++ b/tests/EQBuddy.Avalonia.Tests/OptionsRenderTests.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Headless;
+using Avalonia.Input;
 using Avalonia.Headless.XUnit;
 using Avalonia.VisualTree;
 using EQBuddy.Core;
@@ -66,6 +67,12 @@ public class OptionsRenderTests : IDisposable
         options.Show();
         return (main, options);
     }
+
+    /// <summary>The window's body scroller. Every TextBox and open ComboBox brings its own
+    /// ScrollViewer, so it is picked out by what it holds: the one margined panel.</summary>
+    private static ScrollViewer ContentScroll(OptionsWindow options) =>
+        options.GetVisualDescendants().OfType<ScrollViewer>()
+            .Single(s => s.Content is StackPanel { Margin.Left: 16 });
 
     [AvaloniaFact]
     public void OptionsRendersAFrame()
@@ -151,8 +158,7 @@ public class OptionsRenderTests : IDisposable
 
         var options = new OptionsWindow(main);
         options.Show();
-        var scroll = options.GetVisualDescendants().OfType<ScrollViewer>()
-            .Single(s => s.Content is StackPanel { Width: 520 });
+        var scroll = ContentScroll(options);
 
         Assert.Equal(global::Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
             scroll.VerticalScrollBarVisibility);
@@ -288,6 +294,121 @@ public class OptionsRenderTests : IDisposable
         filterPicker.SelectedIndex = (int)SpellFilter.ByName;
         Assert.True(pattern.IsVisible);
         Assert.Equal("Befriend", pattern.Text);
+
+        options.Close();
+        main.Close();
+    }
+
+    /// <summary>The window opens at the width the user last dragged it to, shared with WPF
+    /// through OptionsWidth — it used to size itself to a hardcoded 520 panel and stay there.
+    /// </summary>
+    [AvaloniaFact]
+    public void OptionsOpensAtTheSavedWidth()
+    {
+        var main = new MainWindow();
+        main.Show();
+        main.Settings.OptionsWidth = 640;
+
+        var options = new OptionsWindow(main);
+        options.Show();
+
+        Assert.Equal(640, options.Width, 1);
+        // The body fills it, less the 1px frame on each side — the panel inside no longer
+        // has a width of its own to hold the window open at.
+        Assert.Equal(638, ContentScroll(options).Bounds.Width, 1);
+
+        options.Close();
+        main.Close();
+    }
+
+    /// <summary>A width beyond the bounds is pulled back in, so a settings file carrying a
+    /// silly number cannot open a two-character-wide rule editor or a window off the screen.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(50, 390)]
+    [InlineData(4000, 900)]
+    public void ASavedWidthOutsideTheBoundsIsClamped(double saved, double expected)
+    {
+        var main = new MainWindow();
+        main.Show();
+        main.Settings.OptionsWidth = saved;
+
+        var options = new OptionsWindow(main);
+        options.Show();
+
+        Assert.Equal(expected, options.Width, 1);
+
+        options.Close();
+        main.Close();
+    }
+
+    /// <summary>Dragging the right grip widens the window and saves the result. Custom chrome
+    /// means there is no native resize border, so these grips are the only way to resize —
+    /// on macOS there was previously no way at all.</summary>
+    [AvaloniaFact]
+    public void DraggingTheRightEdgeWidensTheWindowAndSavesIt()
+    {
+        var main = new MainWindow();
+        main.Show();
+        main.Settings.OptionsWidth = 500;
+        var options = new OptionsWindow(main);
+        options.Show();
+
+        var grabX = options.Bounds.Width - 4;
+        options.MouseDown(new global::Avalonia.Point(grabX, 100), MouseButton.Left);
+        options.MouseMove(new global::Avalonia.Point(grabX + 120, 100));
+        options.MouseUp(new global::Avalonia.Point(grabX + 120, 100), MouseButton.Left);
+
+        Assert.Equal(620, options.Width, 1);
+        Assert.Equal(620, main.Settings.OptionsWidth, 1);
+
+        options.Close();
+        main.Close();
+    }
+
+    /// <summary>The left grip grows the window leftwards: the width goes up and the window
+    /// moves by the same amount, so the right edge stays where the user left it.</summary>
+    [AvaloniaFact]
+    public void DraggingTheLeftEdgeGrowsLeftwardsAndKeepsTheRightEdgeStill()
+    {
+        var main = new MainWindow();
+        main.Show();
+        main.Settings.OptionsWidth = 500;
+        var options = new OptionsWindow(main);
+        options.Show();
+        var startRight = options.Position.X + (int)Math.Round(options.Bounds.Width * options.RenderScaling);
+
+        options.MouseDown(new global::Avalonia.Point(4, 100), MouseButton.Left);
+        options.MouseMove(new global::Avalonia.Point(-80, 100));
+        options.MouseUp(new global::Avalonia.Point(-80, 100), MouseButton.Left);
+
+        Assert.Equal(584, options.Width, 1);   // grabbed at 4, released at -80
+        var right = options.Position.X + (int)Math.Round(options.Bounds.Width * options.RenderScaling);
+        Assert.True(Math.Abs(right - startRight) <= 1,
+            $"right edge moved from {startRight} to {right}");
+
+        options.Close();
+        main.Close();
+    }
+
+    /// <summary>The grips must not also start a window move — the press is theirs alone,
+    /// or the window walks off with the pointer instead of resizing.</summary>
+    [AvaloniaFact]
+    public void PressingAGripDoesNotDragTheWindow()
+    {
+        var main = new MainWindow();
+        main.Show();
+        main.Settings.OptionsWidth = 500;
+        var options = new OptionsWindow(main);
+        options.Show();
+        var start = options.Position;
+
+        var grabX = options.Bounds.Width - 4;
+        options.MouseDown(new global::Avalonia.Point(grabX, 100), MouseButton.Left);
+        options.MouseMove(new global::Avalonia.Point(grabX + 60, 140));
+        options.MouseUp(new global::Avalonia.Point(grabX + 60, 140), MouseButton.Left);
+
+        Assert.Equal(start, options.Position);
 
         options.Close();
         main.Close();


### PR DESCRIPTION
A number of improvements to the Avalonia port targeting macOS - fixes the resize on the Options window, and the various widgets will actually stay above the game (at least with CrossOver - haven't tested other Wines but likely will work there too).