### PR TITLE
Add gear shopping list import

### DIFF
--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -167,6 +167,11 @@ public sealed class AppSettings
     /// for quests finished before this feature existed. Marking one complete also
     /// checks its items (they were acquired and then handed over).</summary>
     public List<string> SkyQuestCompleted { get; set; } = [];
+    /// <summary>Imported equipment shopping list from EQ Legends Tools, shown as a
+    /// lightweight in-game checklist. Manual checkboxes: imports replace the list,
+    /// toggles persist until the next import or clear.</summary>
+    public List<GearChecklistItem> GearChecklist { get; set; } = [];
+    public string GearChecklistName { get; set; } = "";
     /// <summary>Color theme key (see EQBuddy.UI.Shared.ThemeCatalog); defaults to the
     /// original parchment-and-brass look so existing installs don't change on upgrade.</summary>
     public string Theme { get; set; } = "ParchmentBrass";
@@ -330,6 +335,7 @@ public sealed class AppSettings
         // happens to save settings.
         var changed = settings.ApplyDefaultRules();
         changed |= settings.ApplyDefaultSkyQuestSection();
+        changed |= settings.ApplyDefaultGearSection();
         changed |= settings.ApplyDefaultSkyQuestChecklist();
         if (changed | settings.TrackedRules.Any(r => r.IdWasGenerated))
             settings.Save();
@@ -385,6 +391,16 @@ public sealed class AppSettings
         return true;
     }
 
+    public bool ApplyDefaultGearSection()
+    {
+        if (SectionOrder.Count == 0 || SectionOrder.Contains("gear")) return false;
+        var sky = SectionOrder.IndexOf("sky");
+        var motes = SectionOrder.IndexOf("motes");
+        var anchor = sky >= 0 ? sky : motes;
+        SectionOrder.Insert(anchor < 0 ? SectionOrder.Count : anchor + 1, "gear");
+        return true;
+    }
+
     public bool ApplyDefaultSkyQuestChecklist()
     {
         SkyQuestChecklist ??= [];
@@ -435,4 +451,13 @@ public sealed class SkyQuestChecklistItem
         Source = Source,
         Acquired = Acquired,
     };
+}
+
+public sealed class GearChecklistItem
+{
+    public string Slot { get; set; } = "";
+    public string Item { get; set; } = "";
+    public string Source { get; set; } = "";
+    public string Url { get; set; } = "";
+    public bool Acquired { get; set; }
 }

--- a/src/EQBuddy.Core/GearChecklistImporter.cs
+++ b/src/EQBuddy.Core/GearChecklistImporter.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace EQBuddy.Core;
+
+public sealed class GearChecklistImportResult
+{
+    public string Name { get; set; } = "";
+    public List<GearChecklistItem> Items { get; set; } = [];
+}
+
+public static partial class GearChecklistImporter
+{
+    public static GearChecklistImportResult ImportFile(string path)
+    {
+        var html = File.ReadAllText(path);
+        var result = ImportHtml(html);
+        if (result.Name.Length == 0)
+            result.Name = Path.GetFileNameWithoutExtension(path);
+        return result;
+    }
+
+    public static GearChecklistImportResult ImportHtml(string html)
+    {
+        var result = new GearChecklistImportResult { Name = PageTitle(html) };
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (Match slot in SlotCardRegex().Matches(html))
+        {
+            var heading = Clean(slot.Groups["slot"].Value);
+            var body = slot.Groups["body"].Value;
+            if (heading.Length == 0) continue;
+
+            var itemMatch = ItemLinkRegex().Match(body);
+            if (!itemMatch.Success) continue;
+
+            var item = Clean(itemMatch.Groups["item"].Value);
+            if (item.Length == 0) continue;
+
+            var url = WebUtility.HtmlDecode(itemMatch.Groups["href"].Value).Trim();
+            var source = string.Join(" | ", SourceLineRegex().Matches(body)
+                .Select(m => Clean(m.Groups["source"].Value))
+                .Where(s => s.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase));
+            var key = $"{heading}|{item}";
+            if (!seen.Add(key)) continue;
+
+            result.Items.Add(new GearChecklistItem
+            {
+                Slot = TitleSlot(heading),
+                Item = item,
+                Source = source,
+                Url = url,
+            });
+        }
+
+        return result;
+    }
+
+    private static string PageTitle(string html)
+    {
+        var title = TitleRegex().Match(html);
+        if (!title.Success) return "";
+        var clean = Clean(title.Groups["title"].Value);
+        if (clean.EndsWith(" - EQ Legends Tools", StringComparison.OrdinalIgnoreCase))
+            clean = clean[..^" - EQ Legends Tools".Length];
+        return clean.EndsWith(" Shopping List", StringComparison.OrdinalIgnoreCase)
+            ? clean[..^" Shopping List".Length]
+            : clean;
+    }
+
+    private static string Clean(string value)
+    {
+        var noTags = TagRegex().Replace(value, " ");
+        var decoded = WebUtility.HtmlDecode(noTags);
+        return WhitespaceRegex().Replace(decoded, " ").Trim();
+    }
+
+    private static string TitleSlot(string value)
+    {
+        if (value.All(c => !char.IsLetter(c) || char.IsUpper(c)))
+            return string.Join(" ", value.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Select(w => w.Length <= 3 ? w : char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant()));
+        return value;
+    }
+
+    [GeneratedRegex("<title[^>]*>(?<title>.*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex TitleRegex();
+
+    [GeneratedRegex("<div\\s+class=[\"']slot-heading[\"'][^>]*>(?<slot>.*?)</div>(?<body>.*?)(?=<div\\s+class=[\"']slot-heading[\"']|</body>|</html>|$)", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex SlotCardRegex();
+
+    [GeneratedRegex("<a\\s+class=[\"']item-link[\"'][^>]*href=[\"'](?<href>[^\"']*)[\"'][^>]*>(?<item>.*?)</a>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex ItemLinkRegex();
+
+    [GeneratedRegex("<div\\s+class=[\"']source-line[\"'][^>]*>(?<source>.*?)</div>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex SourceLineRegex();
+
+    [GeneratedRegex("<[^>]+>", RegexOptions.Singleline)]
+    private static partial Regex TagRegex();
+
+    [GeneratedRegex("\\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/src/EQBuddy.UI.Shared/OptionsViewModel.cs
+++ b/src/EQBuddy.UI.Shared/OptionsViewModel.cs
@@ -115,7 +115,7 @@ public static class OverlaySections
     [
         ("combat", "Combat"), ("healing", "Healing"), ("kills", "Kills"), ("loot", "Loot"),
         ("motes", "Motes"),
-        ("sky", "Sky Quest"),
+        ("sky", "Sky Quest"), ("gear", "Gear"),
         // Key stays "tracked" — it's persisted in SectionOrder/HiddenSections. Only the
         // label follows the feature's rename from tracked loot to watch rules (#5).
         ("tracked", "Watch"), ("buffs", "Buffs"), ("raids", "Raids"), ("money", "Money"), ("progress", "Progress"),

--- a/src/EQBuddy/MainWindow.xaml
+++ b/src/EQBuddy/MainWindow.xaml
@@ -561,6 +561,30 @@
                 </StackPanel>
             </Expander>
 
+            <Expander x:Name="GearSection" Style="{StaticResource Section}">
+                <Expander.Header>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="&#x1F6E1; Gear" FontSize="13"/>
+                        <TextBlock x:Name="GearHeader" Grid.Column="1" Style="{StaticResource StatValue}" Text="0/0"/>
+                    </Grid>
+                </Expander.Header>
+                <StackPanel>
+                    <TextBlock x:Name="GearListName" Style="{StaticResource Dim}"
+                               TextWrapping="Wrap" Margin="0,2,0,4"/>
+                    <ScrollViewer MaxHeight="320"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  PanningMode="VerticalOnly"
+                                  Padding="0,0,4,0">
+                        <ItemsControl x:Name="GearChecklistList"/>
+                    </ScrollViewer>
+                </StackPanel>
+            </Expander>
+
             <Expander x:Name="TrackedSection" Style="{StaticResource Section}" Visibility="Collapsed">
                 <Expander.Header>
                     <Grid>

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -36,6 +36,7 @@ public partial class MainWindow : Window
     // Rebuilding 200+ checkboxes every UI tick is the one thing this overlay never
     // does elsewhere — the checklist re-renders only when a box actually changed.
     private bool _skyQuestDirty = true;
+    private bool _gearChecklistDirty = true;
     // Perf audit #1: the version last painted into the expanded sections, and the
     // last time a full paint happened (10 s heartbeat keeps time-derived rates live).
     private long _lastRenderedVersion = -1;
@@ -177,7 +178,7 @@ public partial class MainWindow : Window
 
         if (Environment.GetEnvironmentVariable("EQBUDDY_EXPAND") == "1")
             foreach (var ex in new[] { CombatSection, HealingSection, KillsSection, LootSection,
-                         MotesSection, SkyQuestSection, TrackedSection, MoneySection,
+                         MotesSection, SkyQuestSection, GearSection, TrackedSection, MoneySection,
                          ProgressSection, FactionSection, MiscSection })
                 ex.IsExpanded = true;
 
@@ -319,9 +320,8 @@ public partial class MainWindow : Window
     {
         ["combat"] = CombatSection, ["healing"] = HealingSection, ["kills"] = KillsSection,
         ["loot"] = LootSection, ["motes"] = MotesSection, ["sky"] = SkyQuestSection,
-        ["tracked"] = TrackedSection,
-        ["buffs"] = BuffsSection,
-        ["raids"] = RaidsSection,
+        ["gear"] = GearSection, ["tracked"] = TrackedSection,
+        ["buffs"] = BuffsSection, ["raids"] = RaidsSection,
         ["money"] = MoneySection,
         ["progress"] = ProgressSection, ["faction"] = FactionSection, ["misc"] = MiscSection,
     };
@@ -1575,6 +1575,7 @@ public partial class MainWindow : Window
         var motes = Motes.Summarize(s.Loot, s.Elapsed);
         MotesHeader.Text = motes.Total > 0 ? $"{motes.Total} · {motes.PerHour:0.#}/hr" : "0";
         UpdateSkyQuestChecklist(s);
+        UpdateGearHeaderOnly();
         MoneyHeader.Text = StatsSnapshot.FormatCoin(s.Copper);
         ProgressHeader.Text = $"{s.XpPercent:0.0}% xp"
             + (s.Levels.Count > 0 ? $", +{s.Levels.Count} lvl" : "")
@@ -1765,6 +1766,12 @@ public partial class MainWindow : Window
         {
             RenderSkyQuestChecklist();
             _skyQuestDirty = false;
+        }
+
+        if (GearSection.IsExpanded && _gearChecklistDirty)
+        {
+            RenderGearChecklist();
+            _gearChecklistDirty = false;
         }
 
         if (MoneySection.IsExpanded)
@@ -2018,6 +2025,114 @@ public partial class MainWindow : Window
     private static string FormatAge(TimeSpan age) => age.TotalMinutes < 1
         ? $"{Math.Max(0, (int)age.TotalSeconds)}s"
         : age.TotalHours < 1 ? $"{(int)age.TotalMinutes}m" : $"{(int)age.TotalHours}h {age.Minutes}m";
+
+    internal void ImportGearChecklist(GearChecklistImportResult import)
+    {
+        _settings.GearChecklist = import.Items;
+        _settings.GearChecklistName = import.Name;
+        _settings.Save();
+        _gearChecklistDirty = true;
+        UpdateGearHeaderOnly();
+        RefreshUi();
+    }
+
+    internal void ClearGearChecklist()
+    {
+        _settings.GearChecklist.Clear();
+        _settings.GearChecklistName = "";
+        _settings.Save();
+        _gearChecklistDirty = true;
+        UpdateGearHeaderOnly();
+        RefreshUi();
+    }
+
+    private void RenderGearChecklist()
+    {
+        GearChecklistList.Items.Clear();
+        var total = _settings.GearChecklist.Count;
+        if (total == 0)
+        {
+            GearListName.Text = "Import an EQ Legends Tools shopping-list HTML in Options.";
+            GearChecklistList.Items.Add(new TextBlock
+            {
+                Text = "No gear list imported.",
+                FontSize = 11,
+                Foreground = (Brush)FindResource("DimBrush"),
+                TextWrapping = TextWrapping.Wrap,
+            });
+            UpdateGearHeaderOnly();
+            return;
+        }
+
+        var done = _settings.GearChecklist.Count(i => i.Acquired);
+        GearListName.Text = _settings.GearChecklistName.Length > 0
+            ? $"{_settings.GearChecklistName} - {done}/{total}"
+            : $"{done}/{total} imported gear pieces";
+
+        foreach (var item in _settings.GearChecklist)
+        {
+            var text = new StackPanel();
+            text.Children.Add(new TextBlock
+            {
+                Text = item.Slot,
+                FontSize = 10,
+                Foreground = (Brush)FindResource("DimBrush"),
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            });
+            text.Children.Add(new TextBlock
+            {
+                Text = item.Item,
+                FontSize = 12,
+                Foreground = (Brush)FindResource("TextBrush"),
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            });
+            if (item.Source.Length > 0)
+            {
+                text.Children.Add(new TextBlock
+                {
+                    Text = item.Source,
+                    FontSize = 10,
+                    Foreground = (Brush)FindResource("DimBrush"),
+                    TextTrimming = TextTrimming.CharacterEllipsis,
+                });
+            }
+
+            var tip = $"{item.Slot}: {item.Item}";
+            if (item.Source.Length > 0) tip += "\n" + item.Source;
+            if (item.Url.Length > 0) tip += "\n" + item.Url;
+            var check = new CheckBox
+            {
+                IsChecked = item.Acquired,
+                Content = text,
+                Margin = new Thickness(0, 2, 0, 2),
+                ToolTip = tip,
+            };
+            check.Checked += (_, _) => OnGearToggled(item, true);
+            check.Unchecked += (_, _) => OnGearToggled(item, false);
+            GearChecklistList.Items.Add(check);
+        }
+
+        UpdateGearHeaderOnly();
+    }
+
+    private void OnGearToggled(GearChecklistItem item, bool acquired)
+    {
+        item.Acquired = acquired;
+        _settings.Save();
+        UpdateGearHeaderOnly();
+        var total = _settings.GearChecklist.Count;
+        var done = _settings.GearChecklist.Count(i => i.Acquired);
+        GearListName.Text = _settings.GearChecklistName.Length > 0
+            ? $"{_settings.GearChecklistName} - {done}/{total}"
+            : $"{done}/{total} imported gear pieces";
+    }
+
+    private void UpdateGearHeaderOnly()
+    {
+        var total = _settings.GearChecklist.Count;
+        var acquired = _settings.GearChecklist.Count(i => i.Acquired);
+        GearHeader.Text = $"{acquired}/{total}";
+    }
 
     private void UpdateSkyQuestChecklist(StatsSnapshot s)
     {

--- a/src/EQBuddy/OptionsWindow.xaml
+++ b/src/EQBuddy/OptionsWindow.xaml
@@ -294,8 +294,22 @@
                        Foreground="{DynamicResource AccentBrush}" Margin="0,0,0,2"/>
             <TextBlock Text="Every card you leave visible shows on the widget — one with nothing yet says so in a line and fills in as it happens."
                        Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="0,0,0,2"/>
+            <TextBlock Text="Gear checklist" FontSize="12" FontWeight="SemiBold"
+                       Foreground="{DynamicResource AccentBrush}" Margin="0,12,0,2"/>
+            <TextBlock Text="Import the exported shopping-list HTML from EQ Legends Tools, then show it as a checklist in the Gear overlay card."
+                       Style="{StaticResource Dim}" TextWrapping="Wrap"/>
+            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                <Button x:Name="GearToolsBtn" Content="Open EQ Legends Tools" Style="{StaticResource ActionButton}"
+                        FontSize="12" Click="OnOpenGearTools"
+                        ToolTip="Open the EQ Legends Tools character sheet/shopping-list page"/>
+                <Button x:Name="GearImportBtn" Content="Import gear list..." Style="{StaticResource ActionButton}"
+                        FontSize="12" Margin="6,0,0,0" Click="OnImportGearChecklist"/>
+                <Button x:Name="GearClearBtn" Content="Clear" Style="{StaticResource ActionButton}"
+                        FontSize="12" Margin="6,0,0,0" Click="OnClearGearChecklist"/>
+            </StackPanel>
+            <TextBlock x:Name="GearImportStatus" Style="{StaticResource Dim}" TextWrapping="Wrap"
+                       Margin="0,4,0,0"/>
             <StackPanel x:Name="CardsPanel"/>
-
             <TextBlock Text="Breakout windows" FontSize="12" FontWeight="SemiBold"
                        Foreground="{DynamicResource AccentBrush}" Margin="0,14,0,2"/>
             <TextBlock Text="Which floating windows may open while minimized (each still needs its ⭐ star — or a 📌 pinned rule for Watch). Unticking one here is the same as its ✕."

--- a/src/EQBuddy/OptionsWindow.xaml.cs
+++ b/src/EQBuddy/OptionsWindow.xaml.cs
@@ -74,6 +74,7 @@ public partial class OptionsWindow : Window
 
         BuildRulesEditor();
         BuildCardsEditor();
+        UpdateGearImportStatus();
         UpdateCustomColorsPanel();
         BuildBreakoutChecks();
 
@@ -1268,6 +1269,70 @@ public partial class OptionsWindow : Window
     {
         _main.ApplySectionLayout();
         BuildCardsEditor();
+    }
+
+    private void UpdateGearImportStatus()
+    {
+        var total = _main.Settings.GearChecklist.Count;
+        if (total == 0)
+        {
+            GearImportStatus.Text = "No gear list imported.";
+            GearClearBtn.IsEnabled = false;
+            return;
+        }
+
+        var done = _main.Settings.GearChecklist.Count(i => i.Acquired);
+        var name = _main.Settings.GearChecklistName.Length > 0
+            ? _main.Settings.GearChecklistName
+            : "Imported gear list";
+        GearImportStatus.Text = $"{name}: {done}/{total} checked.";
+        GearClearBtn.IsEnabled = true;
+    }
+
+    private void OnImportGearChecklist(object sender, RoutedEventArgs e)
+    {
+        var dlg = new Microsoft.Win32.OpenFileDialog
+        {
+            Title = "Import EQ Legends Tools shopping list",
+            Filter = "HTML files (*.html;*.htm)|*.html;*.htm|All files (*.*)|*.*",
+        };
+        if (dlg.ShowDialog(this) != true) return;
+
+        try
+        {
+            var import = GearChecklistImporter.ImportFile(dlg.FileName);
+            if (import.Items.Count == 0)
+            {
+                GearImportStatus.Text = "No gear items found in that file.";
+                return;
+            }
+
+            _main.ImportGearChecklist(import);
+            UpdateGearImportStatus();
+        }
+        catch (Exception ex)
+        {
+            GearImportStatus.Text = $"Import failed: {ex.Message}";
+        }
+    }
+
+    private void OnOpenGearTools(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(
+                "https://eqlegendstools.com/char-sheet/") { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            GearImportStatus.Text = $"Could not open EQ Legends Tools: {ex.Message}";
+        }
+    }
+
+    private void OnClearGearChecklist(object sender, RoutedEventArgs e)
+    {
+        _main.ClearGearChecklist();
+        UpdateGearImportStatus();
     }
 
     private System.Windows.Controls.Button CardButton(string glyph, string tip, int column, Action action)

--- a/tests/EQBuddy.Tests/GearChecklistImporterTests.cs
+++ b/tests/EQBuddy.Tests/GearChecklistImporterTests.cs
@@ -1,0 +1,54 @@
+using EQBuddy.Core;
+
+namespace EQBuddy.Tests;
+
+public sealed class GearChecklistImporterTests
+{
+    [Fact]
+    public void ImportsEqLegendsToolsShoppingListSlots()
+    {
+        const string html = """
+            <!doctype html>
+            <html>
+            <head><title>Erudite BRD/NEC/WIZ Shopping List - EQ Legends Tools</title></head>
+            <body>
+              <div class="slot-card">
+                <div class="slot-heading">HEAD</div>
+                <a class="item-link" href="https://eqlwiki.com/Carmine_Turban">Carmine Turban</a>
+                <div class="source-lines">
+                  <div class="source-line">Drops From: Plane of Fear: various mobs</div>
+                  <div class="source-line">Drops From: Plane of Hate: <a href="https://eqlwiki.com/a_spite_golem">a spite golem</a></div>
+                </div>
+              </div>
+              <div class="slot-card">
+                <div class="slot-heading">EAR 1</div>
+                <a class="item-link" href="https://eqlwiki.com/Ivandyr%27s_Hoop">Ivandyr&#39;s Hoop</a>
+                <div class="source-line">Reward from Quest: <a href="https://eqlwiki.com/Lynuga">Lynuga's Gem Collection</a></div>
+              </div>
+              <div class="slot-card empty">
+                <div class="slot-heading">AMMO</div>
+                <p>No item selected</p>
+              </div>
+            </body>
+            </html>
+            """;
+
+        var result = GearChecklistImporter.ImportHtml(html);
+
+        Assert.Equal("Erudite BRD/NEC/WIZ", result.Name);
+        Assert.Collection(result.Items,
+            item =>
+            {
+                Assert.Equal("Head", item.Slot);
+                Assert.Equal("Carmine Turban", item.Item);
+                Assert.Equal("Drops From: Plane of Fear: various mobs | Drops From: Plane of Hate: a spite golem", item.Source);
+                Assert.Equal("https://eqlwiki.com/Carmine_Turban", item.Url);
+            },
+            item =>
+            {
+                Assert.Equal("EAR 1", item.Slot);
+                Assert.Equal("Ivandyr's Hoop", item.Item);
+                Assert.Equal("Reward from Quest: Lynuga's Gem Collection", item.Source);
+            });
+    }
+}

--- a/tests/EQBuddy.Tests/OptionsViewModelTests.cs
+++ b/tests/EQBuddy.Tests/OptionsViewModelTests.cs
@@ -53,6 +53,7 @@ public sealed class OptionsViewModelTests
         Assert.Equal(OverlaySections.Catalog.Length, s.SectionOrder.Count);
         Assert.DoesNotContain("bogus", s.SectionOrder);
         Assert.Contains(vm.Cards, c => c.Key == "sky" && c.Title == "Sky Quest");
+        Assert.Contains(vm.Cards, c => c.Key == "gear" && c.Title == "Gear");
 
         vm.MoveCard("kills", -1);                        // top can't move up
         Assert.Equal("kills", s.SectionOrder[0]);
@@ -134,5 +135,21 @@ public sealed class OptionsViewModelTests
         Assert.False(settings.ApplyDefaultSkyQuestChecklist());
         Assert.Equal(count, settings.SkyQuestChecklist.Count);
         Assert.True(settings.SkyQuestChecklist[0].Acquired);
+    }
+
+    [Fact]
+    public void GearSectionSlotsInAfterSky()
+    {
+        var settings = new AppSettings { SectionOrder = ["combat", "motes", "sky", "tracked"] };
+
+        Assert.True(settings.ApplyDefaultGearSection());
+        Assert.Equal(["combat", "motes", "sky", "gear", "tracked"], settings.SectionOrder);
+        Assert.False(settings.ApplyDefaultGearSection());
+
+        var noSky = new AppSettings { SectionOrder = ["combat", "motes", "tracked"] };
+        Assert.True(noSky.ApplyDefaultGearSection());
+        Assert.Equal(["combat", "motes", "gear", "tracked"], noSky.SectionOrder);
+
+        Assert.False(new AppSettings().ApplyDefaultGearSection());
     }
 }


### PR DESCRIPTION
## Summary

Adds a generic Gear checklist overlay card driven by EQ Legends Tools shopping-list exports.

- Adds a Core importer for EQ Legends Tools shopping-list HTML exports, including slot, item, item URL, and source/drop lines.
- Persists imported gear checklists and manual acquired checkmarks in app settings.
- Adds a scrollable Gear overlay card with imported item/source rows and completion counts.
- Adds Options controls to open EQ Legends Tools, import an exported `.html` shopping list, show import status, and clear the current list.
- Adds the Gear card to overlay card ordering/hide controls for existing installs.

## Why

Players can already build/share shopping lists on EQ Legends Tools, but then have to alt-tab or use a separate file while playing. This lets that exported list live in EQBuddy as an in-game checklist.

## Validation

- `dotnet test tests/EQBuddy.Tests/EQBuddy.Tests.csproj -c Release --logger "console;verbosity=minimal"` - 840 passed
- `dotnet build src/EQBuddy/EQBuddy.csproj -c Release` - succeeded, 0 warnings/errors

Note: the test run still reports an existing `xUnit1031` analyzer warning in `ZoneMapTests.cs`, unrelated to this change.
