### PR TITLE
Add Epic checklist prototype

### DIFF
--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -457,8 +457,24 @@ public sealed class AppSettings
         var changed = false;
         foreach (var item in EpicQuestDefaults.Items())
         {
-            if (EpicQuestChecklist.Any(i => string.Equals(i.Id, item.Id, StringComparison.Ordinal)))
+            var existing = EpicQuestChecklist.FirstOrDefault(i => string.Equals(i.Id, item.Id, StringComparison.Ordinal));
+            if (existing is not null)
+            {
+                if (existing.QuestName == item.QuestName &&
+                    existing.Reward == item.Reward &&
+                    existing.QuestItem == item.QuestItem &&
+                    existing.Qty == item.Qty &&
+                    existing.Source == item.Source)
+                    continue;
+
+                existing.QuestName = item.QuestName;
+                existing.Reward = item.Reward;
+                existing.QuestItem = item.QuestItem;
+                existing.Qty = item.Qty;
+                existing.Source = item.Source;
+                changed = true;
                 continue;
+            }
 
             EpicQuestChecklist.Add(item.Clone());
             changed = true;

--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -176,6 +176,12 @@ public sealed class AppSettings
     /// toggles persist until the next import or clear.</summary>
     public List<GearChecklistItem> GearChecklist { get; set; } = [];
     public string GearChecklistName { get; set; } = "";
+    /// <summary>Persistent Epic 1.0 checklist shown in the overlay. Seeded from the
+    /// shipped quest catalog; manual checkboxes for now, with room for log/inventory
+    /// auto-checking later.</summary>
+    public List<EpicQuestChecklistItem> EpicQuestChecklist { get; set; } = [];
+    public string EpicQuestClass { get; set; } = "";
+    public List<string> EpicQuestCompleted { get; set; } = [];
     /// <summary>Color theme key (see EQBuddy.UI.Shared.ThemeCatalog); defaults to the
     /// original parchment-and-brass look so existing installs don't change on upgrade.</summary>
     public string Theme { get; set; } = "ParchmentBrass";
@@ -351,7 +357,9 @@ public sealed class AppSettings
         var changed = settings.ApplyDefaultRules();
         changed |= settings.ApplyDefaultSkyQuestSection();
         changed |= settings.ApplyDefaultGearSection();
+        changed |= settings.ApplyDefaultEpicQuestSection();
         changed |= settings.ApplyDefaultSkyQuestChecklist();
+        changed |= settings.ApplyDefaultEpicQuestChecklist();
         if (changed | settings.TrackedRules.Any(r => r.IdWasGenerated))
             settings.Save();
         return settings;
@@ -416,6 +424,17 @@ public sealed class AppSettings
         return true;
     }
 
+    public bool ApplyDefaultEpicQuestSection()
+    {
+        if (SectionOrder.Count == 0 || SectionOrder.Contains("epic")) return false;
+        var gear = SectionOrder.IndexOf("gear");
+        var sky = SectionOrder.IndexOf("sky");
+        var motes = SectionOrder.IndexOf("motes");
+        var anchor = gear >= 0 ? gear : sky >= 0 ? sky : motes;
+        SectionOrder.Insert(anchor < 0 ? SectionOrder.Count : anchor + 1, "epic");
+        return true;
+    }
+
     public bool ApplyDefaultSkyQuestChecklist()
     {
         SkyQuestChecklist ??= [];
@@ -426,6 +445,22 @@ public sealed class AppSettings
                 continue;
 
             SkyQuestChecklist.Add(item.Clone());
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    public bool ApplyDefaultEpicQuestChecklist()
+    {
+        EpicQuestChecklist ??= [];
+        var changed = false;
+        foreach (var item in EpicQuestDefaults.Items())
+        {
+            if (EpicQuestChecklist.Any(i => string.Equals(i.Id, item.Id, StringComparison.Ordinal)))
+                continue;
+
+            EpicQuestChecklist.Add(item.Clone());
             changed = true;
         }
 
@@ -482,4 +517,28 @@ public sealed class GearChecklistItem
     public string Source { get; set; } = "";
     public string Url { get; set; } = "";
     public bool Acquired { get; set; }
+}
+
+public sealed class EpicQuestChecklistItem
+{
+    public string Id { get; set; } = "";
+    public string ClassName { get; set; } = "";
+    public string QuestName { get; set; } = "";
+    public string Reward { get; set; } = "";
+    public string QuestItem { get; set; } = "";
+    public int Qty { get; set; } = 1;
+    public string Source { get; set; } = "";
+    public bool Acquired { get; set; }
+
+    public EpicQuestChecklistItem Clone() => new()
+    {
+        Id = Id,
+        ClassName = ClassName,
+        QuestName = QuestName,
+        Reward = Reward,
+        QuestItem = QuestItem,
+        Qty = Qty,
+        Source = Source,
+        Acquired = Acquired,
+    };
 }

--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -462,6 +462,7 @@ public sealed class AppSettings
             {
                 if (existing.QuestName == item.QuestName &&
                     existing.Reward == item.Reward &&
+                    existing.Section == item.Section &&
                     existing.QuestItem == item.QuestItem &&
                     existing.Qty == item.Qty &&
                     existing.Order == item.Order &&
@@ -470,6 +471,7 @@ public sealed class AppSettings
 
                 existing.QuestName = item.QuestName;
                 existing.Reward = item.Reward;
+                existing.Section = item.Section;
                 existing.QuestItem = item.QuestItem;
                 existing.Qty = item.Qty;
                 existing.Order = item.Order;
@@ -543,6 +545,7 @@ public sealed class EpicQuestChecklistItem
     public string ClassName { get; set; } = "";
     public string QuestName { get; set; } = "";
     public string Reward { get; set; } = "";
+    public string Section { get; set; } = "";
     public string QuestItem { get; set; } = "";
     public int Qty { get; set; } = 1;
     public int Order { get; set; }
@@ -555,6 +558,7 @@ public sealed class EpicQuestChecklistItem
         ClassName = ClassName,
         QuestName = QuestName,
         Reward = Reward,
+        Section = Section,
         QuestItem = QuestItem,
         Qty = Qty,
         Order = Order,

--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -464,6 +464,7 @@ public sealed class AppSettings
                     existing.Reward == item.Reward &&
                     existing.QuestItem == item.QuestItem &&
                     existing.Qty == item.Qty &&
+                    existing.Order == item.Order &&
                     existing.Source == item.Source)
                     continue;
 
@@ -471,6 +472,7 @@ public sealed class AppSettings
                 existing.Reward = item.Reward;
                 existing.QuestItem = item.QuestItem;
                 existing.Qty = item.Qty;
+                existing.Order = item.Order;
                 existing.Source = item.Source;
                 changed = true;
                 continue;
@@ -543,6 +545,7 @@ public sealed class EpicQuestChecklistItem
     public string Reward { get; set; } = "";
     public string QuestItem { get; set; } = "";
     public int Qty { get; set; } = 1;
+    public int Order { get; set; }
     public string Source { get; set; } = "";
     public bool Acquired { get; set; }
 
@@ -554,6 +557,7 @@ public sealed class EpicQuestChecklistItem
         Reward = Reward,
         QuestItem = QuestItem,
         Qty = Qty,
+        Order = Order,
         Source = Source,
         Acquired = Acquired,
     };

--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -182,6 +182,7 @@ public sealed class AppSettings
     public List<EpicQuestChecklistItem> EpicQuestChecklist { get; set; } = [];
     public string EpicQuestClass { get; set; } = "";
     public List<string> EpicQuestCompleted { get; set; } = [];
+    public bool EpicQuestClassicOnly { get; set; }
     /// <summary>Color theme key (see EQBuddy.UI.Shared.ThemeCatalog); defaults to the
     /// original parchment-and-brass look so existing installs don't change on upgrade.</summary>
     public string Theme { get; set; } = "ParchmentBrass";
@@ -466,7 +467,8 @@ public sealed class AppSettings
                     existing.QuestItem == item.QuestItem &&
                     existing.Qty == item.Qty &&
                     existing.Order == item.Order &&
-                    existing.Source == item.Source)
+                    existing.Source == item.Source &&
+                    existing.AvailableInClassic == item.AvailableInClassic)
                     continue;
 
                 existing.QuestName = item.QuestName;
@@ -476,6 +478,7 @@ public sealed class AppSettings
                 existing.Qty = item.Qty;
                 existing.Order = item.Order;
                 existing.Source = item.Source;
+                existing.AvailableInClassic = item.AvailableInClassic;
                 changed = true;
                 continue;
             }
@@ -550,6 +553,7 @@ public sealed class EpicQuestChecklistItem
     public int Qty { get; set; } = 1;
     public int Order { get; set; }
     public string Source { get; set; } = "";
+    public bool AvailableInClassic { get; set; } = true;
     public bool Acquired { get; set; }
 
     public EpicQuestChecklistItem Clone() => new()
@@ -563,6 +567,7 @@ public sealed class EpicQuestChecklistItem
         Qty = Qty,
         Order = Order,
         Source = Source,
+        AvailableInClassic = AvailableInClassic,
         Acquired = Acquired,
     };
 }

--- a/src/EQBuddy.Core/Data/EpicQuestChecklist.json
+++ b/src/EQBuddy.Core/Data/EpicQuestChecklist.json
@@ -1,0 +1,3476 @@
+{
+  "classes": [
+    {
+      "className": "Bard",
+      "rows": [
+        {
+          "id": "epic-bard-0-maestro-s-symphony-page-24-top-talk-to-konia-swiftfoot-in-western-karana-guard-tower-4-receive-a",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Top",
+          "text": "Talk to Konia Swiftfoot in Western Karana (guard tower #4), receive a Torch of Misty",
+          "order": 0
+        },
+        {
+          "id": "epic-bard-1-maestro-s-symphony-page-24-top-give-the-torch-to-fajio-knejo-in-misty-thicket-receive-torch-of-r",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Top",
+          "text": "Give the torch to Fajio Knejo in Misty Thicket, receive Torch of Ro",
+          "order": 1
+        },
+        {
+          "id": "epic-bard-2-maestro-s-symphony-page-24-top-give-the-torch-to-andad-filla-in-south-ro-receive-torch-of-rathe",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Top",
+          "text": "Give the torch to Andad Filla in South Ro, receive Torch of Rathe",
+          "order": 2
+        },
+        {
+          "id": "epic-bard-3-maestro-s-symphony-page-24-top-give-the-torch-to-misty-tekchita-in-lake-rathetear-receive-ring-p",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Top",
+          "text": "Give the torch to Misty Tekchita in Lake Rathetear, receive ring Proof of Speed",
+          "order": 3
+        },
+        {
+          "id": "epic-bard-4-maestro-s-symphony-page-24-top-give-the-ring-to-konia-swiftfoot-in-w-karana-receive-maestro-s-sy",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Top",
+          "text": "Give the ring to Konia Swiftfoot in W Karana, receive Maestro's Symphony Page 24 Top",
+          "order": 4
+        },
+        {
+          "id": "epic-bard-5-maestro-s-symphony-page-24-bottom-ask-baenar-swiftsong-in-south-karana-what-doll-receive-solusek",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Bottom",
+          "text": "Ask Baenar Swiftsong in South Karana, \u201cwhat doll,\u201d receive Solusek Mining Company Invoice",
+          "order": 5
+        },
+        {
+          "id": "epic-bard-6-maestro-s-symphony-page-24-bottom-take-the-invoice-to-marfen-binkdirple-in-solusek-s-eye-receive",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Bottom",
+          "text": "Take the invoice to Marfen Binkdirple in Solusek's Eye, receive Mechanical Doll",
+          "order": 6
+        },
+        {
+          "id": "epic-bard-7-maestro-s-symphony-page-24-bottom-give-the-doll-to-serra-in-unrest-receive-note-for-baenar-previ",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Bottom",
+          "text": "Give the doll to Serra in Unrest, receive Note for Baenar previously Ripped Qeynos Bards Guild Flyer - I didn't get this 2nd one on turn in 2/6/25",
+          "order": 7
+        },
+        {
+          "id": "epic-bard-8-maestro-s-symphony-page-24-bottom-give-the-note-to-baenar-swiftsong-in-south-karana-receive-a-no",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Bottom",
+          "text": "Give the note to Baenar Swiftsong in South Karana, receive a Note to Maligar",
+          "order": 8
+        },
+        {
+          "id": "epic-bard-9-maestro-s-symphony-page-24-bottom-give-the-note-to-maligar-in-western-plains-of-karana",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Bottom",
+          "text": "Give the note to Maligar in Western Plains of Karana",
+          "order": 9
+        },
+        {
+          "id": "epic-bard-10-maestro-s-symphony-page-24-bottom-kill-45-maligar-s-enraged-doppleganger-loot-his-head",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Bottom",
+          "text": "Kill [45]Maligar's Enraged Doppleganger, loot his head",
+          "order": 10
+        },
+        {
+          "id": "epic-bard-11-maestro-s-symphony-page-24-bottom-give-maligar-s-head-to-baenar-swiftsong-receive-mahlin-s-mysti",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Bottom",
+          "text": "Give Maligar's Head to Baenar Swiftsong, receive Mahlin's Mystical Bongos.",
+          "order": 11
+        },
+        {
+          "id": "epic-bard-12-maestro-s-symphony-page-24-bottom-give-mahlin-s-mystical-bongos-to-konia-swiftfoot-in-western-ka",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 24 Bottom",
+          "text": "Give Mahlin's Mystical Bongos to Konia Swiftfoot in Western Karana (guard tower #4), receive Maestro's Symphony Page 24 Bottom",
+          "order": 12
+        },
+        {
+          "id": "epic-bard-13-maestro-s-symphony-page-25-kill-36-blackwing-in-rathe-mountains-loot-onyx-drake-gut",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 25",
+          "text": "Kill [36]Blackwing in Rathe Mountains, loot Onyx Drake Gut",
+          "order": 13
+        },
+        {
+          "id": "epic-bard-14-maestro-s-symphony-page-25-kill-51-nezekezena-or-47-phurzikon-in-burning-woods-loot-red-wurm-gut",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 25",
+          "text": "Kill [51]Nezekezena or [47]Phurzikon in Burning Woods, loot Red Wurm Gut",
+          "order": 14
+        },
+        {
+          "id": "epic-bard-15-maestro-s-symphony-page-25-kill-51-eldrig-the-old-in-skyfire-mountains-loot-chromodrac-gut",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 25",
+          "text": "Kill [51]Eldrig the Old in Skyfire Mountains, loot Chromodrac Gut",
+          "order": 15
+        },
+        {
+          "id": "epic-bard-16-maestro-s-symphony-page-25-give-all-the-guts-to-kelkim-menkia-in-south-karana-receive-maestro-s-",
+          "className": "Bard",
+          "section": "Maestro's Symphony Page 25",
+          "text": "Give all the guts to Kelkim Menkia in South Karana, receive Maestro's Symphony Page 25",
+          "order": 16
+        },
+        {
+          "id": "epic-bard-17-mystical-lute-head-optional-kill-45-quag-maelstrom-in-ocean-of-tears-loot-alluring-horn",
+          "className": "Bard",
+          "section": "Mystical Lute Head",
+          "text": "(OPTIONAL) Kill [45]Quag Maelstrom in Ocean of Tears, loot Alluring Horn.",
+          "order": 17
+        },
+        {
+          "id": "epic-bard-18-mystical-lute-head-optional-give-alluring-horn-to-vedico-windwhisper-in-butcherblock-mountains-r",
+          "className": "Bard",
+          "section": "Mystical Lute Head",
+          "text": "(OPTIONAL) Give Alluring Horn to Vedico Windwhisper in Butcherblock Mountains, receive a Note to Forpar Fizfla.",
+          "order": 18
+        },
+        {
+          "id": "epic-bard-19-mystical-lute-head-optional-give-note-to-forpar-fizfla-to-forpar-fizfla-in-steamfont-mountains",
+          "className": "Bard",
+          "section": "Mystical Lute Head",
+          "text": "(OPTIONAL) Give Note to Forpar Fizfla to Forpar Fizfla in Steamfont Mountains.",
+          "order": 19
+        },
+        {
+          "id": "epic-bard-20-mystical-lute-head-kill-53-phinigel-autropos-in-kedge-keep-loot-kedge-backbone",
+          "className": "Bard",
+          "section": "Mystical Lute Head",
+          "text": "Kill [53]Phinigel Autropos in Kedge Keep, loot Kedge Backbone",
+          "order": 20
+        },
+        {
+          "id": "epic-bard-21-mystical-lute-head-kill-an-48-amygdalan-warrior-in-plane-of-fear-loot-amygdalan-tendril",
+          "className": "Bard",
+          "section": "Mystical Lute Head",
+          "text": "Kill an [48]Amygdalan warrior in Plane of Fear, loot Amygdalan Tendril",
+          "order": 21
+        },
+        {
+          "id": "epic-bard-22-mystical-lute-head-kill-52-drolvarg-warlord-in-karnor-s-castle-loot-petrified-werewolf-skull",
+          "className": "Bard",
+          "section": "Mystical Lute Head",
+          "text": "Kill [52]Drolvarg Warlord in Karnor's Castle, loot Petrified Werewolf Skull",
+          "order": 22
+        },
+        {
+          "id": "epic-bard-23-mystical-lute-head-say-what-components-to-forpar-fizfla-in-steamfont-mountains-receive-forpar-s-",
+          "className": "Bard",
+          "section": "Mystical Lute Head",
+          "text": "Say \"What Components\" to Forpar Fizfla in Steamfont Mountains, Receive Forpar's Note to Himself.",
+          "order": 23
+        },
+        {
+          "id": "epic-bard-24-mystical-lute-head-give-forpar-s-note-to-himself-kedge-backbone-amygdalan-tendril-petrified-were",
+          "className": "Bard",
+          "section": "Mystical Lute Head",
+          "text": "Give Forpar's Note to Himself, Kedge Backbone, Amygdalan Tendril, Petrified Werewolf Skull to Forpar and receive Mystical Lute Head",
+          "order": 24
+        },
+        {
+          "id": "epic-bard-25-mystical-lute-body-kill-a-red-dragon-lord-nagafen-zordakalicus-ragefire-talendor-or-nortlav-the-",
+          "className": "Bard",
+          "section": "Mystical Lute Body",
+          "text": "Kill a red dragon (Lord Nagafen, Zordakalicus Ragefire, Talendor) or Nortlav the Scalekeeper and loot Red Dragon Scales",
+          "order": 25
+        },
+        {
+          "id": "epic-bard-26-mystical-lute-body-kill-a-white-dragon-lady-vox-gorenaire-loot-white-dragon-scales",
+          "className": "Bard",
+          "section": "Mystical Lute Body",
+          "text": "Kill a white dragon (Lady Vox, Gorenaire), loot White Dragon Scales",
+          "order": 26
+        },
+        {
+          "id": "epic-bard-27-mystical-lute-body-give-1-metal-bits-smithed-red-dragon-scales-and-white-dragon-scales-to-forpar",
+          "className": "Bard",
+          "section": "Mystical Lute Body",
+          "text": "Give 1 metal bits (smithed), Red Dragon Scales and White Dragon Scales to Forpar, receive Mystical Lute Body",
+          "order": 27
+        },
+        {
+          "id": "epic-bard-28-undead-dragongut-strings-give-an-undead-bard-your-mystical-lute-body-kill-an-undead-bard-upon-de",
+          "className": "Bard",
+          "section": "Undead Dragongut Strings",
+          "text": "Give An Undead Bard your Mystical Lute Body. Kill An Undead Bard, upon death he spawns Trakanon (triggered), kill Trakanon (triggered) and loot Undead Dragongut Strings.",
+          "order": 28
+        },
+        {
+          "id": "epic-bard-29-mystical-lute-give-mystical-lute-head-mystical-lute-body-and-undead-dragongut-strings-to-forpar-",
+          "className": "Bard",
+          "section": "Mystical Lute",
+          "text": "Give Mystical Lute Head, Mystical Lute Body and Undead Dragongut Strings to Forpar, receive the Mystical Lute",
+          "order": 29
+        },
+        {
+          "id": "epic-bard-30-singing-short-sword-give-maestro-s-symphony-page-24-top-maestro-s-symphony-page-24-bottom-maestr",
+          "className": "Bard",
+          "section": "Singing Short Sword!",
+          "text": "Give Maestro's Symphony Page 24 top, Maestro's Symphony Page 24 bottom, Maestro's Symphony Page 25 and Mystical Lute to Baldric Slezaf, receive Singing Short Sword",
+          "order": 30
+        }
+      ]
+    },
+    {
+      "className": "Cleric",
+      "rows": [
+        {
+          "id": "epic-cleric-0-checklist-loot-lord-bergurgle-s-crown-from-lord-bergurgle-in-lake-rathetear",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Loot Lord Bergurgle's Crown from Lord Bergurgle in Lake Rathetear",
+          "order": 0
+        },
+        {
+          "id": "epic-cleric-1-checklist-give-lord-bergurgle-s-crown-to-shmendrik-lavawalker-in-lake-rathetear-to-spawn-natasha",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Lord Bergurgle's Crown to Shmendrik Lavawalker in Lake Rathetear to spawn Natasha Whitewater nearby - receive Oil of Fennin Ro (Natasha Whitewater will despawn 5 minutes after spawning in Lake Rathetear unless engaged in combat and after turning in the Damaged Goblin Crown.)",
+          "order": 1
+        },
+        {
+          "id": "epic-cleric-2-checklist-kill-shmendrik-lavawalker-to-spawn-a-spirit-of-flame",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Kill Shmendrik Lavawalker to spawn A Spirit of Flame",
+          "order": 2
+        },
+        {
+          "id": "epic-cleric-3-checklist-loot-damaged-goblin-crown-from-a-spirit-of-flame-do-not-let-natasha-whitewater-get-the",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Loot Damaged Goblin Crown from A Spirit of Flame (Do not let Natasha Whitewater get the last hit or the corpse will disappear)",
+          "order": 3
+        },
+        {
+          "id": "epic-cleric-4-checklist-give-damaged-goblin-crown-to-natasha-whitewater-receive-ornate-sea-shell-natasha-white",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Damaged Goblin Crown to Natasha Whitewater -- receive Ornate Sea Shell (Natasha Whitewater will despawn 5 minutes after spawning in Lake Rathetear unless engaged in combat and after turning in the Damaged Goblin Crown.)",
+          "order": 4
+        },
+        {
+          "id": "epic-cleric-5-checklist-give-ornate-sea-shell-to-omat-vastsea-in-timorous-deep-receive-coral-statue-of-tarew",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Ornate Sea Shell to Omat Vastsea in Timorous Deep -- receive Coral Statue of Tarew",
+          "order": 5
+        },
+        {
+          "id": "epic-cleric-6-checklist-give-the-coral-statue-of-tarew-to-a-seeker-in-the-temple-of-solusek-ro-causing-them-to",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give the Coral Statue of Tarew to a Seeker in The Temple of Solusek Ro causing them to become A Plasmatic Priest",
+          "order": 6
+        },
+        {
+          "id": "epic-cleric-7-checklist-kill-a-plasmatic-priest-in-the-temple-of-solusek-ro-and-loot-blood-soaked-plasmatic-pr",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Kill A Plasmatic Priest in The Temple of Solusek Ro and loot Blood Soaked Plasmatic Priest Robe",
+          "order": 7
+        },
+        {
+          "id": "epic-cleric-8-checklist-give-the-blood-soaked-plasmatic-priest-robe-to-omat-vastsea-receive-orb-of-frozen-wate",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give the Blood Soaked Plasmatic Priest Robe to Omat Vastsea \u2013- receive Orb of Frozen Water (This spawns Natasha inside the hut, It is suggested you wait to turn in until you have Lord Gimblox's Signet Ring)",
+          "order": 8
+        },
+        {
+          "id": "epic-cleric-9-checklist-loot-lord-gimblox-s-signet-ring-from-lord-gimblox-in-solusek-s-eye",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Loot Lord Gimblox's Signet Ring from Lord Gimblox in Solusek's Eye",
+          "order": 9
+        },
+        {
+          "id": "epic-cleric-10-checklist-give-lord-gimblox-s-signet-ring-to-natasha-whitewater-in-timorous-deep-receive-ornate-",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Lord Gimblox's Signet Ring to Natasha Whitewater in Timorous Deep \u2013- receive Ornate Sea Shell(v2) (This despawns Natasha)",
+          "order": 10
+        },
+        {
+          "id": "epic-cleric-11-checklist-give-ornate-sea-shell-v2-to-naxot-deepwater-in-burning-woods-receive-message-to-natash",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Ornate Sea Shell(v2) to Naxot Deepwater in Burning Woods - receive Message to Natasha (This spawns Ixiblat Fer)",
+          "order": 11
+        },
+        {
+          "id": "epic-cleric-12-checklist-loot-sceptre-of-ixiblat-fer-from-ixiblat-fer-in-burning-woods",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Loot Sceptre of Ixiblat Fer from Ixiblat Fer in Burning Woods",
+          "order": 12
+        },
+        {
+          "id": "epic-cleric-13-checklist-loot-singed-scroll-from-overking-bathezid-in-chardok",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Loot Singed Scroll from Overking Bathezid in Chardok",
+          "order": 13
+        },
+        {
+          "id": "epic-cleric-14-checklist-give-sceptre-of-ixiblat-fer-and-singed-scroll-to-omat-vastsea-receive-orb-of-clear-wat",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Sceptre of Ixiblat Fer and Singed Scroll to Omat Vastsea -\u2013 receive Orb of Clear Water (This spawns Natasha inside the hut)",
+          "order": 14
+        },
+        {
+          "id": "epic-cleric-15-checklist-give-message-to-natasha-received-when-spawning-ixiblat-fer-to-natasha-whitewater-in-ti",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Message to Natasha (Received when spawning Ixiblat Fer) to Natasha Whitewater in Timorous Deep \u2013- receive Shimmering Pearl* (This does not despawn Natasha)",
+          "order": 15
+        },
+        {
+          "id": "epic-cleric-16-checklist-give-shimmering-pearl-to-zordak-ragefire-in-nagafen-s-lair-causes-him-to-repop-as-zord",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Shimmering Pearl to Zordak Ragefire in Nagafen's Lair -- causes him to repop as Zordakalicus Ragefire and attack you - kill and loot Heart of Zordak Ragefire",
+          "order": 16
+        },
+        {
+          "id": "epic-cleric-17-checklist-give-heart-of-zordak-ragefire-to-omat-vastsea-receive-orb-of-vapor-do-not-do-this-unti",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Heart of Zordak Ragefire to Omat Vastsea \u2013 receive Orb of Vapor (Do NOT do this until ready to turn all orbs into Jhassad, as this step spawns Jhassad for the final turn in)",
+          "order": 17
+        },
+        {
+          "id": "epic-cleric-18-checklist-give-all-three-orbs-frozen-water-clear-water-vapor-to-jhassad-oceanson-in-timorous-dee",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give all three orbs (Frozen Water / Clear Water / Vapor) to Jhassad Oceanson in Timorous Deep -- receive Orb of Triumvirate (This spawns the Avatar of Water in the lake)",
+          "order": 18
+        },
+        {
+          "id": "epic-cleric-19-checklist-give-orb-of-triumvirate-to-avatar-of-water-receive-water-sprinkler-of-nem-ankh",
+          "className": "Cleric",
+          "section": "Checklist",
+          "text": "Give Orb of Triumvirate to Avatar of Water \u2013- receive Water Sprinkler of Nem Ankh",
+          "order": 19
+        }
+      ]
+    },
+    {
+      "className": "Druid",
+      "rows": [
+        {
+          "id": "epic-druid-0-checklist-acquire-a-shiny-tin-bowl-warning-you-must-be-ready-to-face-dark-elfs-by-starting-east-",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Acquire a Shiny Tin Bowl ( Warning : You must be ready to face Dark Elfs, by starting East Karana part, Nuien trigger Teloa, who trigger Dark Elfs )",
+          "order": 0
+        },
+        {
+          "id": "epic-druid-1-checklist-speak-with-telin-darkforest-in-burning-wood-and-say-i-will-take-action-to-receive-a-wo",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Speak with Telin Darkforest in Burning Wood and say \"I will take action\" to receive a Worn note.",
+          "order": 1
+        },
+        {
+          "id": "epic-druid-2-checklist-spawn-faelin-bloodbriar-in-greater-faydark-and-give-her-the-worn-note-to-receive-faeli",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Spawn Faelin Bloodbriar in Greater Faydark and give her the Worn Note to receive Faelin`s Ring.",
+          "order": 2
+        },
+        {
+          "id": "epic-druid-3-checklist-give-giz-x-tin-in-kithicor-forest-faelin-s-ring-to-receive-a-dark-metal-coin",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Giz X`Tin in Kithicor Forest Faelin`s Ring to receive a Dark Metal Coin.",
+          "order": 3
+        },
+        {
+          "id": "epic-druid-4-checklist-give-telin-darkforest-in-burning-wood-the-dark-metal-coin-to-receive-worn-dark-metal-c",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Telin Darkforest in Burning Wood the Dark Metal Coin to receive Worn Dark Metal Coin.",
+          "order": 4
+        },
+        {
+          "id": "epic-druid-5-checklist-give-althele-in-east-karana-the-worn-dark-metal-coin-to-receive-braided-grass-amulet",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Althele in East Karana the Worn Dark Metal Coin to receive Braided Grass Amulet.",
+          "order": 5
+        },
+        {
+          "id": "epic-druid-6-checklist-give-sionae-2300-930-in-east-karana-the-braided-grass-amulet-amulet-is-returned",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Sionae (-2300, -930 in East Karana) the Braided Grass Amulet. (Amulet is returned)",
+          "order": 6
+        },
+        {
+          "id": "epic-druid-7-checklist-give-nuien-3650-300-in-east-karana-the-braided-grass-amulet-amulet-is-returned",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Nuien (-3650, 300 in East Karana) the Braided Grass Amulet. (Amulet is returned)",
+          "order": 7
+        },
+        {
+          "id": "epic-druid-8-checklist-caution-this-step-spawns-an-enemy-you-must-intercept-give-teloa-3800-2860-in-east-kara",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "CAUTION, THIS STEP SPAWNS AN ENEMY YOU MUST INTERCEPT: Give Teloa (-3800, -2860 in East Karana) the Braided Grass Amulet, spawning the Dark Elf Corruptor and two Dark Elf Reaver at (-700, -1450) Note: They run really fast when spawned, almost SoW fast",
+          "order": 8
+        },
+        {
+          "id": "epic-druid-9-checklist-kill-the-dark-elf-corruptor-loot-fleshbound-tome",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill the Dark Elf Corruptor, loot Fleshbound Tome.",
+          "order": 9
+        },
+        {
+          "id": "epic-druid-10-checklist-give-althele-in-east-karana-the-fleshbound-tome-to-receive-earth-stained-note",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Althele in East Karana the Fleshbound Tome to receive Earth Stained Note.",
+          "order": 10
+        },
+        {
+          "id": "epic-druid-11-checklist-give-ella-foodcrafter-in-misty-thicket-the-earth-stained-note-to-receive-a-shiny-tin-b",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Ella Foodcrafter in Misty Thicket the Earth Stained Note to receive a Shiny Tin Bowl.",
+          "order": 11
+        },
+        {
+          "id": "epic-druid-12-checklist-forage-the-hardened-mixture",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Forage the Hardened Mixture",
+          "order": 12
+        },
+        {
+          "id": "epic-druid-13-checklist-forage-the-following-four-items",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Forage the following four items:",
+          "order": 13
+        },
+        {
+          "id": "epic-druid-14-checklist-chilled-tundra-root-from-everfrost",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Chilled Tundra Root from Everfrost.",
+          "order": 14
+        },
+        {
+          "id": "epic-druid-15-checklist-ripened-heartfruit-from-greater-faydark",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Ripened Heartfruit from Greater Faydark.",
+          "order": 15
+        },
+        {
+          "id": "epic-druid-16-checklist-speckled-molded-mushroom-from-innothule-swamp",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Speckled Molded Mushroom from Innothule Swamp.",
+          "order": 16
+        },
+        {
+          "id": "epic-druid-17-checklist-sweetened-mudroot-from-misty-thicket",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Sweetened Mudroot from Misty Thicket.",
+          "order": 17
+        },
+        {
+          "id": "epic-druid-18-checklist-combine-all-four-items-in-the-shiny-tin-bowl-to-make-a-hardened-mixture",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Combine all four items in the Shiny Tin Bowl to make a Hardened Mixture.",
+          "order": 18
+        },
+        {
+          "id": "epic-druid-19-checklist-make-a-runecrested-bowl",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Make a Runecrested Bowl",
+          "order": 19
+        },
+        {
+          "id": "epic-druid-20-checklist-acquire-an-ancient-pattern",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Acquire an Ancient Pattern",
+          "order": 20
+        },
+        {
+          "id": "epic-druid-21-checklist-speak-with-alrik-farsight-in-timorous-deep-and-say-i-will-take-the-artifact-to-receive",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Speak with Alrik Farsight in Timorous Deep and say \"I will take the artifact\" to receive a Crushed Pot.",
+          "order": 21
+        },
+        {
+          "id": "epic-druid-22-checklist-give-farios-elianos-in-felwithe-south-the-crushed-pot-to-receive-a-grocery-list",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Farios Elianos in Felwithe South the Crushed Pot to receive a Grocery List.",
+          "order": 22
+        },
+        {
+          "id": "epic-druid-23-checklist-give-merchant-nora-in-northern-felwithe-the-grocery-list-to-receive-a-bag-of-provision",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Merchant Nora in Northern Felwithe the Grocery List to receive a Bag of Provisions.",
+          "order": 23
+        },
+        {
+          "id": "epic-druid-24-checklist-give-farios-elianos-the-bag-of-provisions-to-receive-a-receipt",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Farios Elianos the Bag of Provisions to receive a Receipt.",
+          "order": 24
+        },
+        {
+          "id": "epic-druid-25-checklist-give-alrik-farsight-in-timorous-deep-the-receipt-to-receive-an-ancient-pattern",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Alrik Farsight in Timorous Deep the Receipt to receive an Ancient Pattern.",
+          "order": 25
+        },
+        {
+          "id": "epic-druid-26-checklist-acquire-some-platinum-speckled-powder",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Acquire some Platinum Speckled Powder",
+          "order": 26
+        },
+        {
+          "id": "epic-druid-27-checklist-forage-a-rose-of-firiona-from-firiona-vie",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Forage a Rose of Firiona from Firiona Vie.",
+          "order": 27
+        },
+        {
+          "id": "epic-druid-28-checklist-hail-merdan-fleetfoot-in-surefall-glade-ask-him-who-is-niera-then-hand-him-the-rose-of",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Hail Merdan Fleetfoot in Surefall Glade, ask him \"Who is Niera-\", then hand him the Rose of Firiona to receive a Wood Painting.",
+          "order": 28
+        },
+        {
+          "id": "epic-druid-29-checklist-give-a-human-skeleton-in-frontier-mountains-behind-the-giant-fort-the-wood-painting-to",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give a human skeleton in Frontier Mountains (behind the giant fort) the Wood Painting to receive a Silver Chained Locket.",
+          "order": 29
+        },
+        {
+          "id": "epic-druid-30-checklist-give-niera-farbreeze-in-surefall-glade-the-silver-chained-locket-to-receive-platinum-s",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Niera Farbreeze in Surefall Glade the Silver Chained Locket to receive Platinum Speckled Powder.",
+          "order": 30
+        },
+        {
+          "id": "epic-druid-31-checklist-acquire-some-enchanted-clay",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Acquire some Enchanted Clay",
+          "order": 31
+        },
+        {
+          "id": "epic-druid-32-checklist-kill-a-black-reaver-in-city-of-mist-loot-a-jade-reaver",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill a black reaver in City of Mist, loot a Jade Reaver.",
+          "order": 32
+        },
+        {
+          "id": "epic-druid-33-checklist-give-kinlo-strongarm-in-north-kaladim-the-jade-reaver-to-receive-enchanted-clay",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Kinlo Strongarm in North Kaladim the Jade Reaver to receive Enchanted Clay.",
+          "order": 33
+        },
+        {
+          "id": "epic-druid-34-checklist-combine-the-ancient-pattern-platinum-speckled-powder-and-enchanted-clay-in-a-pottery-w",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Combine the Ancient Pattern, Platinum Speckled Powder, and Enchanted Clay in a Pottery Wheel to create a Runecrested Bowl.",
+          "order": 34
+        },
+        {
+          "id": "epic-druid-35-checklist-trade-stones-for-an-elaborate-scimitar",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Trade Stones for an Elaborate Scimitar",
+          "order": 35
+        },
+        {
+          "id": "epic-druid-36-checklist-give-the-hardened-mixture-and-runecrested-bowl-to-ella-foodcrafter-in-misty-thicket-to",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give the Hardened Mixture and Runecrested Bowl to Ella Foodcrafter in Misty Thicket to receive a Softly Glowing Stone.",
+          "order": 36
+        },
+        {
+          "id": "epic-druid-37-checklist-create-a-summoned-firefly-globe-level-1-druid-spell-no-rent-only-castable-at-night-7p-",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Create a Summoned: Firefly Globe (level 1 Druid spell, NO RENT, only castable at night: 7p - 4a).",
+          "order": 37
+        },
+        {
+          "id": "epic-druid-38-checklist-purchase-scroll-of-resurrection-level-49-cleric-spell",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Purchase Scroll of Resurrection (level 49 Cleric spell).",
+          "order": 38
+        },
+        {
+          "id": "epic-druid-39-checklist-give-venril-sathir-remains-in-karnor-s-castle-the-summoned-firefly-globe-to-spawn-spir",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Venril Sathir Remains in Karnor's Castle the Summoned: Firefly Globe to spawn Spirit of Venril Sathir.",
+          "order": 39
+        },
+        {
+          "id": "epic-druid-40-checklist-give-spirit-of-venril-sathir-in-karnor-s-castle-the-spell-resurrection-to-spawn-venril",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Spirit of Venril Sathir in Karnor's Castle the Spell: Resurrection to spawn Venril Sathir.",
+          "order": 40
+        },
+        {
+          "id": "epic-druid-41-checklist-slay-venril-sathir-in-karnor-s-castle-and-loot-a-pulsing-green-stone",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Slay Venril Sathir in Karnor's Castle and loot a Pulsing Green Stone.",
+          "order": 41
+        },
+        {
+          "id": "epic-druid-42-checklist-give-foloal-stormforest-in-firiona-vie-the-pulsing-green-stone-and-softly-glowing-ston",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Foloal Stormforest in Firiona Vie the Pulsing Green Stone and Softly Glowing Stone to receive a Warmly Glowing Stone.",
+          "order": 42
+        },
+        {
+          "id": "epic-druid-43-checklist-give-ella-foodcrafter-in-misty-thicket-the-warmly-glowing-stone-to-receive-an-elaborat",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Ella Foodcrafter in Misty Thicket the Warmly Glowing Stone to receive an Elaborate Scimitar.",
+          "order": 43
+        },
+        {
+          "id": "epic-druid-44-checklist-cleanse-spirits",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Cleanse Spirits",
+          "order": 44
+        },
+        {
+          "id": "epic-druid-45-checklist-cleanse-the-spirits-of-antonica",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Cleanse the Spirits of Antonica",
+          "order": 45
+        },
+        {
+          "id": "epic-druid-46-checklist-kill-corrupted-wooly-mammoth-level-30-in-everfrost-peaks-loot-a-chunk-of-tundra",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill corrupted wooly mammoth (level 30) in Everfrost Peaks, loot a Chunk of Tundra.",
+          "order": 46
+        },
+        {
+          "id": "epic-druid-47-checklist-kill-corrupted-shaman-level-40-in-lake-rathetear-loot-clean-lakewater",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill corrupted shaman (level 40) in Lake Rathetear, loot Clean Lakewater.",
+          "order": 47
+        },
+        {
+          "id": "epic-druid-48-checklist-kill-corrupted-hill-giant-level-40-in-rathe-mountains-loot-an-ancient-rock",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill corrupted hill giant (level 40) in Rathe Mountains, loot an Ancient Rock.",
+          "order": 48
+        },
+        {
+          "id": "epic-druid-49-checklist-give-withered-treant-in-northern-karana-the-chunk-of-tundra-clean-lakewater-and-ancien",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Withered treant in Northern Karana the Chunk of Tundra, Clean Lakewater and Ancient Rock to receive a Warm Pulsing Treant Heart.",
+          "order": 49
+        },
+        {
+          "id": "epic-druid-50-checklist-give-yeka-ias-in-southern-karana-the-warm-pulsing-treant-heart-to-receive-cleansed-spi",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Yeka Ias in Southern Karana the Warm Pulsing Treant Heart to receive Cleansed Spirit of Antonica.",
+          "order": 50
+        },
+        {
+          "id": "epic-druid-51-checklist-cleanse-the-spirits-of-faydwer",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Cleanse the Spirits of Faydwer",
+          "order": 51
+        },
+        {
+          "id": "epic-druid-52-checklist-kill-corrupted-seahorse-level-53-in-kedge-keep-loot-kedge-cave-crystals",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill Corrupted Seahorse (level 53) in Kedge Keep, loot Kedge Cave Crystals.",
+          "order": 52
+        },
+        {
+          "id": "epic-druid-53-checklist-kill-corrupted-seafury-cyclops-level-52-in-ocean-of-tears-loot-ocean-of-tears-seavines",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill Corrupted seafury cyclops (level 52) in Ocean of Tears, loot Ocean of Tears Seavines.",
+          "order": 53
+        },
+        {
+          "id": "epic-druid-54-checklist-kill-corrupted-brownie-level-51-in-lesser-faydark-loot-green-heartwood-branch",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill Corrupted brownie (level 51) in Lesser Faydark, loot Green Heartwood Branch.",
+          "order": 54
+        },
+        {
+          "id": "epic-druid-55-checklist-give-pained-unicorn-in-lesser-faydark-the-kedge-cave-crystals-ocean-of-tears-seavines-",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Pained Unicorn in Lesser Faydark the Kedge Cave Crystals, Ocean of Tears Seavines and Green Heartwood Branch to receive Gleaming Unicorn Horn.",
+          "order": 55
+        },
+        {
+          "id": "epic-druid-56-checklist-give-silox-azrix-in-ak-anon-the-gleaming-unicorn-horn-to-receieve-the-cleansed-spirit-",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Silox Azrix in Ak'Anon the Gleaming Unicorn Horn to receieve the Cleansed Spirit of Faydwer.",
+          "order": 56
+        },
+        {
+          "id": "epic-druid-57-checklist-cleanse-the-spirits-of-kunark",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Cleanse the Spirits of Kunark",
+          "order": 57
+        },
+        {
+          "id": "epic-druid-58-checklist-kill-ulump-pujluk-level-55-in-swamp-of-no-hope-loot-froglok-essence",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill Ulump Pujluk (level 55) in Swamp of No Hope, loot Froglok Essence.",
+          "order": 58
+        },
+        {
+          "id": "epic-druid-59-checklist-kill-corrupted-gorilla-level-47-in-emerald-jungle-loot-green-tree-bark",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill Corrupted Gorilla (level 47) in Emerald Jungle, loot Green Tree Bark.",
+          "order": 59
+        },
+        {
+          "id": "epic-druid-60-checklist-kill-the-corrupted-barracuda-level-46-in-lake-of-ill-omen-and-loot-the-pure-lakewater",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill the Corrupted barracuda (level 46) in Lake of Ill Omen and loot the Pure Lakewater.",
+          "order": 60
+        },
+        {
+          "id": "epic-druid-61-checklist-give-dolgin-codslayer-in-timorous-deep-the-froglok-essence-he-will-hand-it-back-and-de",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Dolgin Codslayer in Timorous Deep the Froglok Essence (he will hand it back and despawn - 14h respawn) to spawn Faydedar.",
+          "order": 61
+        },
+        {
+          "id": "epic-druid-62-checklist-kill-faydedar-in-timorous-deep-loot-pod-of-seawater",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Kill Faydedar in Timorous Deep, loot Pod of Seawater.",
+          "order": 62
+        },
+        {
+          "id": "epic-druid-63-checklist-give-nekexin-virulence-in-the-overthere-the-froglok-essence-pod-of-seawater-green-tree",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Nekexin Virulence in The Overthere the Froglok Essence, Pod of Seawater, Green Tree Bark and Pure Lakewater to receive Cleansed Spirit of Kunark.",
+          "order": 63
+        },
+        {
+          "id": "epic-druid-64-checklist-acquire-a-nature-walkers-scimitar",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Acquire a Nature Walkers Scimitar!",
+          "order": 64
+        },
+        {
+          "id": "epic-druid-65-checklist-give-xanuusus-in-north-karana-the-elaborate-scimitar-and-three-cleansed-spirits-to-rec",
+          "className": "Druid",
+          "section": "Checklist",
+          "text": "Give Xanuusus in North Karana the Elaborate Scimitar and three cleansed spirits to receive the Nature Walkers Scimitar.",
+          "order": 65
+        }
+      ]
+    },
+    {
+      "className": "Enchanter",
+      "rows": [
+        {
+          "id": "epic-enchanter-0-jeb-s-seal-hail-stofo-olan-in-erudin-must-be-level-50",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Hail Stofo Olan in Erudin (Must be level 50)",
+          "order": 0
+        },
+        {
+          "id": "epic-enchanter-1-jeb-s-seal-ink-of-the-dark",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Ink of the Dark",
+          "order": 1
+        },
+        {
+          "id": "epic-enchanter-2-jeb-s-seal-get-empty-ink-vial-from-reania-jukle-in-qeynos-catacombs",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Get Empty Ink Vial from Reania Jukle in Qeynos Catacombs",
+          "order": 2
+        },
+        {
+          "id": "epic-enchanter-3-jeb-s-seal-charm-the-a-ghoul-scribe-in-lower-guk-give-him-the-empty-ink-vial-to-get-the-ink-of-t",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Charm the a ghoul scribe in Lower Guk. Give him the Empty Ink Vial to get the Ink of the Dark.",
+          "order": 3
+        },
+        {
+          "id": "epic-enchanter-4-jeb-s-seal-mechanical-pen",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Mechanical Pen",
+          "order": 4
+        },
+        {
+          "id": "epic-enchanter-5-jeb-s-seal-kill-the-ghoul-arch-magus-in-lower-guk-and-loot-the-shining-metallic-robes",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Kill the ghoul arch magus in Lower Guk and loot the Shining Metallic Robes.",
+          "order": 5
+        },
+        {
+          "id": "epic-enchanter-6-jeb-s-seal-give-the-shining-metallic-robes-to-rilgor-plegnog-in-ak-anon-to-get-the-mechanical-pe",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Give the Shining Metallic Robes to Rilgor Plegnog in Ak'Anon to get the Mechanical Pen.",
+          "order": 6
+        },
+        {
+          "id": "epic-enchanter-7-jeb-s-seal-white-paper",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "White Paper",
+          "order": 7
+        },
+        {
+          "id": "epic-enchanter-8-jeb-s-seal-purchase-a-quill-and-a-piece-of-parchment",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Purchase a Quill and a Piece of Parchment.",
+          "order": 8
+        },
+        {
+          "id": "epic-enchanter-9-jeb-s-seal-give-the-quill-and-the-piece-of-parchment-to-chrislin-baker-in-western-karana-to-spaw",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Give the Quill and the Piece of Parchment to Chrislin Baker in Western Karana to spawn Thrackin Griften. Kill Thrackin Griften and loot a White Paper.",
+          "order": 9
+        },
+        {
+          "id": "epic-enchanter-10-jeb-s-seal-give-the-ink-of-the-dark-the-mechanical-pen-and-the-white-paper-to-stofo-olan-in-erud",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Give the Ink of the Dark, the Mechanical Pen, and the White Paper to Stofo Olan in Erudin to get a Copy of Notes.",
+          "order": 10
+        },
+        {
+          "id": "epic-enchanter-11-jeb-s-seal-give-the-copy-of-notes-to-jeb-lumsed-a-sarnak-imitator-in-burning-woods-to-get-jeb-s-",
+          "className": "Enchanter",
+          "section": "Jeb's Seal",
+          "text": "Give the Copy of Notes to Jeb Lumsed (a sarnak imitator) in Burning Woods to get Jeb's Seal.",
+          "order": 11
+        },
+        {
+          "id": "epic-enchanter-12-1st-piece-of-staff-test-of-illusion-kill-vessel-drozlin-in-cabilis-east-and-loot-the-xolion-rod",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Kill Vessel Drozlin in Cabilis East and loot the Xolion Rod.",
+          "order": 12
+        },
+        {
+          "id": "epic-enchanter-13-1st-piece-of-staff-test-of-illusion-kill-verina-tomb-in-neriak-and-loot-innoruuk-s-word",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Kill Verina Tomb in Neriak and loot Innoruuk's Word.",
+          "order": 13
+        },
+        {
+          "id": "epic-enchanter-14-1st-piece-of-staff-test-of-illusion-obtain-the-chalice-of-kings",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Obtain the Chalice of Kings.",
+          "order": 14
+        },
+        {
+          "id": "epic-enchanter-15-1st-piece-of-staff-test-of-illusion-kill-prince-selrach-di-zok-in-chardok-and-loot-the-head-of-a",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Kill Prince Selrach Di'zok in Chardok and loot the Head of a Prince.",
+          "order": 15
+        },
+        {
+          "id": "epic-enchanter-16-1st-piece-of-staff-test-of-illusion-give-the-head-of-a-prince-to-joren-nobleheart-in-felwithe-to",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Give the Head of a Prince to Joren Nobleheart in Felwithe to get the Chalice of Kings.",
+          "order": 16
+        },
+        {
+          "id": "epic-enchanter-17-1st-piece-of-staff-test-of-illusion-obtain-snow-blossoms-in-oggok",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Obtain Snow Blossoms in Oggok.",
+          "order": 17
+        },
+        {
+          "id": "epic-enchanter-18-1st-piece-of-staff-test-of-illusion-pick-up-large-muddy-sandals",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Pick up Large Muddy Sandals.",
+          "order": 18
+        },
+        {
+          "id": "epic-enchanter-19-1st-piece-of-staff-test-of-illusion-give-large-muddy-sandals-to-bozlum-blossom-to-get-scribbled-",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Give Large Muddy Sandals to Bozlum Blossom to get Scribbled Parchment.",
+          "order": 19
+        },
+        {
+          "id": "epic-enchanter-20-1st-piece-of-staff-test-of-illusion-give-scribbled-parchment-to-brokk-boxtripper-to-get-a-gift-t",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Give Scribbled Parchment to Brokk Boxtripper to get a Gift to Bozlum.",
+          "order": 20
+        },
+        {
+          "id": "epic-enchanter-21-1st-piece-of-staff-test-of-illusion-give-the-gift-to-bozlum-blossom-to-get-snow-blossoms",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Give the gift to Bozlum Blossom to get Snow Blossoms.",
+          "order": 21
+        },
+        {
+          "id": "epic-enchanter-22-1st-piece-of-staff-test-of-illusion-combine-the-chalice-of-kings-xolion-rod-snow-blossoms-and-in",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Combine the Chalice of Kings, Xolion Rod, Snow Blossoms and Innoruuk's Word in an Enchanters Sack.",
+          "order": 22
+        },
+        {
+          "id": "epic-enchanter-23-1st-piece-of-staff-test-of-illusion-give-the-combined-sack-to-modani-qu-loni-in-the-overthere-to",
+          "className": "Enchanter",
+          "section": "1st Piece of Staff -- Test of Illusion",
+          "text": "Give the combined sack to Modani Qu`Loni in The Overthere to get the 1st Piece of Staff.",
+          "order": 23
+        },
+        {
+          "id": "epic-enchanter-24-2nd-piece-of-staff-test-of-enlightenment-kill-cazel-in-oasis-to-get-a-spoon",
+          "className": "Enchanter",
+          "section": "2nd Piece of Staff -- Test of Enlightenment",
+          "text": "Kill Cazel in Oasis to get a Spoon",
+          "order": 24
+        },
+        {
+          "id": "epic-enchanter-25-2nd-piece-of-staff-test-of-enlightenment-pick-up-the-the-one-key-in-the-overthere",
+          "className": "Enchanter",
+          "section": "2nd Piece of Staff -- Test of Enlightenment",
+          "text": "Pick up the The One Key in the Overthere.",
+          "order": 25
+        },
+        {
+          "id": "epic-enchanter-26-2nd-piece-of-staff-test-of-enlightenment-pick-up-the-lost-scroll-in-dalnir",
+          "className": "Enchanter",
+          "section": "2nd Piece of Staff -- Test of Enlightenment",
+          "text": "Pick up the Lost Scroll in Dalnir.",
+          "order": 26
+        },
+        {
+          "id": "epic-enchanter-27-2nd-piece-of-staff-test-of-enlightenment-pick-up-the-book-of-charm-and-sacrifice-in-plane-of-sky",
+          "className": "Enchanter",
+          "section": "2nd Piece of Staff -- Test of Enlightenment",
+          "text": "Pick up the Book of Charm and Sacrifice in Plane of Sky.",
+          "order": 27
+        },
+        {
+          "id": "epic-enchanter-28-2nd-piece-of-staff-test-of-enlightenment-combine-the-spoon-the-one-key-the-lost-scroll-and-the-b",
+          "className": "Enchanter",
+          "section": "2nd Piece of Staff -- Test of Enlightenment",
+          "text": "Combine the Spoon, the One Key, the Lost Scroll and the Book of Charm and Sacrifice in an Enchanters Sack.",
+          "order": 28
+        },
+        {
+          "id": "epic-enchanter-29-2nd-piece-of-staff-test-of-enlightenment-give-the-combined-sack-to-mizzle-gepple-clockwork-viix-",
+          "className": "Enchanter",
+          "section": "2nd Piece of Staff -- Test of Enlightenment",
+          "text": "Give the combined sack to Mizzle Gepple (Clockwork VIIX) in Ak'Anon to get the 2nd Piece of Staff.",
+          "order": 29
+        },
+        {
+          "id": "epic-enchanter-30-3rd-piece-of-staff-test-of-charm-obtain-the-four-dull-gems-from-nadia-starfeast-in-firiona-vie",
+          "className": "Enchanter",
+          "section": "3rd Piece of Staff -- Test of Charm",
+          "text": "Obtain the four dull gems from Nadia Starfeast in Firiona Vie.",
+          "order": 30
+        },
+        {
+          "id": "epic-enchanter-31-3rd-piece-of-staff-test-of-charm-charm-a-spectral-librarian-in-kaesora-give-him-the-dull-diamond",
+          "className": "Enchanter",
+          "section": "3rd Piece of Staff -- Test of Charm",
+          "text": "Charm a Spectral librarian in Kaesora. Give him the Dull Diamond to get the Enchanted Diamond.",
+          "order": 31
+        },
+        {
+          "id": "epic-enchanter-32-3rd-piece-of-staff-test-of-charm-upon-turn-in-an-aggro-enraged-spectral-librarian-will-spawn-it-",
+          "className": "Enchanter",
+          "section": "3rd Piece of Staff -- Test of Charm",
+          "text": "Upon turn in an aggro Enraged spectral librarian will spawn. It is strongly recommended not to kill this see page for details.",
+          "order": 32
+        },
+        {
+          "id": "epic-enchanter-33-3rd-piece-of-staff-test-of-charm-charm-felia-goldenwing-in-skyfire-give-her-the-dull-sapphire-to",
+          "className": "Enchanter",
+          "section": "3rd Piece of Staff -- Test of Charm",
+          "text": "Charm Felia Goldenwing in Skyfire. Give her the Dull Sapphire to get the Enchanted Sapphire.",
+          "order": 33
+        },
+        {
+          "id": "epic-enchanter-34-3rd-piece-of-staff-test-of-charm-charm-the-wraith-of-jaxion-in-the-city-of-mist-give-him-the-dul",
+          "className": "Enchanter",
+          "section": "3rd Piece of Staff -- Test of Charm",
+          "text": "Charm the Wraith of Jaxion in the City of Mist. Give him the Dull Ruby to get the Enchanted Ruby.",
+          "order": 34
+        },
+        {
+          "id": "epic-enchanter-35-3rd-piece-of-staff-test-of-charm-charm-impaler-tzilug-in-the-overthere-give-him-the-dull-emerald",
+          "className": "Enchanter",
+          "section": "3rd Piece of Staff -- Test of Charm",
+          "text": "Charm Impaler Tzilug in the Overthere. Give him the Dull Emerald to get the Enchanted Emerald.",
+          "order": 35
+        },
+        {
+          "id": "epic-enchanter-36-3rd-piece-of-staff-test-of-charm-combine-the-enchanted-diamond-enchanted-sapphire-enchanted-ruby",
+          "className": "Enchanter",
+          "section": "3rd Piece of Staff -- Test of Charm",
+          "text": "Combine the Enchanted Diamond, Enchanted Sapphire, Enchanted Ruby and Enchanted Emerald in an Enchanters Sack.",
+          "order": 36
+        },
+        {
+          "id": "epic-enchanter-37-3rd-piece-of-staff-test-of-charm-give-the-combined-sack-to-nadia-starfeast-in-firiona-vie-to-get",
+          "className": "Enchanter",
+          "section": "3rd Piece of Staff -- Test of Charm",
+          "text": "Give the combined sack to Nadia Starfeast in Firiona Vie to get the 3rd Piece of Staff.",
+          "order": 37
+        },
+        {
+          "id": "epic-enchanter-38-4th-piece-of-staff-test-of-the-phantasm-kill-the-wraith-of-a-shissir-in-the-plane-of-fear-and-lo",
+          "className": "Enchanter",
+          "section": "4th Piece of Staff -- Test of the Phantasm",
+          "text": "Kill the Wraith of a Shissir in the Plane of Fear and loot Head of the Serpent.",
+          "order": 38
+        },
+        {
+          "id": "epic-enchanter-39-4th-piece-of-staff-test-of-the-phantasm-kill-the-ghost-of-kindle-in-the-hole-and-loot-the-essenc",
+          "className": "Enchanter",
+          "section": "4th Piece of Staff -- Test of the Phantasm",
+          "text": "Kill the Ghost of Kindle in The Hole and loot the Essence of a Ghost.",
+          "order": 39
+        },
+        {
+          "id": "epic-enchanter-40-4th-piece-of-staff-test-of-the-phantasm-kill-a-forsaken-revenant-in-the-plane-of-hate-and-loot-t",
+          "className": "Enchanter",
+          "section": "4th Piece of Staff -- Test of the Phantasm",
+          "text": "Kill a forsaken revenant in the Plane of Hate and loot the Essence of a Vampire.",
+          "order": 40
+        },
+        {
+          "id": "epic-enchanter-41-4th-piece-of-staff-test-of-the-phantasm-kill-the-tangrin-in-the-field-of-bone-and-loot-the-sands",
+          "className": "Enchanter",
+          "section": "4th Piece of Staff -- Test of the Phantasm",
+          "text": "Kill The Tangrin in the Field of Bone and loot the Sands of the Mystics.",
+          "order": 41
+        },
+        {
+          "id": "epic-enchanter-42-4th-piece-of-staff-test-of-the-phantasm-combine-the-head-of-the-serpent-essence-of-a-ghost-essen",
+          "className": "Enchanter",
+          "section": "4th Piece of Staff -- Test of the Phantasm",
+          "text": "Combine the Head of the Serpent, Essence of a Ghost, Essence of a Vampire and Sands of the Mystics in an Enchanters Sack.",
+          "order": 42
+        },
+        {
+          "id": "epic-enchanter-43-4th-piece-of-staff-test-of-the-phantasm-give-the-combined-sack-to-polzin-mrid-in-the-hole-to-get",
+          "className": "Enchanter",
+          "section": "4th Piece of Staff -- Test of the Phantasm",
+          "text": "Give the combined sack to Polzin Mrid in The Hole to get the 4th Piece of Staff.",
+          "order": 43
+        },
+        {
+          "id": "epic-enchanter-44-staff-of-the-serpent-combine-the-four-pieces-of-staff-in-an-enchanters-sack-to-make-a-bundle-of-",
+          "className": "Enchanter",
+          "section": "Staff of the Serpent",
+          "text": "Combine the four pieces of staff in an Enchanters Sack to make a Bundle of Staves.",
+          "order": 44
+        },
+        {
+          "id": "epic-enchanter-45-staff-of-the-serpent-give-the-bundle-of-staves-to-jeb-lumsed-a-sarnak-imitator-in-burning-woods-",
+          "className": "Enchanter",
+          "section": "Staff of the Serpent",
+          "text": "Give the Bundle of Staves to Jeb Lumsed (a sarnak imitator) in Burning Woods to get the Staff of the Serpent!",
+          "order": 45
+        }
+      ]
+    },
+    {
+      "className": "Magician",
+      "rows": [
+        {
+          "id": "epic-magician-0-the-beginning-optional-go-find-rykas-in-lake-rathetear-receive-token-of-mastery",
+          "className": "Magician",
+          "section": "The Beginning (Optional)",
+          "text": "Go find Rykas in Lake Rathetear. Receive Token of Mastery.",
+          "order": 0
+        },
+        {
+          "id": "epic-magician-1-the-beginning-optional-take-the-token-to-jahsohn-aksot-in-west-commonlands",
+          "className": "Magician",
+          "section": "The Beginning (Optional)",
+          "text": "Take the Token to Jahsohn Aksot in West Commonlands.",
+          "order": 1
+        },
+        {
+          "id": "epic-magician-2-words-of-magi-kot-kill-an-enraged-dread-wolf-in-kithicor-forest-loot-torn-page-of-magi-kot-pg-1",
+          "className": "Magician",
+          "section": "Words of Magi'Kot",
+          "text": "Kill an enraged dread wolf in Kithicor Forest. Loot Torn Page of Magi`kot pg. 1.",
+          "order": 2
+        },
+        {
+          "id": "epic-magician-3-words-of-magi-kot-kill-tentacle-terrors-in-the-estate-of-unrest-loot-torn-page-of-magi-kot-pg-2",
+          "className": "Magician",
+          "section": "Words of Magi'Kot",
+          "text": "Kill Tentacle Terrors in the Estate of Unrest. Loot Torn Page of Magi`kot pg. 2.",
+          "order": 3
+        },
+        {
+          "id": "epic-magician-4-words-of-magi-kot-kill-a-bloodthirsty-ghoul-in-lower-guk-loot-torn-page-of-magi-kot-pg-3",
+          "className": "Magician",
+          "section": "Words of Magi'Kot",
+          "text": "Kill a bloodthirsty ghoul in Lower Guk. Loot Torn Page of Magi`kot pg. 3.",
+          "order": 4
+        },
+        {
+          "id": "epic-magician-5-words-of-magi-kot-take-them-to-jahsohn-aksotin-west-commonlands-receive-words-of-magi-kot",
+          "className": "Magician",
+          "section": "Words of Magi'Kot",
+          "text": "Take them to Jahsohn Aksotin West Commonlands. Receive Words of Magi`kot.",
+          "order": 5
+        },
+        {
+          "id": "epic-magician-6-power-of-the-elements-kill-a-gypsy-dancer-in-mistmoore-loot-the-power-of-wind",
+          "className": "Magician",
+          "section": "Power of the Elements",
+          "text": "Kill a gypsy dancer in Mistmoore. Loot the Power of Wind.",
+          "order": 6
+        },
+        {
+          "id": "epic-magician-7-power-of-the-elements-kill-lava-elemental-or-blazing-elemental-in-solusek-s-eye-loot-the-power-o",
+          "className": "Magician",
+          "section": "Power of the Elements",
+          "text": "Kill Lava elemental or Blazing Elemental in Solusek's Eye. Loot the Power of Fire.",
+          "order": 7
+        },
+        {
+          "id": "epic-magician-8-power-of-the-elements-kill-famished-ravener-hungered-ravener-gorged-ravener-in-kaesora-loot-the-",
+          "className": "Magician",
+          "section": "Power of the Elements",
+          "text": "Kill famished ravener/Hungered Ravener/Gorged Ravener in Kaesora. Loot the Power of Water.",
+          "order": 8
+        },
+        {
+          "id": "epic-magician-9-power-of-the-elements-kill-a-fairy-guard-a-faerie-guard-in-lesser-faydark-loot-power-of-earth",
+          "className": "Magician",
+          "section": "Power of the Elements",
+          "text": "Kill A Fairy Guard/a faerie guard in Lesser Faydark. Loot Power of Earth.",
+          "order": 9
+        },
+        {
+          "id": "epic-magician-10-power-of-the-elements-give-these-to-walnan-in-the-butcherblock-mountains-you-can-mq-this-step-re",
+          "className": "Magician",
+          "section": "Power of the Elements",
+          "text": "Give these to Walnan in the Butcherblock Mountains. (You can MQ this step). Receive the Power of the Elements.",
+          "order": 10
+        },
+        {
+          "id": "epic-magician-11-words-of-mastery-torn-page-of-mastery-earth",
+          "className": "Magician",
+          "section": "Words of Mastery",
+          "text": "Torn Page of Mastery Earth",
+          "order": 11
+        },
+        {
+          "id": "epic-magician-12-words-of-mastery-torn-page-of-mastery-fire",
+          "className": "Magician",
+          "section": "Words of Mastery",
+          "text": "Torn Page of Mastery Fire",
+          "order": 12
+        },
+        {
+          "id": "epic-magician-13-words-of-mastery-torn-page-of-mastery-water",
+          "className": "Magician",
+          "section": "Words of Mastery",
+          "text": "Torn Page of Mastery Water",
+          "order": 13
+        },
+        {
+          "id": "epic-magician-14-words-of-mastery-torn-page-of-mastery-wind",
+          "className": "Magician",
+          "section": "Words of Mastery",
+          "text": "Torn Page of Mastery Wind.",
+          "order": 14
+        },
+        {
+          "id": "epic-magician-15-words-of-mastery-give-the-torn-pages-to-akksstaff-in-najena-receive-the-words-of-mastery",
+          "className": "Magician",
+          "section": "Words of Mastery",
+          "text": "Give the torn pages to Akksstaff in Najena. Receive the Words of Mastery.",
+          "order": 15
+        },
+        {
+          "id": "epic-magician-16-power-of-the-orb-go-back-to-rykas-in-lake-rathetear-give-him-the-words-of-magi-kot-the-power-of-",
+          "className": "Magician",
+          "section": "Power of the Orb",
+          "text": "Go back to Rykas in Lake Rathetear. Give him the Words of Magi`kot, the Power of the Elements, and the Words of Mastery. Receive the Power of the Orb.",
+          "order": 16
+        },
+        {
+          "id": "epic-magician-17-element-of-fire-kill-neh-ashiir-in-the-city-of-mist-loot-the-torch-of-the-elements",
+          "className": "Magician",
+          "section": "Element of Fire",
+          "text": "Kill Neh'Ashiir in the City of Mist. Loot the Torch of the Elements.",
+          "order": 17
+        },
+        {
+          "id": "epic-magician-18-element-of-fire-kill-in-order-of-difficulty-gylton-phurzikon-or-nezekezena-in-the-burning-woods-",
+          "className": "Magician",
+          "section": "Element of Fire",
+          "text": "Kill (in order of difficulty) Gylton, Phurzikon, or Nezekezena in the Burning Woods until one drops a Burning Embers.",
+          "order": 18
+        },
+        {
+          "id": "epic-magician-19-element-of-fire-kill-undertow-in-kedge-keep-loot-the-blazing-wand",
+          "className": "Magician",
+          "section": "Element of Fire",
+          "text": "Kill Undertow in Kedge Keep. Loot the Blazing Wand.",
+          "order": 19
+        },
+        {
+          "id": "epic-magician-20-element-of-fire-take-power-of-the-orb-and-these-items-to-jennus-lyklobar-in-skyfire-mountains-re",
+          "className": "Magician",
+          "section": "Element of Fire",
+          "text": "Take Power of the Orb and these items to Jennus Lyklobar in Skyfire Mountains. Receive the Element of Fire.",
+          "order": 20
+        },
+        {
+          "id": "epic-magician-21-element-of-earth-kill-magi-p-tasa-in-the-plane-of-hate-loot-the-staff-of-elemental-mastery-earth",
+          "className": "Magician",
+          "section": "Element of Earth",
+          "text": "Kill Magi P`Tasa in the Plane of Hate. Loot the Staff of Elemental Mastery: Earth.",
+          "order": 21
+        },
+        {
+          "id": "epic-magician-22-element-of-earth-kill-slixin-klex-in-the-burning-wood-loot-dirt-of-underfoot",
+          "className": "Magician",
+          "section": "Element of Earth",
+          "text": "Kill Slixin Klex in the Burning Wood. Loot Dirt of Underfoot.",
+          "order": 22
+        },
+        {
+          "id": "epic-magician-23-element-of-earth-quest-for-shovel-of-ponz",
+          "className": "Magician",
+          "section": "Element of Earth",
+          "text": "Quest for Shovel of Ponz.",
+          "order": 23
+        },
+        {
+          "id": "epic-magician-24-element-of-earth-quest-for-broom-of-trilon",
+          "className": "Magician",
+          "section": "Element of Earth",
+          "text": "Quest for Broom of Trilon.",
+          "order": 24
+        },
+        {
+          "id": "epic-magician-25-element-of-earth-bring-these-all-to-tiblner-milnik-in-firiona-vie-receive-element-of-earth",
+          "className": "Magician",
+          "section": "Element of Earth",
+          "text": "Bring these all to Tiblner Milnik in Firiona Vie. Receive Element of Earth.",
+          "order": 25
+        },
+        {
+          "id": "epic-magician-26-element-of-water-kill-phinigel-autropos-in-kedge-keep-loot-staff-of-elemental-mastery-water",
+          "className": "Magician",
+          "section": "Element of Water",
+          "text": "Kill Phinigel Autropos in Kedge Keep. Loot Staff of Elemental Mastery: Water.",
+          "order": 26
+        },
+        {
+          "id": "epic-magician-27-element-of-water-kill-captain-rottgrime-in-the-overthere-loot-tears-of-erollisi",
+          "className": "Magician",
+          "section": "Element of Water",
+          "text": "Kill Captain Rottgrime in The Overthere. Loot Tears of Erollisi.",
+          "order": 27
+        },
+        {
+          "id": "epic-magician-28-element-of-water-kill-tarbul-earthstrider-in-east-karana-loot-rain-of-karana",
+          "className": "Magician",
+          "section": "Element of Water",
+          "text": "Kill Tarbul Earthstrider in East Karana. Loot Rain of Karana.",
+          "order": 28
+        },
+        {
+          "id": "epic-magician-29-element-of-water-takes-the-three-items-to-jinalis-andir-in-dagnor-s-cauldron-and-receive-the-ele",
+          "className": "Magician",
+          "section": "Element of Water",
+          "text": "Takes the three items to Jinalis Andir in Dagnor's Cauldron and receive the Element of Water.",
+          "order": 29
+        },
+        {
+          "id": "epic-magician-30-element-of-wind-kill-mobs-on-the-7th-island-on-the-plane-of-sky-loot-the-crown-of-elemental-mast",
+          "className": "Magician",
+          "section": "Element of Wind",
+          "text": "Kill mobs on the 7th island on the Plane of Sky. Loot the Crown of Elemental Mastery.",
+          "order": 30
+        },
+        {
+          "id": "epic-magician-31-element-of-wind-kill-mobs-in-the-hole-loot-the-elemental-binder",
+          "className": "Magician",
+          "section": "Element of Wind",
+          "text": "Kill mobs in the Hole. Loot the Elemental Binder.",
+          "order": 31
+        },
+        {
+          "id": "epic-magician-32-element-of-wind-kill-quillmane-in-south-karana-loot-the-pegasus-feather-cloak",
+          "className": "Magician",
+          "section": "Element of Wind",
+          "text": "Kill Quillmane in South Karana. Loot the Pegasus Feather Cloak.",
+          "order": 32
+        },
+        {
+          "id": "epic-magician-33-element-of-wind-give-these-items-to-kihun-solstin-in-the-plane-of-air-and-receive-the-element-of",
+          "className": "Magician",
+          "section": "Element of Wind",
+          "text": "Give these items to Kihun Solstin in the Plane of Air and receive the Element of Wind.",
+          "order": 33
+        },
+        {
+          "id": "epic-magician-34-spell-summon-orb-go-to-the-master-of-elements-and-give-him-the-four-elements-receive-spell-summo",
+          "className": "Magician",
+          "section": "Spell Summon Orb",
+          "text": "Go to the Master of Elements and give him the four Elements. Receive Spell: Summon Orb.",
+          "order": 34
+        },
+        {
+          "id": "epic-magician-35-spell-summon-orb-scribe-your-spell-and-summon-the-orb-of-mastery",
+          "className": "Magician",
+          "section": "Spell Summon Orb",
+          "text": "Scribe your spell and summon the Orb of Mastery!",
+          "order": 35
+        }
+      ]
+    },
+    {
+      "className": "Monk",
+      "rows": [
+        {
+          "id": "epic-monk-0-short-walkthrough-checklist-kill-brother-zephyl-or-brother-qwinn-and-loot-robe-of-the-lost-circl",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Kill Brother Zephyl or Brother Qwinn and loot Robe of the Lost Circle OR perform the following sub-quest.",
+          "order": 0
+        },
+        {
+          "id": "epic-monk-1-short-walkthrough-checklist-robe-of-the-lost-circle-sub-quest",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Robe of the Lost Circle sub-quest",
+          "order": 1
+        },
+        {
+          "id": "epic-monk-2-short-walkthrough-checklist-obtain-purple-headband-via-quests",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Obtain Purple Headband via quests.",
+          "order": 2
+        },
+        {
+          "id": "epic-monk-3-short-walkthrough-checklist-obtain-red-sash-of-order-via-quests",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Obtain Red Sash of Order via quests.",
+          "order": 3
+        },
+        {
+          "id": "epic-monk-4-short-walkthrough-checklist-kill-targin-the-rock-in-nagafen-s-lair-king-room-to-get-code-of-zan-",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Kill Targin the Rock in Nagafen's Lair King room to get Code of Zan Fi.",
+          "order": 4
+        },
+        {
+          "id": "epic-monk-5-short-walkthrough-checklist-kill-raster-of-guk-in-lower-guk-to-get-the-idol-it-should-be-noted-y",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Kill Raster of Guk in Lower Guk to get The Idol. It should be noted you CANNOT MQ the idol and sash to Brother Zephyl.",
+          "order": 5
+        },
+        {
+          "id": "epic-monk-6-short-walkthrough-checklist-turn-in-purple-headband-and-code-of-zan-fi-to-brother-qwinn-in-south",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Turn in Purple Headband and Code of Zan Fi to Brother Qwinn in Southern Karana to get Needle of the Void. This turn-in was successfully multiquested (MQ'd) as of 2024-09-14.",
+          "order": 6
+        },
+        {
+          "id": "epic-monk-7-short-walkthrough-checklist-turn-in-red-sash-of-order-and-the-idol-to-brother-zephyl-in-rathe-mo",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Turn in Red Sash of Order and The Idol to Brother Zephyl in Rathe Mountains to get Rare Robe Pattern.",
+          "order": 7
+        },
+        {
+          "id": "epic-monk-8-short-walkthrough-checklist-combine-shadow-wolf-pelt-silk-swatch-and-spell-gather-shadows-in-sew",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Combine Shadow Wolf Pelt, Silk Swatch, and Spell: Gather Shadows in sewing kit to make Shadow Silk (Tailoring 36).",
+          "order": 8
+        },
+        {
+          "id": "epic-monk-9-short-walkthrough-checklist-combine-shadow-silk-needle-of-the-void-rare-robe-pattern-and-song-jo",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Combine Shadow Silk, Needle of the Void, Rare Robe Pattern, and Song: Jonthan's Whistling Warsong in a sewing kit to make Robe of the Lost Circle (no skill check)",
+          "order": 9
+        },
+        {
+          "id": "epic-monk-10-short-walkthrough-checklist-robe-of-the-whistling-fists-sub-quest",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Robe of the Whistling Fists sub-quest",
+          "order": 10
+        },
+        {
+          "id": "epic-monk-11-short-walkthrough-checklist-kill-an-iksar-betrayer-in-chardok-and-loot-a-metal-pipe-fi",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Kill an iksar betrayer in Chardok and loot A Metal Pipe (Fi).",
+          "order": 11
+        },
+        {
+          "id": "epic-monk-12-short-walkthrough-checklist-kill-a-drolvarg-pawbuster-in-karnor-s-castle-and-loot-a-metal-pipe-z",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Kill a drolvarg pawbuster in Karnor's Castle and loot A Metal Pipe (Zan).",
+          "order": 12
+        },
+        {
+          "id": "epic-monk-13-short-walkthrough-checklist-turn-in-the-two-pipes-and-robe-of-the-lost-circle-to-brother-balatin",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Turn in the two pipes and Robe of the Lost Circle to Brother Balatin (must not be aggro'd. Charm and sneak both work, pacify does NOT work.) in Dreadlands to receive Robe of the Whistling Fists.",
+          "order": 13
+        },
+        {
+          "id": "epic-monk-14-short-walkthrough-checklist-first-book",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "First Book",
+          "order": 14
+        },
+        {
+          "id": "epic-monk-15-short-walkthrough-checklist-get-an-immortals-book-from-any-named-mob-in-skyfire",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Get an Immortals book from any named mob in Skyfire.",
+          "order": 15
+        },
+        {
+          "id": "epic-monk-16-short-walkthrough-checklist-turn-in-immortals-to-tomekeeper-danl-in-the-erudin-library-for-danl-",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Turn in Immortals to Tomekeeper Danl in the Erudin library for Danl's Reference. Do not turn in while Feigned Death. Danl will eat your turn in.",
+          "order": 16
+        },
+        {
+          "id": "epic-monk-17-short-walkthrough-checklist-save-this-until-the-final-turn-in-so-you-may-keep-your-robe-longer",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Save this until the final turn in so you may keep your robe longer.",
+          "order": 17
+        },
+        {
+          "id": "epic-monk-18-short-walkthrough-checklist-find-lheao-in-the-hidden-cove-in-timorous-deep-turn-in-danl-s-refere",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Find Lheao in the hidden cove in Timorous Deep. Turn in Danl's Reference and Robe of the Whistling Fists to get Celestial Fists (book).",
+          "order": 18
+        },
+        {
+          "id": "epic-monk-19-short-walkthrough-checklist-fist-of-fire",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Fist of Fire",
+          "order": 19
+        },
+        {
+          "id": "epic-monk-20-short-walkthrough-checklist-find-a-fire-sprite-in-lavastorm-mountains-and-say-i-challenge-eejag-",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Find a fire sprite in Lavastorm Mountains and say \"I challenge Eejag\" to spawn Eejag. Kill Eejag and loot Charred Scale.",
+          "order": 20
+        },
+        {
+          "id": "epic-monk-21-short-walkthrough-checklist-fist-of-air",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Fist of Air",
+          "order": 21
+        },
+        {
+          "id": "epic-monk-22-short-walkthrough-checklist-go-to-dojorn-s-island-isle-1-5-in-plane-of-sky-hand-scale-to-a-prese",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Go to Dojorn's Island (Isle 1.5) in Plane of Sky. Hand Scale to a presence to spawn Gwan. Kill Gwan and loot Breath of Gwan.",
+          "order": 22
+        },
+        {
+          "id": "epic-monk-23-short-walkthrough-checklist-fist-of-earth",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Fist of Earth",
+          "order": 23
+        },
+        {
+          "id": "epic-monk-24-short-walkthrough-checklist-hand-breath-of-gwan-in-to-a-sleeping-ogre-in-mines-of-nurga-to-spawn",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Hand Breath of Gwan in to a sleeping ogre in Mines of Nurga to spawn Trunt. Kill Trunt and loot Trunt's Head (Note: a sleeping ogre must con indifferently, use sneak from behind to turn in).",
+          "order": 24
+        },
+        {
+          "id": "epic-monk-25-short-walkthrough-checklist-fist-of-water",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Fist of Water",
+          "order": 25
+        },
+        {
+          "id": "epic-monk-26-short-walkthrough-checklist-optional-find-dark-elf-named-deep-in-underwater-caverns-of-lake-rath",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "OPTIONAL Find dark elf named Deep in underwater caverns of Lake Rathetear and turn in the Head. She will give it back then despawn.",
+          "order": 26
+        },
+        {
+          "id": "epic-monk-27-short-walkthrough-checklist-go-to-overthere-and-locate-a-monk-named-astral-projection-overthere-",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Go to Overthere and locate a monk named Astral Projection (Overthere). Hand him Trunt's Head and receive Eye of Kaiaren.",
+          "order": 27
+        },
+        {
+          "id": "epic-monk-28-short-walkthrough-checklist-in-lake-of-ill-omen-it-s-not-on-the-platform-but-on-the-shore-loc-ne",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "In Lake of Ill Omen (It's not on the platform, but on the shore, loc neg 1900 neg 950), give an Astral Projection (LOIO) the Eye of Kaiaren to spawn Vorash and Deep. Once Vorash dies, Xenevorash will spawn. Kill Xenevorash and loot Demon Fangs.",
+          "order": 28
+        },
+        {
+          "id": "epic-monk-29-short-walkthrough-checklist-book-conversion-dealing-with-kaiaren",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Book Conversion (Dealing with Kaiaren):",
+          "order": 29
+        },
+        {
+          "id": "epic-monk-30-short-walkthrough-checklist-super-duper-important-if-you-are-doing-receiving-an-mq-or-you-do-not",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "SUPER DUPER IMPORTANT: If you are doing/receiving an MQ or you do not have your Demon Fangs in hand and ready, do NOT turn in Celestial Fists (book) to Sane Kaiaran and receive Book of Celestial Fists because Sane Kaiaren will despawn within 30 minutes. If you lose Celestial Fists (book) you can no longer spawn Sane Kaiaren for the final epic turn in and will have to either 1) wait for another monk to spawn Sane Kaiaren or 2) petition for reimbursement and wait a month or more for Sirken's response.",
+          "order": 30
+        },
+        {
+          "id": "epic-monk-31-short-walkthrough-checklist-give-celestial-fists-book-to-mad-kaiaren-at-the-ruins-near-sebilis-i",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Give Celestial Fists (book) to mad Kaiaren at the ruins near Sebilis in Trakanon's Teeth and he hands you back the book, then he punches you in the face - you can either kill him or feign off the aggro.",
+          "order": 31
+        },
+        {
+          "id": "epic-monk-32-short-walkthrough-checklist-go-to-sane-kaiaren-who-spawns-over-by-the-lake-in-tt-p305-p2470-in-a",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Go to sane Kaiaren, who spawns over by the lake in TT (p305, p2470 in an empty hut) after you hand in Celestial Fists (book) to mad Kaiaren.",
+          "order": 32
+        },
+        {
+          "id": "epic-monk-33-short-walkthrough-checklist-hand-celestial-fists-book-to-sane-kaiaren-and-he-hands-you-back-a-sl",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Hand Celestial Fists (book) to sane Kaiaren and he hands you back a slightly different book called Book of Celestial Fists.",
+          "order": 33
+        },
+        {
+          "id": "epic-monk-34-short-walkthrough-checklist-final-turn-in",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Final Turn-in",
+          "order": 34
+        },
+        {
+          "id": "epic-monk-35-short-walkthrough-checklist-turn-in-the-modified-book-of-celestial-fists-and-demon-fangs-to-sane",
+          "className": "Monk",
+          "section": "Short Walkthrough/Checklist",
+          "text": "Turn in the modified Book of Celestial Fists and Demon Fangs to sane Kaiaren to receive the monk epic, Celestial Fists.",
+          "order": 35
+        },
+        {
+          "id": "epic-monk-36-long-walkthrough-with-dialogue-monk-sash-quests-to-obtain-red-sash-of-order",
+          "className": "Monk",
+          "section": "Long Walkthrough with dialogue",
+          "text": "Monk Sash Quests to obtain Red Sash of Order",
+          "order": 36
+        },
+        {
+          "id": "epic-monk-37-long-walkthrough-with-dialogue-monk-headband-quests-to-obtain-purple-headband",
+          "className": "Monk",
+          "section": "Long Walkthrough with dialogue",
+          "text": "Monk Headband Quests to obtain Purple Headband",
+          "order": 37
+        },
+        {
+          "id": "epic-monk-38-long-walkthrough-with-dialogue-monks-of-the-whistling-fist-to-obtain-robe-of-the-lost-circle",
+          "className": "Monk",
+          "section": "Long Walkthrough with dialogue",
+          "text": "Monks of The Whistling Fist to obtain Robe of the Lost Circle",
+          "order": 38
+        },
+        {
+          "id": "epic-monk-39-long-walkthrough-with-dialogue-the-lost-circle-to-obtain-robe-of-the-whistling-fists-which-is-re",
+          "className": "Monk",
+          "section": "Long Walkthrough with dialogue",
+          "text": "The Lost Circle to obtain Robe of the Whistling Fists, which is required in the next part of the monk epic",
+          "order": 39
+        },
+        {
+          "id": "epic-monk-40-final-turn-in-give-celestial-fists-book-to-mad-kaiaren-he-will-be-apprehensive-at-the-ruins-in-t",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "Give Celestial Fists (book) to mad Kaiaren (he will be apprehensive) at the ruins in Trakanon's Teeth and he hands you back the book.",
+          "order": 40
+        },
+        {
+          "id": "epic-monk-41-final-turn-in-go-to-sane-kaiaren-who-spawns-over-by-the-lake-in-tt-approx-300-2400-after-you-han",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "Go to sane Kaiaren, who spawns over by the lake in TT (approx +300, +2400) after you hand in Celestial Fists (book) to mad Kaiaren.",
+          "order": 41
+        },
+        {
+          "id": "epic-monk-42-final-turn-in-hand-celestial-fists-book-only-to-sane-kaiaren-and-he-hands-you-back-a-new-book-no",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "Hand Celestial Fists (book) ONLY to sane Kaiaren and he hands you back A NEW BOOK, now called Book of Celestial Fists.",
+          "order": 42
+        },
+        {
+          "id": "epic-monk-43-final-turn-in-turn-in-book-of-celestial-fists-and-demon-fangs-to-sane-kaiaren-to-receive-the-mon",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "Turn in Book of Celestial Fists and Demon Fangs to sane Kaiaren to receive the monk epic, Celestial Fists.",
+          "order": 43
+        },
+        {
+          "id": "epic-monk-44-final-turn-in-note-if-on-step-3-you-also-handed-in-demon-fangs-along-with-the-celestial-fists-bo",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "NOTE* If on step 3 you also handed in Demon Fangs along with the Celestial Fists (book), you can hand the Book of Celestial Fists back to Kaiaren to receive your epic.",
+          "order": 44
+        },
+        {
+          "id": "epic-monk-45-final-turn-in-quests",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "Quests",
+          "order": 45
+        },
+        {
+          "id": "epic-monk-46-final-turn-in-monk-quests",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "Monk Quests",
+          "order": 46
+        },
+        {
+          "id": "epic-monk-47-final-turn-in-this-page-was-last-edited-on-27-july-2026-at-18-13",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "This page was last edited on 27 July 2026, at 18:13.",
+          "order": 47
+        },
+        {
+          "id": "epic-monk-48-final-turn-in-privacy-policy",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "Privacy policy",
+          "order": 48
+        },
+        {
+          "id": "epic-monk-49-final-turn-in-about-everquest-legends-wiki",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "About EverQuest Legends Wiki",
+          "order": 49
+        },
+        {
+          "id": "epic-monk-50-final-turn-in-disclaimers",
+          "className": "Monk",
+          "section": "Final Turn-in",
+          "text": "Disclaimers",
+          "order": 50
+        }
+      ]
+    },
+    {
+      "className": "Necromancer",
+      "rows": [
+        {
+          "id": "epic-necromancer-0-symbol-of-the-apprentice-optional-hail-venenzi-oberzendi-in-nektulos-forest",
+          "className": "Necromancer",
+          "section": "Symbol of the Apprentice",
+          "text": "(optional) Hail Venenzi Oberzendi in Nektulos Forest",
+          "order": 0
+        },
+        {
+          "id": "epic-necromancer-1-symbol-of-the-apprentice-optional-hail-kazen-fecae-in-lake-rathetear",
+          "className": "Necromancer",
+          "section": "Symbol of the Apprentice",
+          "text": "(optional) Hail Kazen Fecae in Lake Rathetear",
+          "order": 1
+        },
+        {
+          "id": "epic-necromancer-2-symbol-of-the-apprentice-kill-sir-edwin-motte-and-loot-his-head",
+          "className": "Necromancer",
+          "section": "Symbol of the Apprentice",
+          "text": "Kill Sir Edwin Motte and loot his Head",
+          "order": 2
+        },
+        {
+          "id": "epic-necromancer-3-symbol-of-the-apprentice-give-the-head-to-kazen-fecae-for-the-symbol-of-the-apprentice",
+          "className": "Necromancer",
+          "section": "Symbol of the Apprentice",
+          "text": "Give the Head to Kazen Fecae for the Symbol of the Apprentice",
+          "order": 3
+        },
+        {
+          "id": "epic-necromancer-4-symbol-of-the-serpent-give-the-symbol-to-venenzi-oberzendi-in-nektulos-forest-for-the-twisted-sy",
+          "className": "Necromancer",
+          "section": "Symbol of the Serpent",
+          "text": "Give the Symbol to Venenzi Oberzendi in Nektulos Forest for the Twisted Symbol of the Apprentice",
+          "order": 4
+        },
+        {
+          "id": "epic-necromancer-5-symbol-of-the-serpent-kill-najena-npc-and-loot-the-flowing-black-robe",
+          "className": "Necromancer",
+          "section": "Symbol of the Serpent",
+          "text": "Kill Najena (NPC) and loot the Flowing Black Robe",
+          "order": 5
+        },
+        {
+          "id": "epic-necromancer-6-symbol-of-the-serpent-give-the-flowing-black-robe-to-venenzi-for-rolling-stone-moss",
+          "className": "Necromancer",
+          "section": "Symbol of the Serpent",
+          "text": "Give the Flowing Black Robe to Venenzi for Rolling Stone Moss",
+          "order": 6
+        },
+        {
+          "id": "epic-necromancer-7-symbol-of-the-serpent-head-to-lake-rathetear-give-the-rolling-stone-moss-and-the-twisted-symbol-",
+          "className": "Necromancer",
+          "section": "Symbol of the Serpent",
+          "text": "Head to Lake Rathetear, Give the Rolling Stone Moss and the Twisted Symbol of the Apprentice to Emkel Kabae.",
+          "order": 7
+        },
+        {
+          "id": "epic-necromancer-8-symbol-of-the-serpent-receive-symbol-of-the-serpent",
+          "className": "Necromancer",
+          "section": "Symbol of the Serpent",
+          "text": "Receive Symbol of the Serpent",
+          "order": 8
+        },
+        {
+          "id": "epic-necromancer-9-symbol-of-testing-hail-ssessthrass-in-swamp-of-no-hope-and-give-him-the-symbol-of-the-serpent-fo",
+          "className": "Necromancer",
+          "section": "Symbol of Testing",
+          "text": "Hail Ssessthrass in Swamp of No Hope and give him the Symbol of the Serpent for the Scaled Symbol of the Serpent",
+          "order": 9
+        },
+        {
+          "id": "epic-necromancer-10-symbol-of-testing-kill-grand-herbalist-mak-ha-royal-sarnak-herbalist-in-chardok-and-loot-the-man",
+          "className": "Necromancer",
+          "section": "Symbol of Testing",
+          "text": "Kill Grand Herbalist Mak`ha/Royal Sarnak Herbalist in Chardok and loot the Manisi Herb",
+          "order": 10
+        },
+        {
+          "id": "epic-necromancer-11-symbol-of-testing-give-the-manisi-herb-and-the-scaled-symbol-of-the-serpent-to-ssessthrass-for-a",
+          "className": "Necromancer",
+          "section": "Symbol of Testing",
+          "text": "Give the Manisi Herb and the Scaled Symbol of the Serpent to Ssessthrass for a Refined Mainsi Herb",
+          "order": 11
+        },
+        {
+          "id": "epic-necromancer-12-symbol-of-testing-give-the-refined-mainsi-herb-to-emkel-kabae-for-the-symbol-of-testing",
+          "className": "Necromancer",
+          "section": "Symbol of Testing",
+          "text": "Give the Refined Mainsi Herb to Emkel Kabae for the Symbol of Testing",
+          "order": 12
+        },
+        {
+          "id": "epic-necromancer-13-symbol-of-insanity-optional-give-the-symbol-of-testing-to-kazen-fecae",
+          "className": "Necromancer",
+          "section": "Symbol of Insanity",
+          "text": "OPTIONAL: Give the Symbol of Testing to Kazen Fecae",
+          "order": 13
+        },
+        {
+          "id": "epic-necromancer-14-symbol-of-insanity-or-kill-kazen-fecae-see-kazen-s-page-for-more-info-on-the-fight",
+          "className": "Necromancer",
+          "section": "Symbol of Insanity",
+          "text": "OR Kill Kazen Fecae (see Kazen's page for more info on the fight)",
+          "order": 14
+        },
+        {
+          "id": "epic-necromancer-15-symbol-of-insanity-go-to-the-small-inlet-east-of-emkel-and-kill-a-bone-golem",
+          "className": "Necromancer",
+          "section": "Symbol of Insanity",
+          "text": "Go to the small inlet east of Emkel and kill a bone golem",
+          "order": 15
+        },
+        {
+          "id": "epic-necromancer-16-symbol-of-insanity-kill-a-failed-apprentice",
+          "className": "Necromancer",
+          "section": "Symbol of Insanity",
+          "text": "Kill a failed apprentice",
+          "order": 16
+        },
+        {
+          "id": "epic-necromancer-17-symbol-of-insanity-kill-a-tortured-soul-and-loot-the-symbol-of-insanity",
+          "className": "Necromancer",
+          "section": "Symbol of Insanity",
+          "text": "Kill A tortured soul and loot the Symbol of Insanity",
+          "order": 17
+        },
+        {
+          "id": "epic-necromancer-18-gzallk-in-a-box-give-the-symbol-of-insanity-to-drendico-metalbones-in-timorous-deep-and-receive-",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Give the Symbol of Insanity to Drendico Metalbones in Timorous Deep and receive the Journal",
+          "order": 18
+        },
+        {
+          "id": "epic-necromancer-19-gzallk-in-a-box-speak-to-jzil-gsix-in-plane-of-sky",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Speak to Jzil GSix in Plane of Sky",
+          "order": 19
+        },
+        {
+          "id": "epic-necromancer-20-gzallk-in-a-box-kill-an-azarack-s-and-other-second-isle-monsters-for-the-silver-disc",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Kill An azarack's and other second isle monsters for the Silver Disc",
+          "order": 20
+        },
+        {
+          "id": "epic-necromancer-21-gzallk-in-a-box-kill-a-gorgalask-and-other-third-isle-monsters-for-the-spiroc-feathers",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Kill A gorgalask and other third isle monsters for the Spiroc Feathers",
+          "order": 21
+        },
+        {
+          "id": "epic-necromancer-22-gzallk-in-a-box-kill-keeper-of-souls-for-the-black-silk-cape",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Kill Keeper of Souls for the Black Silk Cape",
+          "order": 22
+        },
+        {
+          "id": "epic-necromancer-23-gzallk-in-a-box-give-the-items-to-jzil-gsix-for-the-cloak-of-spiroc-feathers",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Give the items to Jzil GSix for the Cloak of Spiroc Feathers",
+          "order": 23
+        },
+        {
+          "id": "epic-necromancer-24-gzallk-in-a-box-kill-mini-bosses-formerly-innoruuk-god-from-plane-of-hate-for-the-eye-of-innoruu",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Kill Mini-Bosses formerly Innoruuk (God) from Plane of Hate for the Eye of Innoruuk",
+          "order": 24
+        },
+        {
+          "id": "epic-necromancer-25-gzallk-in-a-box-kill-cazic-thule-god-or-the-golems-from-plane-of-fear-for-the-slime-blood-of-caz",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Kill Cazic Thule (God) or the golems from Plane of Fear for the Slime Blood of Cazic Thule",
+          "order": 25
+        },
+        {
+          "id": "epic-necromancer-26-gzallk-in-a-box-give-the-cloak-of-spiroc-feathers-eye-of-innoruuk-slime-blood-of-cazic-thule-and",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Give the Cloak of Spiroc Feathers, Eye of Innoruuk, Slime Blood of Cazic Thule, and Journal to Drendico Metalbones and receive the Prepared Regents Box",
+          "order": 26
+        },
+        {
+          "id": "epic-necromancer-27-gzallk-in-a-box-give-the-prepared-regents-box-to-kazen-for-the-tome-of-instruction",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Give the Prepared Regents Box to Kazen for the Tome of Instruction",
+          "order": 27
+        },
+        {
+          "id": "epic-necromancer-28-gzallk-in-a-box-give-the-tome-of-instruction-to-gkzzallk-for-gkzzallk-in-a-box-see-the-note-belo",
+          "className": "Necromancer",
+          "section": "Gzallk in a Box",
+          "text": "Give the Tome of Instruction to Gkzzallk for Gkzzallk in a Box -- See the note below. Do not do this step on someone else's (or your own Guild's) Sky slot without contacting their officers first. This will despawn the island 1 boss AND prevent them from raiding normally until respawn.",
+          "order": 28
+        },
+        {
+          "id": "epic-necromancer-29-scythe-of-the-shadowed-soul-give-gkzzallk-in-a-box-to-kazen-fecae-for-scythe-of-the-shadowed-sou",
+          "className": "Necromancer",
+          "section": "Scythe of the Shadowed Soul",
+          "text": "Give Gkzzallk in a Box to Kazen Fecae for Scythe of the Shadowed Soul",
+          "order": 29
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "rows": [
+        {
+          "id": "epic-paladin-0-checklist-complete-quest-for-the-fiery-avenger-which-includes-the-quest-for-soulfire-and-camping",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Complete quest for The Fiery Avenger, which includes the quest for SoulFire and camping (or questing) Ghoulbane",
+          "order": 0
+        },
+        {
+          "id": "epic-paladin-1-checklist-tainted-darksteel-breastplate-thought-destroyer-in-plane-of-hate",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Tainted Darksteel Breastplate - thought destroyer in Plane of Hate.",
+          "order": 1
+        },
+        {
+          "id": "epic-paladin-2-checklist-do-the-pure-crystal-quest-or-in-other-words-find-jark-in-north-kaladim-tell-him-i-will",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Do the Pure Crystal Quest or in other words Find Jark in North Kaladim. Tell him \"I will get your dinner\". Nella Stonebraids will spawn in the temple area, tell her \"Do you have Jark's Dinner-\" Receive: Cold Plate of Beef and Bread",
+          "order": 2
+        },
+        {
+          "id": "epic-paladin-3-checklist-give-cold-plate-of-beef-and-bread-to-jark-receive-pure-crystal",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Give Cold Plate of Beef and Bread to Jark Receive: Pure Crystal.",
+          "order": 3
+        },
+        {
+          "id": "epic-paladin-4-checklist-give-tainted-darksteel-breastplate-and-pure-crystal-to-reklon-gnallen-in-quellious-tem",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Give Tainted Darksteel Breastplate and Pure Crystal to Reklon Gnallen in Quellious Temple in Erudin for Gleaming Crested Breastplate.",
+          "order": 4
+        },
+        {
+          "id": "epic-paladin-5-checklist-tainted-darksteel-sword-keeper-of-the-tombs-the-hole",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Tainted Darksteel Sword - Keeper of the Tombs, the Hole.",
+          "order": 5
+        },
+        {
+          "id": "epic-paladin-6-checklist-tell-a-peasant-woman-in-west-freeport-at-190-725-i-will-take-it-to-him-receive-bucket-",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Tell a peasant woman in West Freeport at -190, -725 \"I will take it to him.\" Receive: Bucket of Water",
+          "order": 6
+        },
+        {
+          "id": "epic-paladin-7-checklist-give-the-bucket-of-water-to-joshua-in-west-freeport-at-245-710-in-the-back-of-the-bake",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Give the Bucket of Water to Joshua in West Freeport at -245, -710 in the back of the bakery. Receive: Bucket of Pure Water",
+          "order": 7
+        },
+        {
+          "id": "epic-paladin-8-checklist-give-the-tainted-darksteel-sword-and-bucket-of-pure-water-to-reklon-gnallen-in-quellio",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Give the Tainted Darksteel Sword and Bucket of Pure Water to Reklon Gnallen in Quellious Temple in Erudin Recieve: Gleaming Crested Sword.",
+          "order": 8
+        },
+        {
+          "id": "epic-paladin-9-checklist-tainted-darksteel-shield-kirak-vil-56th-level-nektulous-forest",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Tainted Darksteel Shield - Kirak Vil (56th level), Nektulous Forest.",
+          "order": 9
+        },
+        {
+          "id": "epic-paladin-10-checklist-give-to-elia-the-pure-in-felwithe-for-gleaming-crested-shield",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Give to Elia the Pure, in Felwithe, for Gleaming Crested Shield.",
+          "order": 10
+        },
+        {
+          "id": "epic-paladin-11-checklist-turn-in-the-three-purified-items-gleaming-crested-shield-gleaming-crested-breastplate-",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Turn in the three purified items (Gleaming Crested Shield, Gleaming Crested Breastplate, and Gleaming Crested Sword) to Reklon Gnallen for the Mark of Atonement.",
+          "order": 11
+        },
+        {
+          "id": "epic-paladin-12-checklist-turn-in-mark-of-atonement-and-fiery-avenger-to-irak-altil-a-wandering-skeleton-in-plan",
+          "className": "Paladin",
+          "section": "Checklist",
+          "text": "Turn in Mark of Atonement and Fiery Avenger to Irak Altil, a wandering skeleton in Plane of Fear to receive your Fiery Defender.",
+          "order": 12
+        },
+        {
+          "id": "epic-paladin-13-resources-the-white-cross-fiery-defender-walkthrough-with-pictures",
+          "className": "Paladin",
+          "section": "Resources",
+          "text": "The White Cross - Fiery Defender Walkthrough (with pictures)",
+          "order": 13
+        }
+      ]
+    },
+    {
+      "className": "Ranger",
+      "rows": [
+        {
+          "id": "epic-ranger-0-making-the-hardened-mixture-ask-telin-darkforest-in-burning-wood-what-action-and-receive-a-worn-",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Ask Telin Darkforest in Burning Wood \"what action\" and receive a Worn Note.",
+          "order": 0
+        },
+        {
+          "id": "epic-ranger-1-making-the-hardened-mixture-spawn-faelin-bloodbriar-in-greater-faydark-and-give-her-the-worn-not",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Spawn Faelin Bloodbriar in Greater Faydark and give her the Worn Note, receiving Faelin`s Ring.",
+          "order": 1
+        },
+        {
+          "id": "epic-ranger-2-making-the-hardened-mixture-find-giz-x-tin-in-kithicor-forest-and-give-him-faelin-s-ring-receivi",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Find Giz X`Tin in Kithicor Forest and give him Faelin`s Ring, receiving a Dark Metal Coin.",
+          "order": 2
+        },
+        {
+          "id": "epic-ranger-3-making-the-hardened-mixture-give-coin-to-telin-darkforest-receive-worn-dark-metal-coin",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Give coin to Telin Darkforest, receive Worn Dark Metal Coin",
+          "order": 3
+        },
+        {
+          "id": "epic-ranger-4-making-the-hardened-mixture-give-sionae-the-braided-grass-amulet-frayed-braided-grass-amulet-is-",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Give Sionae the Braided Grass Amulet, Frayed Braided Grass Amulet is returned.",
+          "order": 4
+        },
+        {
+          "id": "epic-ranger-5-making-the-hardened-mixture-give-nuien-the-frayed-braided-grass-amulet-frayed-braided-grass-amul",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Give Nuien the Frayed Braided Grass Amulet, Frayed Braided Grass Amulet is returned.",
+          "order": 5
+        },
+        {
+          "id": "epic-ranger-6-making-the-hardened-mixture-give-teloa-the-frayed-braided-grass-amulet-spawning-a-dark-elf-corru",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Give Teloa the Frayed Braided Grass Amulet, spawning a Dark Elf Corruptor and two Dark Elf Reavers and they run really fast when spawned, almost SOW fast.",
+          "order": 6
+        },
+        {
+          "id": "epic-ranger-7-making-the-hardened-mixture-kill-the-dark-elf-corruptor-loot-fleshbound-tome-give-to-althele-rec",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Kill the Dark Elf Corruptor, loot Fleshbound Tome, give to Althele, receive a Earth Stained Note.",
+          "order": 7
+        },
+        {
+          "id": "epic-ranger-8-making-the-hardened-mixture-give-ella-foodcrafter-in-misty-thicket-the-earth-stained-note-and-re",
+          "className": "Ranger",
+          "section": "Making the Hardened Mixture",
+          "text": "Give Ella Foodcrafter in Misty Thicket the Earth Stained Note and receive a Shiny Tin Bowl.",
+          "order": 8
+        },
+        {
+          "id": "epic-ranger-9-acquiring-the-shiny-tin-bowl-chilled-tundra-root-from-everfrost-note-if-you-forage-a-rose-of-fir",
+          "className": "Ranger",
+          "section": "Acquiring the Shiny Tin Bowl",
+          "text": "Chilled Tundra Root from Everfrost. NOTE: If you forage a Rose of Firiona before coming here, you can stop by Surefall Glade while you're in this neck of the woods and give the rose to Merdan Fleetfoot for a later step",
+          "order": 9
+        },
+        {
+          "id": "epic-ranger-10-acquiring-the-shiny-tin-bowl-ripened-heartfruit-from-greater-faydark",
+          "className": "Ranger",
+          "section": "Acquiring the Shiny Tin Bowl",
+          "text": "Ripened Heartfruit from Greater Faydark.",
+          "order": 10
+        },
+        {
+          "id": "epic-ranger-11-acquiring-the-shiny-tin-bowl-speckled-molded-mushroom-from-innothule-swamp",
+          "className": "Ranger",
+          "section": "Acquiring the Shiny Tin Bowl",
+          "text": "Speckled Molded Mushroom from Innothule Swamp.",
+          "order": 11
+        },
+        {
+          "id": "epic-ranger-12-acquiring-the-shiny-tin-bowl-sweetened-mudroot-from-misty-thicket",
+          "className": "Ranger",
+          "section": "Acquiring the Shiny Tin Bowl",
+          "text": "Sweetened Mudroot from Misty Thicket.",
+          "order": 12
+        },
+        {
+          "id": "epic-ranger-13-forage-the-following-four-items-combine-all-four-items-in-the-shiny-tin-bowl-to-make-a-hardened-",
+          "className": "Ranger",
+          "section": "Forage the following four items:",
+          "text": "Combine all four items in the Shiny Tin Bowl to make a Hardened Mixture. Don't destroy the Shiny Tin Bowl you'll need it later in the quest.",
+          "order": 13
+        },
+        {
+          "id": "epic-ranger-14-making-the-runecrested-bowl-talk-to-alrik-farsight-in-timorous-deep-and-receive-a-crushed-pot",
+          "className": "Ranger",
+          "section": "Making the Runecrested Bowl",
+          "text": "Talk to Alrik Farsight in Timorous Deep and receive a Crushed Pot.",
+          "order": 14
+        },
+        {
+          "id": "epic-ranger-15-making-the-runecrested-bowl-give-farios-elianos-in-felwithe-the-crushed-pot-and-receive-a-grocer",
+          "className": "Ranger",
+          "section": "Making the Runecrested Bowl",
+          "text": "Give Farios Elianos in Felwithe the Crushed Pot and receive a Grocery List.",
+          "order": 15
+        },
+        {
+          "id": "epic-ranger-16-making-the-runecrested-bowl-give-merchant-nora-in-northern-felwithe-the-grocery-list-and-receive",
+          "className": "Ranger",
+          "section": "Making the Runecrested Bowl",
+          "text": "Give Merchant Nora in Northern Felwithe the Grocery List and receive a Bag of Provisions.",
+          "order": 16
+        },
+        {
+          "id": "epic-ranger-17-making-the-runecrested-bowl-give-the-bag-of-provisions-to-farios-elianos-and-receive-a-receipt",
+          "className": "Ranger",
+          "section": "Making the Runecrested Bowl",
+          "text": "Give the Bag of Provisions to Farios Elianos and receive a Receipt.",
+          "order": 17
+        },
+        {
+          "id": "epic-ranger-18-making-the-runecrested-bowl-give-the-receipt-to-alrik-farsight-and-receive-an-ancient-pattern",
+          "className": "Ranger",
+          "section": "Making the Runecrested Bowl",
+          "text": "Give the Receipt to Alrik Farsight and receive an Ancient Pattern.",
+          "order": 18
+        },
+        {
+          "id": "epic-ranger-19-the-ancient-pattern-forage-a-rose-of-firiona-from-firiona-vie",
+          "className": "Ranger",
+          "section": "The Ancient Pattern",
+          "text": "Forage a Rose of Firiona from Firiona Vie.",
+          "order": 19
+        },
+        {
+          "id": "epic-ranger-20-the-ancient-pattern-hail-merdan-fleetfoot-ask-him-who-is-niera-then-hand-him-the-rose-of-firiona",
+          "className": "Ranger",
+          "section": "The Ancient Pattern",
+          "text": "Hail Merdan Fleetfoot, ask him \"Who is Niera-\", then hand him the Rose of Firiona receiving a Wood Painting.",
+          "order": 20
+        },
+        {
+          "id": "epic-ranger-21-the-ancient-pattern-track-down-a-human-skeleton-in-frontier-mountains-give-it-the-wood-painting-",
+          "className": "Ranger",
+          "section": "The Ancient Pattern",
+          "text": "Track down a human skeleton in Frontier Mountains, give it the Wood Painting receiving a Silver Chained Locket.",
+          "order": 21
+        },
+        {
+          "id": "epic-ranger-22-the-ancient-pattern-give-niera-farbreeze-in-surefall-glade-the-silver-chained-locket-receiving-p",
+          "className": "Ranger",
+          "section": "The Ancient Pattern",
+          "text": "Give Niera Farbreeze in Surefall Glade the Silver Chained Locket receiving Platinum Speckled Powder.",
+          "order": 22
+        },
+        {
+          "id": "epic-ranger-23-the-platinum-speckled-powder-slay-black-reavers-in-city-of-mist-and-loot-a-jade-reaver",
+          "className": "Ranger",
+          "section": "The Platinum Speckled Powder",
+          "text": "Slay black reavers in City of Mist and loot a Jade Reaver.",
+          "order": 23
+        },
+        {
+          "id": "epic-ranger-24-the-platinum-speckled-powder-speak-to-kinlo-strongarm-in-north-kaladim-and-give-him-the-jade-rea",
+          "className": "Ranger",
+          "section": "The Platinum Speckled Powder",
+          "text": "Speak to Kinlo Strongarm in North Kaladim and give him the Jade Reaver receiving Enchanted Clay.",
+          "order": 24
+        },
+        {
+          "id": "epic-ranger-25-the-enchanted-clay-combine-the-ancient-pattern-platinum-speckled-powder-and-enchanted-clay-in-a-",
+          "className": "Ranger",
+          "section": "The Enchanted Clay",
+          "text": "Combine the Ancient Pattern, Platinum Speckled Powder, and Enchanted Clay in a pottery wheel creating a Runecrested Bowl.",
+          "order": 25
+        },
+        {
+          "id": "epic-ranger-26-making-swiftwind-give-the-hardened-mixture-and-runecrested-bowl-to-ella-foodcrafter-receiving-a-",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Give the Hardened Mixture and Runecrested Bowl to Ella Foodcrafter, receiving a Softly glowing stone.",
+          "order": 26
+        },
+        {
+          "id": "epic-ranger-27-making-swiftwind-create-a-summoned-firefly-globe-level-1-druid-spell-no-rent-only-castable-at-ni",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Create a Summoned: Firefly Globe (level 1 Druid spell, NO RENT, only castable at night: 7p - 4a).",
+          "order": 27
+        },
+        {
+          "id": "epic-ranger-28-making-swiftwind-purchase-scroll-of-resurrection-level-49-cleric-spell",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Purchase Scroll of Resurrection (level 49 Cleric spell).",
+          "order": 28
+        },
+        {
+          "id": "epic-ranger-29-making-swiftwind-give-venril-sathir-remains-in-karnor-s-castle-the-summoned-firefly-globe-to-spa",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Give Venril Sathir Remains in Karnor's Castle the Summoned: Firefly Globe to spawn Spirit of Venril Sathir.",
+          "order": 29
+        },
+        {
+          "id": "epic-ranger-30-making-swiftwind-give-spirit-of-venril-sathir-in-karnor-s-castle-the-spell-resurrection-to-spawn",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Give Spirit of Venril Sathir in Karnor's Castle the Spell: Resurrection to spawn Venril Sathir.",
+          "order": 30
+        },
+        {
+          "id": "epic-ranger-31-making-swiftwind-slay-venril-sathir-in-karnor-s-castle-and-loot-a-pulsing-green-stone",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Slay Venril Sathir in Karnor's Castle and loot a Pulsing Green Stone.",
+          "order": 31
+        },
+        {
+          "id": "epic-ranger-32-making-swiftwind-give-foloal-stormforest-in-firiona-vie-the-pulsing-green-stone-and-softly-glowi",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Give Foloal Stormforest in Firiona Vie the Pulsing Green Stone and Softly Glowing Stone, receiving a Warmly Glowing Stone.",
+          "order": 32
+        },
+        {
+          "id": "epic-ranger-33-making-swiftwind-give-telin-darkforest-the-warmly-glowing-stone-receiving-an-ancient-longsword",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Give Telin Darkforest the Warmly Glowing Stone receiving an Ancient Longsword.",
+          "order": 33
+        },
+        {
+          "id": "epic-ranger-34-making-swiftwind-check-below-for-how-to-spawn-usbak-the-old",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Check Below for How to Spawn Usbak the Old",
+          "order": 34
+        },
+        {
+          "id": "epic-ranger-35-making-swiftwind-hail-usbak-the-old-and-give-him-the-ancient-longsword-receiving-a-refined-ancie",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Hail Usbak the Old and give him the Ancient Longsword receiving a Refined Ancient Sword.",
+          "order": 35
+        },
+        {
+          "id": "epic-ranger-36-making-swiftwind-give-telin-darkforest-the-refined-ancient-sword-spawning-faelin-bloodbriar-then",
+          "className": "Ranger",
+          "section": "Making Swiftwind",
+          "text": "Give Telin Darkforest the Refined Ancient Sword spawning Faelin Bloodbriar, then give her the Refined Ancient Sword receiving Swiftwind.",
+          "order": 36
+        },
+        {
+          "id": "epic-ranger-37-making-refined-mithril-blade-slay-essence-tamers-in-plane-of-sky-and-loot-a-swirling-sphere-of-c",
+          "className": "Ranger",
+          "section": "Making Refined Mithril Blade",
+          "text": "Slay essence tamers in Plane of Sky and loot a Swirling Sphere of Color.",
+          "order": 37
+        },
+        {
+          "id": "epic-ranger-38-making-refined-mithril-blade-spawn-jaeil-the-insane-by-giving-jaeil-the-wretched-in-the-hole-ell",
+          "className": "Ranger",
+          "section": "Making Refined Mithril Blade",
+          "text": "Spawn Jaeil the Insane by giving Jaeil the Wretched in The Hole Ella's Shiny Tin Bowl and slay him. Loot a Soulbound Hammer.",
+          "order": 38
+        },
+        {
+          "id": "epic-ranger-39-making-refined-mithril-blade-speak-to-mairee-silentone-in-erudin-palace-and-give-her-the-soulbou",
+          "className": "Ranger",
+          "section": "Making Refined Mithril Blade",
+          "text": "Speak to Mairee Silentone in Erudin Palace and give her the Soulbound Hammer, receiving a Dwarven Smiths Hammer.",
+          "order": 39
+        },
+        {
+          "id": "epic-ranger-40-making-refined-mithril-blade-give-mairee-silentone-the-dwarven-smiths-hammer-and-swirling-sphere",
+          "className": "Ranger",
+          "section": "Making Refined Mithril Blade",
+          "text": "Give Mairee Silentone the Dwarven Smiths Hammer and Swirling Sphere of Color, receiving Hammer of the Ancients.",
+          "order": 40
+        },
+        {
+          "id": "epic-ranger-41-making-refined-mithril-blade-stop-obtain-ancient-longsword-from-telin-see-making-swiftwind-above",
+          "className": "Ranger",
+          "section": "Making Refined Mithril Blade",
+          "text": "STOP! OBTAIN Ancient Longsword FROM TELIN (see Making Swiftwind above). YOU NEED TO HAND THAT IN TO USBAK, WHO WILL DESPAWN!",
+          "order": 41
+        },
+        {
+          "id": "epic-ranger-42-making-refined-mithril-blade-give-kinlo-strongarm-the-hammer-of-the-ancients-spawning-usbak-the-",
+          "className": "Ranger",
+          "section": "Making Refined Mithril Blade",
+          "text": "Give Kinlo Strongarm the Hammer of the Ancients spawning Usbak the Old who gives you a Small bit of Mithril Ore.",
+          "order": 42
+        },
+        {
+          "id": "epic-ranger-43-making-refined-mithril-blade-give-kinlo-strongarm-the-small-bit-of-mithril-ore-receiving-a-refin",
+          "className": "Ranger",
+          "section": "Making Refined Mithril Blade",
+          "text": "Give Kinlo Strongarm the Small bit of Mithril Ore receiving a Refined Mithril Blade.",
+          "order": 43
+        },
+        {
+          "id": "epic-ranger-44-making-earthcaller-loot-a-shattered-emerald-of-corruption-from-the-plane-of-hate-mini-bosses-72-",
+          "className": "Ranger",
+          "section": "Making Earthcaller",
+          "text": "Loot a Shattered Emerald of Corruption from the Plane of Hate \"mini bosses\" (72 hour respawn) or Innoruuk.",
+          "order": 44
+        },
+        {
+          "id": "epic-ranger-45-making-earthcaller-give-xanuusus-in-north-karana-the-shattered-emerald-of-corruption-and-refined",
+          "className": "Ranger",
+          "section": "Making Earthcaller",
+          "text": "Give Xanuusus in North Karana the Shattered Emerald of Corruption and Refined Mithril Blade receiving Earthcaller.",
+          "order": 45
+        }
+      ]
+    },
+    {
+      "className": "Rogue",
+      "rows": [
+        {
+          "id": "epic-rogue-0-checklist-obtain-stanos-pouch",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Obtain Stanos' Pouch",
+          "order": 0
+        },
+        {
+          "id": "epic-rogue-1-checklist-optional-acquire-level-50-will-need-assistance-from-a-50-rogue-if-you-are-not-high-eno",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "(OPTIONAL) Acquire level 50 (will need assistance from a 50+ rogue if you are not high enough)",
+          "order": 1
+        },
+        {
+          "id": "epic-rogue-2-checklist-optional-go-to-the-qeynos-aqueducts-and-find-malka-rale-at-380-210-spawns-at-8pm-game-",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "(OPTIONAL) Go to the Qeynos Aqueducts and find Malka Rale at +380, -210 (spawns at 8PM game time), tell her 'I can help' to receive Stanos' Pouch.",
+          "order": 2
+        },
+        {
+          "id": "epic-rogue-3-checklist-pickpocketing-and-travel",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Pickpocketing and Travel",
+          "order": 3
+        },
+        {
+          "id": "epic-rogue-4-checklist-pickpocket-stained-parchment-top-from-founy-jestands-in-north-kaladim",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Pickpocket Stained Parchment Top from Founy Jestands in North Kaladim.",
+          "order": 4
+        },
+        {
+          "id": "epic-rogue-5-checklist-pickpocket-stained-parchment-bottom-from-tani-n-mar-in-neriak-third-gate",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Pickpocket Stained Parchment Bottom from Tani N`Mar in Neriak Third Gate.",
+          "order": 5
+        },
+        {
+          "id": "epic-rogue-6-checklist-hand-stanos-pouch-to-anson-mcbale-and-say-i-need-to-see-stanos-to-spawn-stanos-herkano",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Hand Stanos' Pouch to Anson Mcbale and say \"I need to see Stanos\" to spawn Stanos Herkanor and then turn both parchment pieces into Stanos in Highpass Hold to receive Combined Parchment.",
+          "order": 6
+        },
+        {
+          "id": "epic-rogue-7-checklist-give-combined-parchment-100pp-and-2-unstacked-bottle-of-milk-to-eldreth-in-lake-rathet",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Give Combined Parchment, 100pp, and 2 unstacked Bottle of Milk to Eldreth in Lake Rathetear. Receive Scribbled Parchment.",
+          "order": 7
+        },
+        {
+          "id": "epic-rogue-8-checklist-take-scribbled-parchment-to-yendar-starpyre-in-steamfont-mountains-receive-tattered-pa",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Take Scribbled Parchment to Yendar Starpyre in Steamfont Mountains. Receive Tattered Parchment.",
+          "order": 8
+        },
+        {
+          "id": "epic-rogue-9-checklist-book-of-souls",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Book of Souls",
+          "order": 9
+        },
+        {
+          "id": "epic-rogue-10-checklist-wizard-teleport-to-plane-of-hate-obtain-book-of-souls-10-hr-ground-spawn-at-60-325-56",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Wizard teleport to Plane of Hate, obtain Book of Souls (10 hr ground spawn at -60, +325, 56).",
+          "order": 10
+        },
+        {
+          "id": "epic-rogue-11-checklist-renux",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Renux",
+          "order": 11
+        },
+        {
+          "id": "epic-rogue-12-checklist-give-tattered-parchment-and-book-of-souls-to-yendar-starpyre-to-spawn-renux-kill-renux",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Give Tattered Parchment and Book of Souls to Yendar Starpyre to spawn Renux. Kill Renux Herkanor, loot Translated Parchment and, if it drops, Jagged Diamond Dagger*.",
+          "order": 12
+        },
+        {
+          "id": "epic-rogue-13-checklist-general-v-ghera",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "General V`Ghera",
+          "order": 13
+        },
+        {
+          "id": "epic-rogue-14-checklist-return-translated-parchment-to-stanos-receive-a-sealed-box-from-stanos",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Return Translated Parchment to Stanos. Receive a Sealed Box from Stanos.",
+          "order": 14
+        },
+        {
+          "id": "epic-rogue-15-checklist-travel-to-kithicor-forest-hand-in-a-sealed-box-to-any-of-the-dark-elves-to-spawn-gener",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Travel to Kithicor Forest, hand in a Sealed Box to any of the Dark Elves to spawn General V`ghera. IMPORTANT: Do not use hide or invisibility / IVU while turning in the box, but do use sneak. Verify that you are sneaking but not hidden and that the mob cons indifferent before turning-in or you may lose your progress!",
+          "order": 15
+        },
+        {
+          "id": "epic-rogue-16-checklist-kill-general-v-ghera-loot-general-s-pouch-and-if-it-drops-cazic-quill",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Kill General V`ghera. Loot General's Pouch and, if it drops, Cazic Quill*.",
+          "order": 16
+        },
+        {
+          "id": "epic-rogue-17-checklist-auxiliary-questing-if-they-did-not-previously-drop",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "*Auxiliary Questing (if they did not previously drop)",
+          "order": 17
+        },
+        {
+          "id": "epic-rogue-18-checklist-cazic-quill",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Cazic Quill",
+          "order": 18
+        },
+        {
+          "id": "epic-rogue-19-checklist-get-robe-of-the-kedge-from-phinigel-autropos-in-kedge-keep-or-a-rare-drop-from-coercer",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Get Robe of the Kedge from Phinigel Autropos in Kedge Keep or a rare drop from Coercer Q`ioul in Kithicor Forest.",
+          "order": 19
+        },
+        {
+          "id": "epic-rogue-20-checklist-get-robe-of-the-ishva-from-the-ishva-mal-in-splitpaw-or-a-rare-drop-from-coercer-q-iou",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Get Robe of the Ishva from The Ishva Mal in Splitpaw or a rare drop from Coercer Q`ioul in Kithicor Forest.",
+          "order": 20
+        },
+        {
+          "id": "epic-rogue-21-checklist-get-shining-metallic-robes-from-ghoul-archmagus-in-lower-guk-or-a-much-harder-yendar-s",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Get Shining Metallic Robes from Ghoul Archmagus in Lower Guk or a much harder Yendar Starpyre in Steamfont Mountains.",
+          "order": 21
+        },
+        {
+          "id": "epic-rogue-22-checklist-get-robe-of-the-oracle-from-oracle-of-k-arnon-in-ocean-of-tears",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Get Robe of the Oracle from Oracle of K`Arnon in Ocean of Tears.",
+          "order": 22
+        },
+        {
+          "id": "epic-rogue-23-checklist-turn-in-all-four-robes-to-vilnius-the-small-in-western-plains-of-karana-to-receive-caz",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Turn in all four robes to Vilnius the Small in Western Plains of Karana to receive Cazic Quill.",
+          "order": 23
+        },
+        {
+          "id": "epic-rogue-24-checklist-jagged-diamond-dagger",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Jagged Diamond Dagger",
+          "order": 24
+        },
+        {
+          "id": "epic-rogue-25-checklist-get-fleshripper-from-solusek-kobold-king-in-nagafen-s-lair",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Get Fleshripper from Solusek kobold king in Nagafen's Lair.",
+          "order": 25
+        },
+        {
+          "id": "epic-rogue-26-checklist-get-painbringer-from-kobold-champion-in-nagafen-s-lair",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Get Painbringer from Kobold champion in Nagafen's Lair.",
+          "order": 26
+        },
+        {
+          "id": "epic-rogue-27-checklist-get-mithril-two-handed-sword-from-the-froglok-king-in-lower-guk-live-side",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Get Mithril Two-Handed Sword from The froglok king in Lower Guk (live side).",
+          "order": 27
+        },
+        {
+          "id": "epic-rogue-28-checklist-get-gigantic-zweihander-from-karg-icebear-in-everfrost-peaks",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Get Gigantic Zweihander from Karg Icebear in Everfrost Peaks.",
+          "order": 28
+        },
+        {
+          "id": "epic-rogue-29-checklist-turn-in-all-four-blades-to-vilnius-the-small-in-western-plains-of-karana-to-receive-ja",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Turn in all four blades to Vilnius the Small in Western Plains of Karana to receive Jagged Diamond Dagger.",
+          "order": 29
+        },
+        {
+          "id": "epic-rogue-30-checklist-final-turn-in",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Final Turn in",
+          "order": 30
+        },
+        {
+          "id": "epic-rogue-31-checklist-turn-in-general-s-pouch-jagged-diamond-dagger-and-cazic-quill-to-stanos-herkanor-to-re",
+          "className": "Rogue",
+          "section": "Checklist",
+          "text": "Turn in General's Pouch, Jagged Diamond Dagger, and Cazic Quill to Stanos Herkanor to receive Ragebringer!",
+          "order": 31
+        }
+      ]
+    },
+    {
+      "className": "Shadow Knight",
+      "rows": [
+        {
+          "id": "epic-shadow-knight-0-the-letter-to-duriek-hail-kurron-ni-in-overthere-outpost",
+          "className": "Shadow Knight",
+          "section": "The Letter to Duriek",
+          "text": "Hail Kurron Ni in Overthere Outpost",
+          "order": 0
+        },
+        {
+          "id": "epic-shadow-knight-1-the-letter-to-duriek-give-kurron-ni-darkforge-breastplate-darkforge-greaves-darkforge-helm-and-9",
+          "className": "Shadow Knight",
+          "section": "The Letter to Duriek",
+          "text": "Give Kurron Ni Darkforge Breastplate, Darkforge Greaves, Darkforge Helm and 900 Platinum. You can get the armor through the Darkforge Armor Quests.",
+          "order": 1
+        },
+        {
+          "id": "epic-shadow-knight-2-the-letter-to-duriek-kill-kurron-ni-and-loot-the-letter-to-duriek",
+          "className": "Shadow Knight",
+          "section": "The Letter to Duriek",
+          "text": "Kill Kurron Ni and Loot the Letter to Duriek",
+          "order": 2
+        },
+        {
+          "id": "epic-shadow-knight-3-the-dusty-tome-give-the-letter-to-duriek-bloodpool-in-paineel",
+          "className": "Shadow Knight",
+          "section": "The Dusty Tome",
+          "text": "Give the letter to Duriek Bloodpool in Paineel",
+          "order": 3
+        },
+        {
+          "id": "epic-shadow-knight-4-the-dusty-tome-hail-smaka-in-neriak-foreign-quarter",
+          "className": "Shadow Knight",
+          "section": "The Dusty Tome",
+          "text": "Hail Smaka in Neriak Foreign Quarter",
+          "order": 4
+        },
+        {
+          "id": "epic-shadow-knight-5-the-dusty-tome-give-smaka-1000-platinum-for-a-cough-elixir",
+          "className": "Shadow Knight",
+          "section": "The Dusty Tome",
+          "text": "Give Smaka 1000 Platinum for a Cough Elixir",
+          "order": 5
+        },
+        {
+          "id": "epic-shadow-knight-6-the-dusty-tome-give-the-cough-elixir-to-duriek",
+          "className": "Shadow Knight",
+          "section": "The Dusty Tome",
+          "text": "Give the Cough Elixir to Duriek",
+          "order": 6
+        },
+        {
+          "id": "epic-shadow-knight-7-the-dusty-tome-kill-a-ratman-guard-in-the-hole-and-loot-a-dusty-tome",
+          "className": "Shadow Knight",
+          "section": "The Dusty Tome",
+          "text": "Kill a ratman guard in The Hole and loot a Dusty Tome",
+          "order": 7
+        },
+        {
+          "id": "epic-shadow-knight-8-the-dusty-tome-give-the-dusty-tome-to-duriek",
+          "className": "Shadow Knight",
+          "section": "The Dusty Tome",
+          "text": "Give the Dusty Tome to Duriek",
+          "order": 8
+        },
+        {
+          "id": "epic-shadow-knight-9-the-corrupted-ghoulbane-kill-the-the-froglok-shin-lord-in-ruins-of-upper-guk-and-loot-the-ghoulb",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Kill the The froglok shin lord in Ruins of Upper Guk and loot The Ghoulbane",
+          "order": 9
+        },
+        {
+          "id": "epic-shadow-knight-10-the-corrupted-ghoulbane-kill-cazic-thule-and-loot-the-soul-leech-dark-sword-of-blood-note-post-f",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Kill Cazic-Thule and Loot The Soul Leech, Dark Sword of Blood (NOTE: Post Fear Revamp this now drops off Fear Golems Fright, Dread, and Terror)",
+          "order": 10
+        },
+        {
+          "id": "epic-shadow-knight-11-the-corrupted-ghoulbane-kill-monsters-in-plane-of-sky-for-the-blade-of-abrogation",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Kill monsters in Plane of Sky for the Blade of Abrogation",
+          "order": 11
+        },
+        {
+          "id": "epic-shadow-knight-12-the-corrupted-ghoulbane-kill-rharzar-in-rathe-mountains-for-a-drake-spine",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Kill Rharzar in Rathe Mountains for a Drake Spine",
+          "order": 12
+        },
+        {
+          "id": "epic-shadow-knight-13-the-corrupted-ghoulbane-kill-an-ashenbone-drakes-in-plane-of-hate-for-a-decrepit-hide",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Kill An ashenbone drakes in Plane of Hate for a Decrepit Hide",
+          "order": 13
+        },
+        {
+          "id": "epic-shadow-knight-14-the-corrupted-ghoulbane-buy-a-platinum-bar-and-find-an-enchanter-to-make-an-enchanted-platinum-b",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Buy a Platinum Bar and find an enchanter to make an Enchanted Platinum Bar",
+          "order": 14
+        },
+        {
+          "id": "epic-shadow-knight-15-the-corrupted-ghoulbane-open-trade-window-click-hide-and-make-sure-you-con-indifferent-status-hi",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Open trade window, click Hide and make sure you con INDIFFERENT STATUS (Hiding is not needed if you have better faction). SUPER IMPORTANT! DO NOT HAND IN ITEMS W/O indifferent status or better. Teydar in the evil guild area of the Qeynos Aqueducts",
+          "order": 15
+        },
+        {
+          "id": "epic-shadow-knight-16-the-corrupted-ghoulbane-give-the-drake-spine-decrepit-hide-and-enchanted-platinum-bar-to-teydar-",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Give the Drake Spine, Decrepit Hide and Enchanted Platinum Bar to Teydar for a Decrepit Sheath",
+          "order": 16
+        },
+        {
+          "id": "epic-shadow-knight-17-the-corrupted-ghoulbane-go-to-duriek-open-trade-window-click-hide-and-make-sure-you-con-indiffer",
+          "className": "Shadow Knight",
+          "section": "The Corrupted Ghoulbane",
+          "text": "Go to Duriek. Open trade window, click Hide and make sure you con INDIFFERENT STATUS (Hiding is not needed if you have better faction). SUPER IMPORTANT! DO NOT HAND IN ITEMS W/O indifferent status or better. Give the Ghoulbane, the Soul Leech, Dark Sword of Blood, the Blade of Abrogation and the Decrepit Sheath to Duriek for the Corrupted Ghoulbane.",
+          "order": 17
+        },
+        {
+          "id": "epic-shadow-knight-18-the-dark-shroud-optional-hail-lhranc-in-the-city-of-mist",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "(Optional) Hail Lhranc in the City of Mist",
+          "order": 18
+        },
+        {
+          "id": "epic-shadow-knight-19-the-dark-shroud-optional-hail-marl-kastane-in-kerra-isle-and-say-i-have-the-will-of-innoruuk-and",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "(Optional) Hail Marl Kastane in Kerra Isle and say 'I have the will of innoruuk' and 'What prophecy-' to get a Seal of Kastane",
+          "order": 19
+        },
+        {
+          "id": "epic-shadow-knight-20-the-dark-shroud-optional-hail-gerot-kastane-in-paineel-and-give-him-the-seal-of-kastane-to-get-t",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "(Optional) Hail Gerot Kastane in Paineel and give him the Seal of Kastane to get the Note to Marl",
+          "order": 20
+        },
+        {
+          "id": "epic-shadow-knight-21-the-dark-shroud-optional-give-the-note-to-marl-to-marl-kastane",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "(Optional) Give the Note to Marl to Marl Kastane",
+          "order": 21
+        },
+        {
+          "id": "epic-shadow-knight-22-the-dark-shroud-hail-knarthenne-skurl-in-toxxulia-forest-and-say-what-heart-of-an-innocent-to-ge",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "Hail Knarthenne Skurl in Toxxulia Forest and say 'what heart of an innocent-' to get a Soulcase",
+          "order": 22
+        },
+        {
+          "id": "epic-shadow-knight-23-the-dark-shroud-gather-a-cell-key-from-a-mimic-looks-like-a-chest-in-the-city-bank-of-the-hole",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "Gather a Cell Key from a mimic (looks like a chest) in the city bank of the Hole",
+          "order": 23
+        },
+        {
+          "id": "epic-shadow-knight-24-the-dark-shroud-give-the-cell-key-to-caradon-you-must-be-indifferent-for-this-turn-in-use-hide-s",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "Give the Cell Key to Caradon (You must be indifferent for this turn-in) - Use \"Hide\" Skill.",
+          "order": 24
+        },
+        {
+          "id": "epic-shadow-knight-25-the-dark-shroud-kill-kyrenna-not-caradon-if-it-can-be-avoided-and-loot-blood-of-kyrenna-and-hear",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "Kill Kyrenna NOT Caradon (if it can be avoided) and Loot Blood of Kyrenna and Heart of Kyrenna",
+          "order": 25
+        },
+        {
+          "id": "epic-shadow-knight-26-the-dark-shroud-give-the-blood-of-kyrenna-to-marl-kastane-and-receive-the-dark-shroud-dont-feign",
+          "className": "Shadow Knight",
+          "section": "The Dark Shroud",
+          "text": "Give the Blood of Kyrenna to Marl Kastane and receive the Dark Shroud DONT FEIGN DEATH FOR THIS TURN-IN You must be Indifferent for this turn in (use \"Hide\" skill). Make sure to be Hidden for this turn in.",
+          "order": 26
+        },
+        {
+          "id": "epic-shadow-knight-27-lhranc-s-coin-give-the-dark-shroud-to-the-ghost-of-glohnor-in-the-hole-make-sure-to-con-indiff-w",
+          "className": "Shadow Knight",
+          "section": "Lhranc's Coin",
+          "text": "Give the Dark Shroud to the Ghost of Glohnor in the Hole (Make sure to con indiff w/ IVU!)",
+          "order": 27
+        },
+        {
+          "id": "epic-shadow-knight-28-lhranc-s-coin-kill-mummy-of-glohnor-and-loot-the-head-of-glohnor-and-the-glohnor-wrappings",
+          "className": "Shadow Knight",
+          "section": "Lhranc's Coin",
+          "text": "Kill Mummy of Glohnor and loot the Head of Glohnor and the Glohnor wrappings",
+          "order": 28
+        },
+        {
+          "id": "epic-shadow-knight-29-lhranc-s-coin-give-the-head-of-glohnor-to-gerot-kastane-and-receive-the-head-of-the-valiant-make",
+          "className": "Shadow Knight",
+          "section": "Lhranc's Coin",
+          "text": "Give the Head of Glohnor to Gerot Kastane and receive the Head of the Valiant (Make sure to con indifferent w/ hide!)",
+          "order": 29
+        },
+        {
+          "id": "epic-shadow-knight-30-lhranc-s-coin-give-the-glohnor-wrappings-to-marl-kastane-and-receive-the-will-of-innoruuk-make-s",
+          "className": "Shadow Knight",
+          "section": "Lhranc's Coin",
+          "text": "Give the Glohnor wrappings to Marl Kastane and receive the Will of Innoruuk (Make sure to con indifferent w/ hide!)",
+          "order": 30
+        },
+        {
+          "id": "epic-shadow-knight-31-lhranc-s-coin-combine-the-heart-of-kyrenna-with-the-soulcase-to-produce-the-heart-of-the-innocen",
+          "className": "Shadow Knight",
+          "section": "Lhranc's Coin",
+          "text": "Combine the Heart of Kyrenna with the Soulcase to produce the Heart of the Innocent",
+          "order": 31
+        },
+        {
+          "id": "epic-shadow-knight-32-lhranc-s-coin-give-the-corrupted-ghoulbane-the-heart-of-the-innocent-the-head-of-the-valiant-and",
+          "className": "Shadow Knight",
+          "section": "Lhranc's Coin",
+          "text": "Give the Corrupted Ghoulbane, the Heart of the Innocent, the Head of the Valiant and the Will of Innoruuk to Lhranc - Make sure you are indifferent to him before you do the hand in, have someone else cast IVU on you before you hit trade. He will respawn with the sword... prepare for a fight. If you wipe in fight, Lhranc won't despawn. Bring at least 2 groups.",
+          "order": 32
+        },
+        {
+          "id": "epic-shadow-knight-33-lhranc-s-coin-kill-lhranc-and-loot-innoruuk-s-curse-gratz",
+          "className": "Shadow Knight",
+          "section": "Lhranc's Coin",
+          "text": "Kill Lhranc and LOOT Innoruuk's Curse! Gratz!",
+          "order": 33
+        }
+      ]
+    },
+    {
+      "className": "Shaman",
+      "rows": [
+        {
+          "id": "epic-shaman-0-checklist-begin-quest-by-talking-to-a-lesser-spirit-after-killing-one-of-the-mobs-in-rm-oot-bbm-",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Begin quest by talking to a lesser spirit after killing one of the mobs in RM, OoT, BBM, or FoB, receive Tiny Gem from a Lesser Spirit (do not kill him).",
+          "order": 0
+        },
+        {
+          "id": "epic-shaman-1-checklist-take-gem-to-north-freeport-and-give-the-gem-to-bondl-felligan-who-will-lead-you-to-the",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Take gem to North Freeport and give the gem to Bondl Felligan who will lead you to the Jade Tiger and spawn Greater Spirits.",
+          "order": 1
+        },
+        {
+          "id": "epic-shaman-2-checklist-talk-to-the-proper-greater-spirit-for-your-god-until-you-get-an-opaque-gem",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Talk to the proper Greater Spirit for your god until you get an Opaque Gem.",
+          "order": 2
+        },
+        {
+          "id": "epic-shaman-3-checklist-test-of-patience-in-erud-s-crossing-receive-a-small-gem-from-a-greater-spirit",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Test of Patience in Erud\u2019s Crossing, receive a small gem from a Greater Spirit.",
+          "order": 3
+        },
+        {
+          "id": "epic-shaman-4-checklist-turn-gem-into-a-wandering-spirit-in-west-karana",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Turn gem into a wandering spirit in West Karana.",
+          "order": 4
+        },
+        {
+          "id": "epic-shaman-5-checklist-kill-glaron-the-wicked-drops-envy-woe-and-tabien-the-goodly-drops-marr-s-promise-in-ra",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Kill Glaron the Wicked (drops Envy & Woe) and Tabien the Goodly (drops Marr's Promise) in Rathe Mountains.",
+          "order": 5
+        },
+        {
+          "id": "epic-shaman-6-checklist-take-envy-woe-and-marr-s-promise-to-the-wandering-spirit-in-west-karana-generally-betw",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Take Envy, Woe, and Marr\u2019s Promise to the Wandering Spirit in West Karana (generally between Qeynos hills and bandit camp in the mountains,) receive Shield of Falsehood and gem in return.",
+          "order": 6
+        },
+        {
+          "id": "epic-shaman-7-checklist-take-gem-to-spirit-sentinel-in-emerald-jungle",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Take gem to Spirit Sentinel in Emerald Jungle.",
+          "order": 7
+        },
+        {
+          "id": "epic-shaman-8-checklist-kill-black-dire-in-mistmoore-minimum-level-5-to-zone-into-mistmoore-loot-black-dire-pe",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Kill Black Dire in Mistmoore (minimum level 5 to zone into Mistmoore), loot Black Dire Pelt.",
+          "order": 8
+        },
+        {
+          "id": "epic-shaman-9-checklist-turn-in-pelt-to-spirit-sentinel-in-emerald-jungle-you-need-faction-for-this-turn-in-re",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Turn in pelt to Spirit Sentinel in Emerald Jungle (you need faction for this turn in) Receive Black Fur Boots! Get 6 slot booklet from the spirit.",
+          "order": 9
+        },
+        {
+          "id": "epic-shaman-10-checklist-collect-6-reports-from-the-city-of-mist-for-booklet-turn-in-is-kindly-or-better",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Collect 6 reports from the City of Mist for booklet. (turn in is KINDLY or better)",
+          "order": 10
+        },
+        {
+          "id": "epic-shaman-11-checklist-combine-and-turn-in-completed-booklet-to-spirit-sentinel-in-emerald-jungle",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Combine and turn in completed booklet to Spirit Sentinel in Emerald Jungle.",
+          "order": 11
+        },
+        {
+          "id": "epic-shaman-12-checklist-kill-lord-ghiosk-in-the-city-of-mist-and-loot-the-3-books",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Kill Lord Ghiosk in the City of Mist and loot the 3 books.",
+          "order": 12
+        },
+        {
+          "id": "epic-shaman-13-checklist-turn-in-books-to-spirit-in-lake-in-emerald-jungle",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Turn in books to Spirit (in lake) in Emerald Jungle.",
+          "order": 13
+        },
+        {
+          "id": "epic-shaman-14-checklist-obtain-icon-of-the-high-scale-from-the-city-of-mist-ground-spawn-in-the-temple",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Obtain Icon of the High Scale from the City of Mist (ground spawn in the temple).",
+          "order": 14
+        },
+        {
+          "id": "epic-shaman-15-checklist-give-icon-to-high-scale-kirn-in-the-hole-kill-him-and-loot-his-ring",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Give Icon to High Scale Kirn in the Hole, kill him and loot his ring.",
+          "order": 15
+        },
+        {
+          "id": "epic-shaman-16-checklist-give-the-ring-to-neh-ashiir-in-the-city-of-mist-kill-her-loot-her-diary",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Give the ring to Neh`Ashiir in the City of Mist, kill her, loot her diary.",
+          "order": 16
+        },
+        {
+          "id": "epic-shaman-17-checklist-turn-in-the-diary-to-spirit-sentinel-in-emerald-jungle",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Turn in the diary to Spirit Sentinel in Emerald Jungle.",
+          "order": 17
+        },
+        {
+          "id": "epic-shaman-18-checklist-go-to-fear-to-kill-the-iksar-broodling-loot-child-s-tear-random-spawn-from-killing-gol",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Go to Fear to kill the Iksar Broodling, loot Child's Tear (random spawn from killing Golems, slay either Dread, Fright, or Terror).",
+          "order": 18
+        },
+        {
+          "id": "epic-shaman-19-checklist-give-the-tear-to-lord-rak-ashiir-in-city-of-mist-kill-him-and-loot-his-iksar-scale-you",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Give the tear to Lord Rak`Ashiir in City of Mist, kill him and loot his Iksar Scale. YOU NEED ALLY FACTION FOR THIS TURN IN -- JUST NOT MAXED ALLY",
+          "order": 19
+        },
+        {
+          "id": "epic-shaman-20-checklist-take-scale-to-spirit-sentinel-wolf-in-emerald-jungle-in-the-pond-to-receive-your-epic-",
+          "className": "Shaman",
+          "section": "Checklist",
+          "text": "Take Scale to Spirit Sentinel wolf in Emerald Jungle IN THE POND to receive your epic! YOU NEED MAX ALLY, NOT JUST ALLY",
+          "order": 20
+        },
+        {
+          "id": "epic-shaman-21-faction-based-completions-if-one-does-the-quest-with-all-the-steps-up-to-finishing-one-turn-in-o",
+          "className": "Shaman",
+          "section": "Faction-Based Completions",
+          "text": "If one does the quest with all the steps up to finishing one turn in of CoM pages, it takes 25 turn-ins of Envy, Woe, and Marr's Promise to the wandering spirit in West Karana to reach max Truespirit faction.",
+          "order": 21
+        },
+        {
+          "id": "epic-shaman-22-faction-based-completions-ogre-rallos-zek-shaman-went-from-indifferent-to-max-faction-by-doing-t",
+          "className": "Shaman",
+          "section": "Faction-Based Completions",
+          "text": "Ogre Rallos Zek Shaman went from indifferent to max faction by doing the Tiny Gem turn in 13 times, 1 turn in of Woe/Envy/Marr, 1 turn in of 6 CoM letters, 1 turn in of 3 CoM books, 1 turn in of Dire Pelt.",
+          "order": 22
+        },
+        {
+          "id": "epic-shaman-23-faction-based-completions-iksar-shaman-lvl-14-2x-turn-ins-of-envy-woe-and-marr-s-promise-got-me-",
+          "className": "Shaman",
+          "section": "Faction-Based Completions",
+          "text": "Iksar Shaman lvl 14 - 2x turn-ins of Envy, Woe, and Marr's Promise got me to amiable. I then went to turn in the resulting gem from the Wandering Spirit and was also able to complete the Black Fur Boots portion directly afterward (still amiable).",
+          "order": 23
+        },
+        {
+          "id": "epic-shaman-24-faction-based-completions-repeating-part-2-the-drunken-shaman-took-approximately-76-turn-ins-of-",
+          "className": "Shaman",
+          "section": "Faction-Based Completions",
+          "text": "Repeating Part 2 - The Drunken Shaman took approximately 76 turn ins of the 'Tiny Gem' to Bondl Felligan to go from start to max faction with Truespirit.",
+          "order": 24
+        },
+        {
+          "id": "epic-shaman-25-faction-based-completions-for-a-rallos-zek-ogre-it-only-took-me-20-hand-ins-to-bondl-felligan-to",
+          "className": "Shaman",
+          "section": "Faction-Based Completions",
+          "text": "For a Rallos Zek Ogre, it only took me 20 hand ins to Bondl Felligan to get to max ally.",
+          "order": 25
+        }
+      ]
+    },
+    {
+      "className": "Warrior",
+      "rows": [
+        {
+          "id": "epic-warrior-0-checklist-hail-kargek-redblade-and-wenden-blackhammer-in-east-freeport",
+          "className": "Warrior",
+          "section": "Checklist",
+          "text": "Hail Kargek Redblade and Wenden Blackhammer in East Freeport",
+          "order": 0
+        },
+        {
+          "id": "epic-warrior-1-checklist-retrieve-unjeweled-dragon-head-hilt-from-the-bottom-of-lake-rathetear",
+          "className": "Warrior",
+          "section": "Checklist",
+          "text": "Retrieve Unjeweled Dragon Head Hilt from the bottom of Lake Rathetear",
+          "order": 1
+        },
+        {
+          "id": "epic-warrior-2-checklist-give-the-unjeweled-dragon-head-hilt-a-diamond-a-jacinth-and-a-black-sapphire-to-wenden",
+          "className": "Warrior",
+          "section": "Checklist",
+          "text": "Give the Unjeweled Dragon Head Hilt, a Diamond, a Jacinth, and a Black Sapphire to Wenden Blackhammer",
+          "order": 2
+        },
+        {
+          "id": "epic-warrior-3-checklist-receive-the-jeweled-dragon-head-hilt",
+          "className": "Warrior",
+          "section": "Checklist",
+          "text": "Receive the Jeweled Dragon Head Hilt",
+          "order": 3
+        },
+        {
+          "id": "epic-warrior-4-jeweled-dragon-head-hilt-retrieve-severely-damaged-dragon-head-hilt-from-the-chessboard-in-timor",
+          "className": "Warrior",
+          "section": "Jeweled Dragon Head Hilt",
+          "text": "Retrieve Severely Damaged Dragon Head Hilt from the chessboard in Timorous Deep",
+          "order": 4
+        },
+        {
+          "id": "epic-warrior-5-jeweled-dragon-head-hilt-get-a-giant-sized-monocle-from-a-mountain-giant-patriarch-in-dreadlands",
+          "className": "Warrior",
+          "section": "Jeweled Dragon Head Hilt",
+          "text": "Get a Giant Sized Monocle from A mountain giant patriarch in Dreadlands",
+          "order": 5
+        },
+        {
+          "id": "epic-warrior-6-jeweled-dragon-head-hilt-give-the-giant-sized-monocle-to-mentrax-mountainbone-in-frontier-mounta",
+          "className": "Warrior",
+          "section": "Jeweled Dragon Head Hilt",
+          "text": "Give the Giant Sized Monocle to Mentrax Mountainbone in Frontier Mountains and receive Rejesiam Ore.",
+          "order": 6
+        },
+        {
+          "id": "epic-warrior-7-jeweled-dragon-head-hilt-kill-fright-dread-or-terror-and-loot-ball-of-everliving-golem-in-plane-",
+          "className": "Warrior",
+          "section": "Jeweled Dragon Head Hilt",
+          "text": "Kill Fright, Dread, or Terror and loot Ball of Everliving Golem in Plane of Fear",
+          "order": 7
+        },
+        {
+          "id": "epic-warrior-8-jeweled-dragon-head-hilt-give-severely-damaged-dragon-head-hilt-rejesiam-ore-and-ball-of-everliv",
+          "className": "Warrior",
+          "section": "Jeweled Dragon Head Hilt",
+          "text": "Give Severely Damaged Dragon Head Hilt, Rejesiam Ore, and Ball of Everliving Golem to Wenden Blackhammer (MQable)",
+          "order": 8
+        },
+        {
+          "id": "epic-warrior-9-jeweled-dragon-head-hilt-receive-finely-crafted-dragon-head-hilt",
+          "className": "Warrior",
+          "section": "Jeweled Dragon Head Hilt",
+          "text": "Receive Finely Crafted Dragon Head Hilt",
+          "order": 9
+        },
+        {
+          "id": "epic-warrior-10-finely-crafted-dragon-head-hilt-purchase-a-keg-of-vox-tail-ale-from-various-merchants-across-nor",
+          "className": "Warrior",
+          "section": "Finely Crafted Dragon Head Hilt",
+          "text": "Purchase A Keg of Vox Tail Ale from various merchants across Norrath.",
+          "order": 10
+        },
+        {
+          "id": "epic-warrior-11-finely-crafted-dragon-head-hilt-purchase-two-2-rebreathers-from-other-players-or-craft-as-a-gnom",
+          "className": "Warrior",
+          "section": "Finely Crafted Dragon Head Hilt",
+          "text": "Purchase two(2) Rebreathers from other players, or craft as a Gnome with Tinkering Skill, Trivial 175.",
+          "order": 11
+        },
+        {
+          "id": "epic-warrior-12-finely-crafted-dragon-head-hilt-kill-ice-giants-and-loot-block-of-permafrost-in-permafrost",
+          "className": "Warrior",
+          "section": "Finely Crafted Dragon Head Hilt",
+          "text": "Kill Ice Giants and Loot Block of Permafrost in Permafrost",
+          "order": 12
+        },
+        {
+          "id": "epic-warrior-13-finely-crafted-dragon-head-hilt-give-block-of-permafrost-a-keg-of-vox-tail-ale-and-the-two-2-reb",
+          "className": "Warrior",
+          "section": "Finely Crafted Dragon Head Hilt",
+          "text": "Give Block of Permafrost, A Keg of Vox Tail Ale, and the two(2) Rebreathers to Denken Strongpick in Ocean of Tears.",
+          "order": 13
+        },
+        {
+          "id": "epic-warrior-14-finely-crafted-dragon-head-hilt-receive-ancient-sword-blade",
+          "className": "Warrior",
+          "section": "Finely Crafted Dragon Head Hilt",
+          "text": "Receive Ancient Sword Blade",
+          "order": 14
+        },
+        {
+          "id": "epic-warrior-15-finely-crafted-dragon-head-hilt-kill-queen-velazul-di-zok-in-chardok-and-loot-ancient-blade",
+          "className": "Warrior",
+          "section": "Finely Crafted Dragon Head Hilt",
+          "text": "Kill Queen Velazul Di`zok in Chardok and loot Ancient Blade",
+          "order": 15
+        },
+        {
+          "id": "epic-warrior-16-the-blades-hail-kargek-redblade-and-get-wax-sealed-note-by-saying-what-favor",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Hail Kargek Redblade and get Wax Sealed Note by saying \"what favor\"",
+          "order": 16
+        },
+        {
+          "id": "epic-warrior-17-the-blades-give-wax-sealed-note-to-oknoggin-stonesmacker-in-feerrott-and-receive-tiny-lute",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Give Wax Sealed Note to Oknoggin Stonesmacker in Feerrott and receive Tiny Lute",
+          "order": 17
+        },
+        {
+          "id": "epic-warrior-18-the-blades-give-tiny-lute-to-kargek-redblade-and-receive-the-book-redblade-s-legacy",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Give Tiny Lute to Kargek Redblade and receive the book Redblade's Legacy",
+          "order": 18
+        },
+        {
+          "id": "epic-warrior-19-the-blades-give-book-to-tenal-redblade-in-east-karana-and-receive-totem-of-the-freezing-war",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Give book to Tenal Redblade in East Karana and receive Totem of the Freezing War",
+          "order": 19
+        },
+        {
+          "id": "epic-warrior-20-the-blades-kill-goblin-wizards-in-permafrost-loot-heart-of-frost",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Kill goblin wizards in Permafrost, loot Heart of Frost",
+          "order": 20
+        },
+        {
+          "id": "epic-warrior-21-the-blades-give-totem-of-the-freezing-war-and-heart-of-frost-to-tenal-redblade-and-receive-totem",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Give Totem of the Freezing War and Heart of Frost to Tenal Redblade and receive Totem of Fiery War",
+          "order": 21
+        },
+        {
+          "id": "epic-warrior-22-the-blades-kill-lord-nagafen-or-ragefire-in-nagafen-s-lair-nortlav-the-scalekeeper-in-the-hole-o",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Kill Lord Nagafen or Ragefire in Nagafen's Lair, Nortlav the Scalekeeper in The Hole or Talendor in Skyfire Mountains and loot Red Dragon Scales",
+          "order": 22
+        },
+        {
+          "id": "epic-warrior-23-the-blades-kill-severilous-in-emerald-jungle-or-hoshkar-in-veeshan-s-peak-and-loot-green-dragon-",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Kill Severilous in Emerald Jungle or Hoshkar in Veeshan's Peak and loot Green Dragon Scales",
+          "order": 23
+        },
+        {
+          "id": "epic-warrior-24-the-blades-give-totem-of-fiery-war-red-dragon-scales-and-green-dragon-scales-to-tenal-redblade-a",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Give Totem of Fiery War, Red Dragon Scales, and Green Dragon Scales to Tenal Redblade and receive Mark of the Sword",
+          "order": 24
+        },
+        {
+          "id": "epic-warrior-25-the-blades-kill-maestro-in-plane-of-hate-and-loot-hand-of-the-maestro",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Kill Maestro in Plane of Hate and loot Hand of the Maestro",
+          "order": 25
+        },
+        {
+          "id": "epic-warrior-26-the-blades-give-mark-of-the-sword-and-hand-of-the-maestro-to-tenal-redblade-and-receive-tenal-s-",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Give Mark of the Sword and Hand of the Maestro to Tenal Redblade and receive Tenal`s note to Kargek",
+          "order": 26
+        },
+        {
+          "id": "epic-warrior-27-the-blades-kill-spiroc-lord-in-plane-of-air-and-loot-spiroc-wingblade",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Kill Spiroc Lord in Plane of Air and Loot Spiroc Wingblade",
+          "order": 27
+        },
+        {
+          "id": "epic-warrior-28-the-blades-give-tenal-s-note-to-kargek-and-spiroc-wingblade-to-kargek-redblade-and-receive-red-s",
+          "className": "Warrior",
+          "section": "The Blades",
+          "text": "Give Tenal`s note to Kargek and Spiroc Wingblade to Kargek Redblade and receive Red Scabbard",
+          "order": 28
+        },
+        {
+          "id": "epic-warrior-29-the-red-scabbard-combine-both-hilts-and-both-blades-in-red-scabbard-to-receive-the-jagged-blade-",
+          "className": "Warrior",
+          "section": "The Red Scabbard",
+          "text": "Combine both hilts and both blades in Red Scabbard to receive the Jagged Blade of War.",
+          "order": 29
+        }
+      ]
+    },
+    {
+      "className": "Wizard",
+      "rows": [
+        {
+          "id": "epic-wizard-0-post-revamp-checklist-hand-the-note-to-camin-at-the-vasty-deep-inn-in-erudin-hail-him-then-hand-",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Hand the note to Camin at the Vasty Deep Inn in Erudin. Hail him, then hand him 1000pp. [OPTIONAL if using Ornate Velium Pendant][NOTE: Doing this part twice is NOT enough faction to get you to indifferent.]",
+          "order": 0
+        },
+        {
+          "id": "epic-wizard-1-post-revamp-checklist-take-the-potion-to-camin-receive-potion-back-with-the-charge-missing",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Take the potion to Camin, receive potion back with the charge missing.",
+          "order": 1
+        },
+        {
+          "id": "epic-wizard-2-post-revamp-checklist-hand-the-used-potion-to-dargon-who-turns-into-arantir-karondor-hail-him-an",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Hand the used potion to Dargon, who turns into Arantir Karondor. Hail him and receive the ring (note more than one wizard can hail Arantir after he has been triggered and each receive a ring).",
+          "order": 2
+        },
+        {
+          "id": "epic-wizard-3-post-revamp-checklist-hand-challice-the-ring-in-the-basement-of-the-paladin-guild-in-felwithe-re",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Hand Challice the ring in the basement of the Paladin Guild in Felwithe, receive another ring back.",
+          "order": 3
+        },
+        {
+          "id": "epic-wizard-4-post-revamp-checklist-hand-the-ring-to-dargon-arantir-karondor-talk-to-him-of-the-other-wizards-",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Hand the ring to Dargon/Arantir Karondor. Talk to him of the other wizards and receive Note from Arantir. (Say 'Who is the gnome-' to skip to the end of the conversation)",
+          "order": 4
+        },
+        {
+          "id": "epic-wizard-5-post-revamp-checklist-talk-to-kandin-firepot-in-butcherblock-hand-him-note-from-arantir-say-what",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Talk to Kandin Firepot in Butcherblock. Hand him Note from Arantir, say \"what oil-\" to receive Golem Sprocket.",
+          "order": 5
+        },
+        {
+          "id": "epic-wizard-6-post-revamp-checklist-kill-phinigel-autropos-in-kedge-keep-loot-the-blue-crystal-staff",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Kill Phinigel Autropos in Kedge Keep. Loot the Blue Crystal Staff.",
+          "order": 6
+        },
+        {
+          "id": "epic-wizard-7-post-revamp-checklist-kill-venril-sathir-in-karnors-s-castle-loot-gnarled-staff",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Kill Venril Sathir in Karnors's Castle, loot Gnarled Staff.",
+          "order": 7
+        },
+        {
+          "id": "epic-wizard-8-post-revamp-checklist-give-the-golem-sprocket-to-a-broken-golem-in-fear-this-spawns-an-enraged-g",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Give the Golem Sprocket to a broken golem in Fear. This spawns an enraged golem. Kill him and loot Green Oil.",
+          "order": 8
+        },
+        {
+          "id": "epic-wizard-9-post-revamp-checklist-give-the-oil-to-kandin-firepot-receive-the-staff-of-gabstik-and-note-to-ar",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Give the oil to Kandin Firepot. Receive the Staff of Gabstik and Note to Arantir.",
+          "order": 9
+        },
+        {
+          "id": "epic-wizard-10-post-revamp-checklist-give-note-to-arantir-to-dargon-to-spawn-arantir-karondor-then-hail-him-giv",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Give Note to Arantir to Dargon to spawn Arantir Karondor, then hail him. Give him the Blue Crystal Staff, Gnarled Staff, and Staff of Gabstik. Receive a bag.",
+          "order": 10
+        },
+        {
+          "id": "epic-wizard-11-post-revamp-checklist-give-the-bag-to-solomen-receive-the-staff-of-the-four",
+          "className": "Wizard",
+          "section": "Post-Revamp Checklist",
+          "text": "Give the bag to Solomen, receive the Staff of the Four",
+          "order": 11
+        },
+        {
+          "id": "epic-wizard-12-pre-revamp-checklist-hand-the-note-to-camin-at-the-vasty-deep-inn-in-erudin-hail-him-then-hand-h",
+          "className": "Wizard",
+          "section": "Pre-Revamp Checklist",
+          "text": "Hand the note to Camin at the Vasty Deep Inn in Erudin. Hail him, then hand him 1000pp. [OPTIONAL]",
+          "order": 12
+        },
+        {
+          "id": "epic-wizard-13-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-take-the-potion-to-camin-rec",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "Take the potion to Camin, receive potion back with the charge missing.",
+          "order": 13
+        },
+        {
+          "id": "epic-wizard-14-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-hand-the-used-potion-to-darg",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "Hand the used potion to Dargon, who turns into Arantir Karondor, and receive the ring.",
+          "order": 14
+        },
+        {
+          "id": "epic-wizard-15-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-hand-challice-the-ring-in-th",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "Hand Challice the ring in the basement of the Paladin Guild in Felwithe, receive another ring back.",
+          "order": 15
+        },
+        {
+          "id": "epic-wizard-16-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-hand-the-ring-to-dargon-aran",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "Hand the ring to Dargon/Arantir. Talk to him of the other wizards and receive a note.",
+          "order": 16
+        },
+        {
+          "id": "epic-wizard-17-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-kill-phinigel-autropos-in-ke",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "Kill Phinigel Autropos in Kedge Keep. Loot the Blue Crystal Staff.",
+          "order": 17
+        },
+        {
+          "id": "epic-wizard-18-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-kill-venril-sathir-in-karnor",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "Kill Venril Sathir in Karnors's Castle, loot Gnarled Staff.",
+          "order": 18
+        },
+        {
+          "id": "epic-wizard-19-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-1-give-him-cazic-s-skin-from",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "1. Give him Cazic's Skin from CT to recieve Kandin's Bag.",
+          "order": 19
+        },
+        {
+          "id": "epic-wizard-20-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-2-give-him-mistletoe-powder-",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "2. Give him Mistletoe Powder to obtain the Staff of Gabstik",
+          "order": 20
+        },
+        {
+          "id": "epic-wizard-21-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-3-give-him-back-kandin-s-bag",
+          "className": "Wizard",
+          "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
+          "text": "3. Give him back Kandin's Bag to get a new note.",
+          "order": 21
+        },
+        {
+          "id": "epic-wizard-22-take-the-note-to-kandin-firepot-then-give-note-to-dargon-to-spawn-arantir-then-hail-him-give-him",
+          "className": "Wizard",
+          "section": "Take the note to Kandin Firepot, then:",
+          "text": "Give note to Dargon to spawn Arantir, then hail him. Give him the Blue Crystal Staff, Gnarled Staff, and Staff of Gabstik. Receive a bag.",
+          "order": 22
+        },
+        {
+          "id": "epic-wizard-23-take-the-note-to-kandin-firepot-then-give-the-bag-to-solomen-receive-the-staff-of-the-four",
+          "className": "Wizard",
+          "section": "Take the note to Kandin Firepot, then:",
+          "text": "Give the bag to Solomen, receive the Staff of the Four",
+          "order": 23
+        }
+      ]
+    }
+  ]
+}

--- a/src/EQBuddy.Core/Data/EpicQuestChecklist.json
+++ b/src/EQBuddy.Core/Data/EpicQuestChecklist.json
@@ -8,217 +8,248 @@
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Top",
           "text": "Talk to Konia Swiftfoot in Western Karana (guard tower #4), receive a Torch of Misty",
-          "order": 0
+          "order": 0,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-1-maestro-s-symphony-page-24-top-give-the-torch-to-fajio-knejo-in-misty-thicket-receive-torch-of-r",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Top",
           "text": "Give the torch to Fajio Knejo in Misty Thicket, receive Torch of Ro",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-2-maestro-s-symphony-page-24-top-give-the-torch-to-andad-filla-in-south-ro-receive-torch-of-rathe",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Top",
           "text": "Give the torch to Andad Filla in South Ro, receive Torch of Rathe",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-3-maestro-s-symphony-page-24-top-give-the-torch-to-misty-tekchita-in-lake-rathetear-receive-ring-p",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Top",
           "text": "Give the torch to Misty Tekchita in Lake Rathetear, receive ring Proof of Speed",
-          "order": 3
+          "order": 3,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-4-maestro-s-symphony-page-24-top-give-the-ring-to-konia-swiftfoot-in-w-karana-receive-maestro-s-sy",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Top",
           "text": "Give the ring to Konia Swiftfoot in W Karana, receive Maestro's Symphony Page 24 Top",
-          "order": 4
+          "order": 4,
+          "availableInClassic": true
         },
         {
           "id": "epic-bard-5-maestro-s-symphony-page-24-bottom-ask-baenar-swiftsong-in-south-karana-what-doll-receive-solusek",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Bottom",
           "text": "Ask Baenar Swiftsong in South Karana, \u201cwhat doll,\u201d receive Solusek Mining Company Invoice",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-6-maestro-s-symphony-page-24-bottom-take-the-invoice-to-marfen-binkdirple-in-solusek-s-eye-receive",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Bottom",
           "text": "Take the invoice to Marfen Binkdirple in Solusek's Eye, receive Mechanical Doll",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-7-maestro-s-symphony-page-24-bottom-give-the-doll-to-serra-in-unrest-receive-note-for-baenar-previ",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Bottom",
           "text": "Give the doll to Serra in Unrest, receive Note for Baenar previously Ripped Qeynos Bards Guild Flyer - I didn't get this 2nd one on turn in 2/6/25",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-8-maestro-s-symphony-page-24-bottom-give-the-note-to-baenar-swiftsong-in-south-karana-receive-a-no",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Bottom",
           "text": "Give the note to Baenar Swiftsong in South Karana, receive a Note to Maligar",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-9-maestro-s-symphony-page-24-bottom-give-the-note-to-maligar-in-western-plains-of-karana",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Bottom",
           "text": "Give the note to Maligar in Western Plains of Karana",
-          "order": 9
+          "order": 9,
+          "availableInClassic": true
         },
         {
           "id": "epic-bard-10-maestro-s-symphony-page-24-bottom-kill-45-maligar-s-enraged-doppleganger-loot-his-head",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Bottom",
           "text": "Kill [45]Maligar's Enraged Doppleganger, loot his head",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-11-maestro-s-symphony-page-24-bottom-give-maligar-s-head-to-baenar-swiftsong-receive-mahlin-s-mysti",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Bottom",
           "text": "Give Maligar's Head to Baenar Swiftsong, receive Mahlin's Mystical Bongos.",
-          "order": 11
+          "order": 11,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-12-maestro-s-symphony-page-24-bottom-give-mahlin-s-mystical-bongos-to-konia-swiftfoot-in-western-ka",
           "className": "Bard",
           "section": "Maestro's Symphony Page 24 Bottom",
           "text": "Give Mahlin's Mystical Bongos to Konia Swiftfoot in Western Karana (guard tower #4), receive Maestro's Symphony Page 24 Bottom",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-13-maestro-s-symphony-page-25-kill-36-blackwing-in-rathe-mountains-loot-onyx-drake-gut",
           "className": "Bard",
           "section": "Maestro's Symphony Page 25",
           "text": "Kill [36]Blackwing in Rathe Mountains, loot Onyx Drake Gut",
-          "order": 13
+          "order": 13,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-14-maestro-s-symphony-page-25-kill-51-nezekezena-or-47-phurzikon-in-burning-woods-loot-red-wurm-gut",
           "className": "Bard",
           "section": "Maestro's Symphony Page 25",
           "text": "Kill [51]Nezekezena or [47]Phurzikon in Burning Woods, loot Red Wurm Gut",
-          "order": 14
+          "order": 14,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-15-maestro-s-symphony-page-25-kill-51-eldrig-the-old-in-skyfire-mountains-loot-chromodrac-gut",
           "className": "Bard",
           "section": "Maestro's Symphony Page 25",
           "text": "Kill [51]Eldrig the Old in Skyfire Mountains, loot Chromodrac Gut",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-16-maestro-s-symphony-page-25-give-all-the-guts-to-kelkim-menkia-in-south-karana-receive-maestro-s-",
           "className": "Bard",
           "section": "Maestro's Symphony Page 25",
           "text": "Give all the guts to Kelkim Menkia in South Karana, receive Maestro's Symphony Page 25",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-17-mystical-lute-head-optional-kill-45-quag-maelstrom-in-ocean-of-tears-loot-alluring-horn",
           "className": "Bard",
           "section": "Mystical Lute Head",
           "text": "(OPTIONAL) Kill [45]Quag Maelstrom in Ocean of Tears, loot Alluring Horn.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-18-mystical-lute-head-optional-give-alluring-horn-to-vedico-windwhisper-in-butcherblock-mountains-r",
           "className": "Bard",
           "section": "Mystical Lute Head",
           "text": "(OPTIONAL) Give Alluring Horn to Vedico Windwhisper in Butcherblock Mountains, receive a Note to Forpar Fizfla.",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-19-mystical-lute-head-optional-give-note-to-forpar-fizfla-to-forpar-fizfla-in-steamfont-mountains",
           "className": "Bard",
           "section": "Mystical Lute Head",
           "text": "(OPTIONAL) Give Note to Forpar Fizfla to Forpar Fizfla in Steamfont Mountains.",
-          "order": 19
+          "order": 19,
+          "availableInClassic": true
         },
         {
           "id": "epic-bard-20-mystical-lute-head-kill-53-phinigel-autropos-in-kedge-keep-loot-kedge-backbone",
           "className": "Bard",
           "section": "Mystical Lute Head",
           "text": "Kill [53]Phinigel Autropos in Kedge Keep, loot Kedge Backbone",
-          "order": 20
+          "order": 20,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-21-mystical-lute-head-kill-an-48-amygdalan-warrior-in-plane-of-fear-loot-amygdalan-tendril",
           "className": "Bard",
           "section": "Mystical Lute Head",
           "text": "Kill an [48]Amygdalan warrior in Plane of Fear, loot Amygdalan Tendril",
-          "order": 21
+          "order": 21,
+          "availableInClassic": true
         },
         {
           "id": "epic-bard-22-mystical-lute-head-kill-52-drolvarg-warlord-in-karnor-s-castle-loot-petrified-werewolf-skull",
           "className": "Bard",
           "section": "Mystical Lute Head",
           "text": "Kill [52]Drolvarg Warlord in Karnor's Castle, loot Petrified Werewolf Skull",
-          "order": 22
+          "order": 22,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-23-mystical-lute-head-say-what-components-to-forpar-fizfla-in-steamfont-mountains-receive-forpar-s-",
           "className": "Bard",
           "section": "Mystical Lute Head",
           "text": "Say \"What Components\" to Forpar Fizfla in Steamfont Mountains, Receive Forpar's Note to Himself.",
-          "order": 23
+          "order": 23,
+          "availableInClassic": true
         },
         {
           "id": "epic-bard-24-mystical-lute-head-give-forpar-s-note-to-himself-kedge-backbone-amygdalan-tendril-petrified-were",
           "className": "Bard",
           "section": "Mystical Lute Head",
           "text": "Give Forpar's Note to Himself, Kedge Backbone, Amygdalan Tendril, Petrified Werewolf Skull to Forpar and receive Mystical Lute Head",
-          "order": 24
+          "order": 24,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-25-mystical-lute-body-kill-a-red-dragon-lord-nagafen-zordakalicus-ragefire-talendor-or-nortlav-the-",
           "className": "Bard",
           "section": "Mystical Lute Body",
           "text": "Kill a red dragon (Lord Nagafen, Zordakalicus Ragefire, Talendor) or Nortlav the Scalekeeper and loot Red Dragon Scales",
-          "order": 25
+          "order": 25,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-26-mystical-lute-body-kill-a-white-dragon-lady-vox-gorenaire-loot-white-dragon-scales",
           "className": "Bard",
           "section": "Mystical Lute Body",
           "text": "Kill a white dragon (Lady Vox, Gorenaire), loot White Dragon Scales",
-          "order": 26
+          "order": 26,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-27-mystical-lute-body-give-1-metal-bits-smithed-red-dragon-scales-and-white-dragon-scales-to-forpar",
           "className": "Bard",
           "section": "Mystical Lute Body",
           "text": "Give 1 metal bits (smithed), Red Dragon Scales and White Dragon Scales to Forpar, receive Mystical Lute Body",
-          "order": 27
+          "order": 27,
+          "availableInClassic": true
         },
         {
           "id": "epic-bard-28-undead-dragongut-strings-give-an-undead-bard-your-mystical-lute-body-kill-an-undead-bard-upon-de",
           "className": "Bard",
           "section": "Undead Dragongut Strings",
           "text": "Give An Undead Bard your Mystical Lute Body. Kill An Undead Bard, upon death he spawns Trakanon (triggered), kill Trakanon (triggered) and loot Undead Dragongut Strings.",
-          "order": 28
+          "order": 28,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-29-mystical-lute-give-mystical-lute-head-mystical-lute-body-and-undead-dragongut-strings-to-forpar-",
           "className": "Bard",
           "section": "Mystical Lute",
           "text": "Give Mystical Lute Head, Mystical Lute Body and Undead Dragongut Strings to Forpar, receive the Mystical Lute",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         },
         {
           "id": "epic-bard-30-singing-short-sword-give-maestro-s-symphony-page-24-top-maestro-s-symphony-page-24-bottom-maestr",
           "className": "Bard",
           "section": "Singing Short Sword!",
           "text": "Give Maestro's Symphony Page 24 top, Maestro's Symphony Page 24 bottom, Maestro's Symphony Page 25 and Mystical Lute to Baldric Slezaf, receive Singing Short Sword",
-          "order": 30
+          "order": 30,
+          "availableInClassic": false
         }
       ]
     },
@@ -230,140 +261,160 @@
           "className": "Cleric",
           "section": "Checklist",
           "text": "Loot Lord Bergurgle's Crown from Lord Bergurgle in Lake Rathetear",
-          "order": 0
+          "order": 0,
+          "availableInClassic": true
         },
         {
           "id": "epic-cleric-1-checklist-give-lord-bergurgle-s-crown-to-shmendrik-lavawalker-in-lake-rathetear-to-spawn-natasha",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Lord Bergurgle's Crown to Shmendrik Lavawalker in Lake Rathetear to spawn Natasha Whitewater nearby - receive Oil of Fennin Ro (Natasha Whitewater will despawn 5 minutes after spawning in Lake Rathetear unless engaged in combat and after turning in the Damaged Goblin Crown.)",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-2-checklist-kill-shmendrik-lavawalker-to-spawn-a-spirit-of-flame",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Kill Shmendrik Lavawalker to spawn A Spirit of Flame",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-3-checklist-loot-damaged-goblin-crown-from-a-spirit-of-flame-do-not-let-natasha-whitewater-get-the",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Loot Damaged Goblin Crown from A Spirit of Flame (Do not let Natasha Whitewater get the last hit or the corpse will disappear)",
-          "order": 3
+          "order": 3,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-4-checklist-give-damaged-goblin-crown-to-natasha-whitewater-receive-ornate-sea-shell-natasha-white",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Damaged Goblin Crown to Natasha Whitewater -- receive Ornate Sea Shell (Natasha Whitewater will despawn 5 minutes after spawning in Lake Rathetear unless engaged in combat and after turning in the Damaged Goblin Crown.)",
-          "order": 4
+          "order": 4,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-5-checklist-give-ornate-sea-shell-to-omat-vastsea-in-timorous-deep-receive-coral-statue-of-tarew",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Ornate Sea Shell to Omat Vastsea in Timorous Deep -- receive Coral Statue of Tarew",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-6-checklist-give-the-coral-statue-of-tarew-to-a-seeker-in-the-temple-of-solusek-ro-causing-them-to",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give the Coral Statue of Tarew to a Seeker in The Temple of Solusek Ro causing them to become A Plasmatic Priest",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-7-checklist-kill-a-plasmatic-priest-in-the-temple-of-solusek-ro-and-loot-blood-soaked-plasmatic-pr",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Kill A Plasmatic Priest in The Temple of Solusek Ro and loot Blood Soaked Plasmatic Priest Robe",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-8-checklist-give-the-blood-soaked-plasmatic-priest-robe-to-omat-vastsea-receive-orb-of-frozen-wate",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give the Blood Soaked Plasmatic Priest Robe to Omat Vastsea \u2013- receive Orb of Frozen Water (This spawns Natasha inside the hut, It is suggested you wait to turn in until you have Lord Gimblox's Signet Ring)",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-9-checklist-loot-lord-gimblox-s-signet-ring-from-lord-gimblox-in-solusek-s-eye",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Loot Lord Gimblox's Signet Ring from Lord Gimblox in Solusek's Eye",
-          "order": 9
+          "order": 9,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-10-checklist-give-lord-gimblox-s-signet-ring-to-natasha-whitewater-in-timorous-deep-receive-ornate-",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Lord Gimblox's Signet Ring to Natasha Whitewater in Timorous Deep \u2013- receive Ornate Sea Shell(v2) (This despawns Natasha)",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-11-checklist-give-ornate-sea-shell-v2-to-naxot-deepwater-in-burning-woods-receive-message-to-natash",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Ornate Sea Shell(v2) to Naxot Deepwater in Burning Woods - receive Message to Natasha (This spawns Ixiblat Fer)",
-          "order": 11
+          "order": 11,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-12-checklist-loot-sceptre-of-ixiblat-fer-from-ixiblat-fer-in-burning-woods",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Loot Sceptre of Ixiblat Fer from Ixiblat Fer in Burning Woods",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-13-checklist-loot-singed-scroll-from-overking-bathezid-in-chardok",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Loot Singed Scroll from Overking Bathezid in Chardok",
-          "order": 13
+          "order": 13,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-14-checklist-give-sceptre-of-ixiblat-fer-and-singed-scroll-to-omat-vastsea-receive-orb-of-clear-wat",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Sceptre of Ixiblat Fer and Singed Scroll to Omat Vastsea -\u2013 receive Orb of Clear Water (This spawns Natasha inside the hut)",
-          "order": 14
+          "order": 14,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-15-checklist-give-message-to-natasha-received-when-spawning-ixiblat-fer-to-natasha-whitewater-in-ti",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Message to Natasha (Received when spawning Ixiblat Fer) to Natasha Whitewater in Timorous Deep \u2013- receive Shimmering Pearl* (This does not despawn Natasha)",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-16-checklist-give-shimmering-pearl-to-zordak-ragefire-in-nagafen-s-lair-causes-him-to-repop-as-zord",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Shimmering Pearl to Zordak Ragefire in Nagafen's Lair -- causes him to repop as Zordakalicus Ragefire and attack you - kill and loot Heart of Zordak Ragefire",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-17-checklist-give-heart-of-zordak-ragefire-to-omat-vastsea-receive-orb-of-vapor-do-not-do-this-unti",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Heart of Zordak Ragefire to Omat Vastsea \u2013 receive Orb of Vapor (Do NOT do this until ready to turn all orbs into Jhassad, as this step spawns Jhassad for the final turn in)",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-18-checklist-give-all-three-orbs-frozen-water-clear-water-vapor-to-jhassad-oceanson-in-timorous-dee",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give all three orbs (Frozen Water / Clear Water / Vapor) to Jhassad Oceanson in Timorous Deep -- receive Orb of Triumvirate (This spawns the Avatar of Water in the lake)",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-cleric-19-checklist-give-orb-of-triumvirate-to-avatar-of-water-receive-water-sprinkler-of-nem-ankh",
           "className": "Cleric",
           "section": "Checklist",
           "text": "Give Orb of Triumvirate to Avatar of Water \u2013- receive Water Sprinkler of Nem Ankh",
-          "order": 19
+          "order": 19,
+          "availableInClassic": false
         }
       ]
     },
@@ -375,462 +426,528 @@
           "className": "Druid",
           "section": "Checklist",
           "text": "Acquire a Shiny Tin Bowl ( Warning : You must be ready to face Dark Elfs, by starting East Karana part, Nuien trigger Teloa, who trigger Dark Elfs )",
-          "order": 0
+          "order": 0,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-1-checklist-speak-with-telin-darkforest-in-burning-wood-and-say-i-will-take-action-to-receive-a-wo",
           "className": "Druid",
           "section": "Checklist",
           "text": "Speak with Telin Darkforest in Burning Wood and say \"I will take action\" to receive a Worn note.",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-2-checklist-spawn-faelin-bloodbriar-in-greater-faydark-and-give-her-the-worn-note-to-receive-faeli",
           "className": "Druid",
           "section": "Checklist",
           "text": "Spawn Faelin Bloodbriar in Greater Faydark and give her the Worn Note to receive Faelin`s Ring.",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-3-checklist-give-giz-x-tin-in-kithicor-forest-faelin-s-ring-to-receive-a-dark-metal-coin",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Giz X`Tin in Kithicor Forest Faelin`s Ring to receive a Dark Metal Coin.",
-          "order": 3
+          "order": 3,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-4-checklist-give-telin-darkforest-in-burning-wood-the-dark-metal-coin-to-receive-worn-dark-metal-c",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Telin Darkforest in Burning Wood the Dark Metal Coin to receive Worn Dark Metal Coin.",
-          "order": 4
+          "order": 4,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-5-checklist-give-althele-in-east-karana-the-worn-dark-metal-coin-to-receive-braided-grass-amulet",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Althele in East Karana the Worn Dark Metal Coin to receive Braided Grass Amulet.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-6-checklist-give-sionae-2300-930-in-east-karana-the-braided-grass-amulet-amulet-is-returned",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Sionae (-2300, -930 in East Karana) the Braided Grass Amulet. (Amulet is returned)",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-7-checklist-give-nuien-3650-300-in-east-karana-the-braided-grass-amulet-amulet-is-returned",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Nuien (-3650, 300 in East Karana) the Braided Grass Amulet. (Amulet is returned)",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-8-checklist-caution-this-step-spawns-an-enemy-you-must-intercept-give-teloa-3800-2860-in-east-kara",
           "className": "Druid",
           "section": "Checklist",
           "text": "CAUTION, THIS STEP SPAWNS AN ENEMY YOU MUST INTERCEPT: Give Teloa (-3800, -2860 in East Karana) the Braided Grass Amulet, spawning the Dark Elf Corruptor and two Dark Elf Reaver at (-700, -1450) Note: They run really fast when spawned, almost SoW fast",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-9-checklist-kill-the-dark-elf-corruptor-loot-fleshbound-tome",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill the Dark Elf Corruptor, loot Fleshbound Tome.",
-          "order": 9
+          "order": 9,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-10-checklist-give-althele-in-east-karana-the-fleshbound-tome-to-receive-earth-stained-note",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Althele in East Karana the Fleshbound Tome to receive Earth Stained Note.",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-11-checklist-give-ella-foodcrafter-in-misty-thicket-the-earth-stained-note-to-receive-a-shiny-tin-b",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Ella Foodcrafter in Misty Thicket the Earth Stained Note to receive a Shiny Tin Bowl.",
-          "order": 11
+          "order": 11,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-12-checklist-forage-the-hardened-mixture",
           "className": "Druid",
           "section": "Checklist",
           "text": "Forage the Hardened Mixture",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-13-checklist-forage-the-following-four-items",
           "className": "Druid",
           "section": "Checklist",
           "text": "Forage the following four items:",
-          "order": 13
+          "order": 13,
+          "availableInClassic": true
         },
         {
           "id": "epic-druid-14-checklist-chilled-tundra-root-from-everfrost",
           "className": "Druid",
           "section": "Checklist",
           "text": "Chilled Tundra Root from Everfrost.",
-          "order": 14
+          "order": 14,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-15-checklist-ripened-heartfruit-from-greater-faydark",
           "className": "Druid",
           "section": "Checklist",
           "text": "Ripened Heartfruit from Greater Faydark.",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-16-checklist-speckled-molded-mushroom-from-innothule-swamp",
           "className": "Druid",
           "section": "Checklist",
           "text": "Speckled Molded Mushroom from Innothule Swamp.",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-17-checklist-sweetened-mudroot-from-misty-thicket",
           "className": "Druid",
           "section": "Checklist",
           "text": "Sweetened Mudroot from Misty Thicket.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-18-checklist-combine-all-four-items-in-the-shiny-tin-bowl-to-make-a-hardened-mixture",
           "className": "Druid",
           "section": "Checklist",
           "text": "Combine all four items in the Shiny Tin Bowl to make a Hardened Mixture.",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-19-checklist-make-a-runecrested-bowl",
           "className": "Druid",
           "section": "Checklist",
           "text": "Make a Runecrested Bowl",
-          "order": 19
+          "order": 19,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-20-checklist-acquire-an-ancient-pattern",
           "className": "Druid",
           "section": "Checklist",
           "text": "Acquire an Ancient Pattern",
-          "order": 20
+          "order": 20,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-21-checklist-speak-with-alrik-farsight-in-timorous-deep-and-say-i-will-take-the-artifact-to-receive",
           "className": "Druid",
           "section": "Checklist",
           "text": "Speak with Alrik Farsight in Timorous Deep and say \"I will take the artifact\" to receive a Crushed Pot.",
-          "order": 21
+          "order": 21,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-22-checklist-give-farios-elianos-in-felwithe-south-the-crushed-pot-to-receive-a-grocery-list",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Farios Elianos in Felwithe South the Crushed Pot to receive a Grocery List.",
-          "order": 22
+          "order": 22,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-23-checklist-give-merchant-nora-in-northern-felwithe-the-grocery-list-to-receive-a-bag-of-provision",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Merchant Nora in Northern Felwithe the Grocery List to receive a Bag of Provisions.",
-          "order": 23
+          "order": 23,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-24-checklist-give-farios-elianos-the-bag-of-provisions-to-receive-a-receipt",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Farios Elianos the Bag of Provisions to receive a Receipt.",
-          "order": 24
+          "order": 24,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-25-checklist-give-alrik-farsight-in-timorous-deep-the-receipt-to-receive-an-ancient-pattern",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Alrik Farsight in Timorous Deep the Receipt to receive an Ancient Pattern.",
-          "order": 25
+          "order": 25,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-26-checklist-acquire-some-platinum-speckled-powder",
           "className": "Druid",
           "section": "Checklist",
           "text": "Acquire some Platinum Speckled Powder",
-          "order": 26
+          "order": 26,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-27-checklist-forage-a-rose-of-firiona-from-firiona-vie",
           "className": "Druid",
           "section": "Checklist",
           "text": "Forage a Rose of Firiona from Firiona Vie.",
-          "order": 27
+          "order": 27,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-28-checklist-hail-merdan-fleetfoot-in-surefall-glade-ask-him-who-is-niera-then-hand-him-the-rose-of",
           "className": "Druid",
           "section": "Checklist",
           "text": "Hail Merdan Fleetfoot in Surefall Glade, ask him \"Who is Niera-\", then hand him the Rose of Firiona to receive a Wood Painting.",
-          "order": 28
+          "order": 28,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-29-checklist-give-a-human-skeleton-in-frontier-mountains-behind-the-giant-fort-the-wood-painting-to",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give a human skeleton in Frontier Mountains (behind the giant fort) the Wood Painting to receive a Silver Chained Locket.",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-30-checklist-give-niera-farbreeze-in-surefall-glade-the-silver-chained-locket-to-receive-platinum-s",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Niera Farbreeze in Surefall Glade the Silver Chained Locket to receive Platinum Speckled Powder.",
-          "order": 30
+          "order": 30,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-31-checklist-acquire-some-enchanted-clay",
           "className": "Druid",
           "section": "Checklist",
           "text": "Acquire some Enchanted Clay",
-          "order": 31
+          "order": 31,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-32-checklist-kill-a-black-reaver-in-city-of-mist-loot-a-jade-reaver",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill a black reaver in City of Mist, loot a Jade Reaver.",
-          "order": 32
+          "order": 32,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-33-checklist-give-kinlo-strongarm-in-north-kaladim-the-jade-reaver-to-receive-enchanted-clay",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Kinlo Strongarm in North Kaladim the Jade Reaver to receive Enchanted Clay.",
-          "order": 33
+          "order": 33,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-34-checklist-combine-the-ancient-pattern-platinum-speckled-powder-and-enchanted-clay-in-a-pottery-w",
           "className": "Druid",
           "section": "Checklist",
           "text": "Combine the Ancient Pattern, Platinum Speckled Powder, and Enchanted Clay in a Pottery Wheel to create a Runecrested Bowl.",
-          "order": 34
+          "order": 34,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-35-checklist-trade-stones-for-an-elaborate-scimitar",
           "className": "Druid",
           "section": "Checklist",
           "text": "Trade Stones for an Elaborate Scimitar",
-          "order": 35
+          "order": 35,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-36-checklist-give-the-hardened-mixture-and-runecrested-bowl-to-ella-foodcrafter-in-misty-thicket-to",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give the Hardened Mixture and Runecrested Bowl to Ella Foodcrafter in Misty Thicket to receive a Softly Glowing Stone.",
-          "order": 36
+          "order": 36,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-37-checklist-create-a-summoned-firefly-globe-level-1-druid-spell-no-rent-only-castable-at-night-7p-",
           "className": "Druid",
           "section": "Checklist",
           "text": "Create a Summoned: Firefly Globe (level 1 Druid spell, NO RENT, only castable at night: 7p - 4a).",
-          "order": 37
+          "order": 37,
+          "availableInClassic": true
         },
         {
           "id": "epic-druid-38-checklist-purchase-scroll-of-resurrection-level-49-cleric-spell",
           "className": "Druid",
           "section": "Checklist",
           "text": "Purchase Scroll of Resurrection (level 49 Cleric spell).",
-          "order": 38
+          "order": 38,
+          "availableInClassic": true
         },
         {
           "id": "epic-druid-39-checklist-give-venril-sathir-remains-in-karnor-s-castle-the-summoned-firefly-globe-to-spawn-spir",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Venril Sathir Remains in Karnor's Castle the Summoned: Firefly Globe to spawn Spirit of Venril Sathir.",
-          "order": 39
+          "order": 39,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-40-checklist-give-spirit-of-venril-sathir-in-karnor-s-castle-the-spell-resurrection-to-spawn-venril",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Spirit of Venril Sathir in Karnor's Castle the Spell: Resurrection to spawn Venril Sathir.",
-          "order": 40
+          "order": 40,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-41-checklist-slay-venril-sathir-in-karnor-s-castle-and-loot-a-pulsing-green-stone",
           "className": "Druid",
           "section": "Checklist",
           "text": "Slay Venril Sathir in Karnor's Castle and loot a Pulsing Green Stone.",
-          "order": 41
+          "order": 41,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-42-checklist-give-foloal-stormforest-in-firiona-vie-the-pulsing-green-stone-and-softly-glowing-ston",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Foloal Stormforest in Firiona Vie the Pulsing Green Stone and Softly Glowing Stone to receive a Warmly Glowing Stone.",
-          "order": 42
+          "order": 42,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-43-checklist-give-ella-foodcrafter-in-misty-thicket-the-warmly-glowing-stone-to-receive-an-elaborat",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Ella Foodcrafter in Misty Thicket the Warmly Glowing Stone to receive an Elaborate Scimitar.",
-          "order": 43
+          "order": 43,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-44-checklist-cleanse-spirits",
           "className": "Druid",
           "section": "Checklist",
           "text": "Cleanse Spirits",
-          "order": 44
+          "order": 44,
+          "availableInClassic": true
         },
         {
           "id": "epic-druid-45-checklist-cleanse-the-spirits-of-antonica",
           "className": "Druid",
           "section": "Checklist",
           "text": "Cleanse the Spirits of Antonica",
-          "order": 45
+          "order": 45,
+          "availableInClassic": true
         },
         {
           "id": "epic-druid-46-checklist-kill-corrupted-wooly-mammoth-level-30-in-everfrost-peaks-loot-a-chunk-of-tundra",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill corrupted wooly mammoth (level 30) in Everfrost Peaks, loot a Chunk of Tundra.",
-          "order": 46
+          "order": 46,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-47-checklist-kill-corrupted-shaman-level-40-in-lake-rathetear-loot-clean-lakewater",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill corrupted shaman (level 40) in Lake Rathetear, loot Clean Lakewater.",
-          "order": 47
+          "order": 47,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-48-checklist-kill-corrupted-hill-giant-level-40-in-rathe-mountains-loot-an-ancient-rock",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill corrupted hill giant (level 40) in Rathe Mountains, loot an Ancient Rock.",
-          "order": 48
+          "order": 48,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-49-checklist-give-withered-treant-in-northern-karana-the-chunk-of-tundra-clean-lakewater-and-ancien",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Withered treant in Northern Karana the Chunk of Tundra, Clean Lakewater and Ancient Rock to receive a Warm Pulsing Treant Heart.",
-          "order": 49
+          "order": 49,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-50-checklist-give-yeka-ias-in-southern-karana-the-warm-pulsing-treant-heart-to-receive-cleansed-spi",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Yeka Ias in Southern Karana the Warm Pulsing Treant Heart to receive Cleansed Spirit of Antonica.",
-          "order": 50
+          "order": 50,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-51-checklist-cleanse-the-spirits-of-faydwer",
           "className": "Druid",
           "section": "Checklist",
           "text": "Cleanse the Spirits of Faydwer",
-          "order": 51
+          "order": 51,
+          "availableInClassic": true
         },
         {
           "id": "epic-druid-52-checklist-kill-corrupted-seahorse-level-53-in-kedge-keep-loot-kedge-cave-crystals",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill Corrupted Seahorse (level 53) in Kedge Keep, loot Kedge Cave Crystals.",
-          "order": 52
+          "order": 52,
+          "availableInClassic": true
         },
         {
           "id": "epic-druid-53-checklist-kill-corrupted-seafury-cyclops-level-52-in-ocean-of-tears-loot-ocean-of-tears-seavines",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill Corrupted seafury cyclops (level 52) in Ocean of Tears, loot Ocean of Tears Seavines.",
-          "order": 53
+          "order": 53,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-54-checklist-kill-corrupted-brownie-level-51-in-lesser-faydark-loot-green-heartwood-branch",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill Corrupted brownie (level 51) in Lesser Faydark, loot Green Heartwood Branch.",
-          "order": 54
+          "order": 54,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-55-checklist-give-pained-unicorn-in-lesser-faydark-the-kedge-cave-crystals-ocean-of-tears-seavines-",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Pained Unicorn in Lesser Faydark the Kedge Cave Crystals, Ocean of Tears Seavines and Green Heartwood Branch to receive Gleaming Unicorn Horn.",
-          "order": 55
+          "order": 55,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-56-checklist-give-silox-azrix-in-ak-anon-the-gleaming-unicorn-horn-to-receieve-the-cleansed-spirit-",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Silox Azrix in Ak'Anon the Gleaming Unicorn Horn to receieve the Cleansed Spirit of Faydwer.",
-          "order": 56
+          "order": 56,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-57-checklist-cleanse-the-spirits-of-kunark",
           "className": "Druid",
           "section": "Checklist",
           "text": "Cleanse the Spirits of Kunark",
-          "order": 57
+          "order": 57,
+          "availableInClassic": true
         },
         {
           "id": "epic-druid-58-checklist-kill-ulump-pujluk-level-55-in-swamp-of-no-hope-loot-froglok-essence",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill Ulump Pujluk (level 55) in Swamp of No Hope, loot Froglok Essence.",
-          "order": 58
+          "order": 58,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-59-checklist-kill-corrupted-gorilla-level-47-in-emerald-jungle-loot-green-tree-bark",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill Corrupted Gorilla (level 47) in Emerald Jungle, loot Green Tree Bark.",
-          "order": 59
+          "order": 59,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-60-checklist-kill-the-corrupted-barracuda-level-46-in-lake-of-ill-omen-and-loot-the-pure-lakewater",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill the Corrupted barracuda (level 46) in Lake of Ill Omen and loot the Pure Lakewater.",
-          "order": 60
+          "order": 60,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-61-checklist-give-dolgin-codslayer-in-timorous-deep-the-froglok-essence-he-will-hand-it-back-and-de",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Dolgin Codslayer in Timorous Deep the Froglok Essence (he will hand it back and despawn - 14h respawn) to spawn Faydedar.",
-          "order": 61
+          "order": 61,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-62-checklist-kill-faydedar-in-timorous-deep-loot-pod-of-seawater",
           "className": "Druid",
           "section": "Checklist",
           "text": "Kill Faydedar in Timorous Deep, loot Pod of Seawater.",
-          "order": 62
+          "order": 62,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-63-checklist-give-nekexin-virulence-in-the-overthere-the-froglok-essence-pod-of-seawater-green-tree",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Nekexin Virulence in The Overthere the Froglok Essence, Pod of Seawater, Green Tree Bark and Pure Lakewater to receive Cleansed Spirit of Kunark.",
-          "order": 63
+          "order": 63,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-64-checklist-acquire-a-nature-walkers-scimitar",
           "className": "Druid",
           "section": "Checklist",
           "text": "Acquire a Nature Walkers Scimitar!",
-          "order": 64
+          "order": 64,
+          "availableInClassic": false
         },
         {
           "id": "epic-druid-65-checklist-give-xanuusus-in-north-karana-the-elaborate-scimitar-and-three-cleansed-spirits-to-rec",
           "className": "Druid",
           "section": "Checklist",
           "text": "Give Xanuusus in North Karana the Elaborate Scimitar and three cleansed spirits to receive the Nature Walkers Scimitar.",
-          "order": 65
+          "order": 65,
+          "availableInClassic": false
         }
       ]
     },
@@ -842,322 +959,368 @@
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Hail Stofo Olan in Erudin (Must be level 50)",
-          "order": 0
+          "order": 0,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-1-jeb-s-seal-ink-of-the-dark",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Ink of the Dark",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-2-jeb-s-seal-get-empty-ink-vial-from-reania-jukle-in-qeynos-catacombs",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Get Empty Ink Vial from Reania Jukle in Qeynos Catacombs",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-3-jeb-s-seal-charm-the-a-ghoul-scribe-in-lower-guk-give-him-the-empty-ink-vial-to-get-the-ink-of-t",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Charm the a ghoul scribe in Lower Guk. Give him the Empty Ink Vial to get the Ink of the Dark.",
-          "order": 3
+          "order": 3,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-4-jeb-s-seal-mechanical-pen",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Mechanical Pen",
-          "order": 4
+          "order": 4,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-5-jeb-s-seal-kill-the-ghoul-arch-magus-in-lower-guk-and-loot-the-shining-metallic-robes",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Kill the ghoul arch magus in Lower Guk and loot the Shining Metallic Robes.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-6-jeb-s-seal-give-the-shining-metallic-robes-to-rilgor-plegnog-in-ak-anon-to-get-the-mechanical-pe",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Give the Shining Metallic Robes to Rilgor Plegnog in Ak'Anon to get the Mechanical Pen.",
-          "order": 6
+          "order": 6,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-7-jeb-s-seal-white-paper",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "White Paper",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-8-jeb-s-seal-purchase-a-quill-and-a-piece-of-parchment",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Purchase a Quill and a Piece of Parchment.",
-          "order": 8
+          "order": 8,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-9-jeb-s-seal-give-the-quill-and-the-piece-of-parchment-to-chrislin-baker-in-western-karana-to-spaw",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Give the Quill and the Piece of Parchment to Chrislin Baker in Western Karana to spawn Thrackin Griften. Kill Thrackin Griften and loot a White Paper.",
-          "order": 9
+          "order": 9,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-10-jeb-s-seal-give-the-ink-of-the-dark-the-mechanical-pen-and-the-white-paper-to-stofo-olan-in-erud",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Give the Ink of the Dark, the Mechanical Pen, and the White Paper to Stofo Olan in Erudin to get a Copy of Notes.",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-11-jeb-s-seal-give-the-copy-of-notes-to-jeb-lumsed-a-sarnak-imitator-in-burning-woods-to-get-jeb-s-",
           "className": "Enchanter",
           "section": "Jeb's Seal",
           "text": "Give the Copy of Notes to Jeb Lumsed (a sarnak imitator) in Burning Woods to get Jeb's Seal.",
-          "order": 11
+          "order": 11,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-12-1st-piece-of-staff-test-of-illusion-kill-vessel-drozlin-in-cabilis-east-and-loot-the-xolion-rod",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Kill Vessel Drozlin in Cabilis East and loot the Xolion Rod.",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-13-1st-piece-of-staff-test-of-illusion-kill-verina-tomb-in-neriak-and-loot-innoruuk-s-word",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Kill Verina Tomb in Neriak and loot Innoruuk's Word.",
-          "order": 13
+          "order": 13,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-14-1st-piece-of-staff-test-of-illusion-obtain-the-chalice-of-kings",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Obtain the Chalice of Kings.",
-          "order": 14
+          "order": 14,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-15-1st-piece-of-staff-test-of-illusion-kill-prince-selrach-di-zok-in-chardok-and-loot-the-head-of-a",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Kill Prince Selrach Di'zok in Chardok and loot the Head of a Prince.",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-16-1st-piece-of-staff-test-of-illusion-give-the-head-of-a-prince-to-joren-nobleheart-in-felwithe-to",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Give the Head of a Prince to Joren Nobleheart in Felwithe to get the Chalice of Kings.",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-17-1st-piece-of-staff-test-of-illusion-obtain-snow-blossoms-in-oggok",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Obtain Snow Blossoms in Oggok.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-18-1st-piece-of-staff-test-of-illusion-pick-up-large-muddy-sandals",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Pick up Large Muddy Sandals.",
-          "order": 18
+          "order": 18,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-19-1st-piece-of-staff-test-of-illusion-give-large-muddy-sandals-to-bozlum-blossom-to-get-scribbled-",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Give Large Muddy Sandals to Bozlum Blossom to get Scribbled Parchment.",
-          "order": 19
+          "order": 19,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-20-1st-piece-of-staff-test-of-illusion-give-scribbled-parchment-to-brokk-boxtripper-to-get-a-gift-t",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Give Scribbled Parchment to Brokk Boxtripper to get a Gift to Bozlum.",
-          "order": 20
+          "order": 20,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-21-1st-piece-of-staff-test-of-illusion-give-the-gift-to-bozlum-blossom-to-get-snow-blossoms",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Give the gift to Bozlum Blossom to get Snow Blossoms.",
-          "order": 21
+          "order": 21,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-22-1st-piece-of-staff-test-of-illusion-combine-the-chalice-of-kings-xolion-rod-snow-blossoms-and-in",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Combine the Chalice of Kings, Xolion Rod, Snow Blossoms and Innoruuk's Word in an Enchanters Sack.",
-          "order": 22
+          "order": 22,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-23-1st-piece-of-staff-test-of-illusion-give-the-combined-sack-to-modani-qu-loni-in-the-overthere-to",
           "className": "Enchanter",
           "section": "1st Piece of Staff -- Test of Illusion",
           "text": "Give the combined sack to Modani Qu`Loni in The Overthere to get the 1st Piece of Staff.",
-          "order": 23
+          "order": 23,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-24-2nd-piece-of-staff-test-of-enlightenment-kill-cazel-in-oasis-to-get-a-spoon",
           "className": "Enchanter",
           "section": "2nd Piece of Staff -- Test of Enlightenment",
           "text": "Kill Cazel in Oasis to get a Spoon",
-          "order": 24
+          "order": 24,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-25-2nd-piece-of-staff-test-of-enlightenment-pick-up-the-the-one-key-in-the-overthere",
           "className": "Enchanter",
           "section": "2nd Piece of Staff -- Test of Enlightenment",
           "text": "Pick up the The One Key in the Overthere.",
-          "order": 25
+          "order": 25,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-26-2nd-piece-of-staff-test-of-enlightenment-pick-up-the-lost-scroll-in-dalnir",
           "className": "Enchanter",
           "section": "2nd Piece of Staff -- Test of Enlightenment",
           "text": "Pick up the Lost Scroll in Dalnir.",
-          "order": 26
+          "order": 26,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-27-2nd-piece-of-staff-test-of-enlightenment-pick-up-the-book-of-charm-and-sacrifice-in-plane-of-sky",
           "className": "Enchanter",
           "section": "2nd Piece of Staff -- Test of Enlightenment",
           "text": "Pick up the Book of Charm and Sacrifice in Plane of Sky.",
-          "order": 27
+          "order": 27,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-28-2nd-piece-of-staff-test-of-enlightenment-combine-the-spoon-the-one-key-the-lost-scroll-and-the-b",
           "className": "Enchanter",
           "section": "2nd Piece of Staff -- Test of Enlightenment",
           "text": "Combine the Spoon, the One Key, the Lost Scroll and the Book of Charm and Sacrifice in an Enchanters Sack.",
-          "order": 28
+          "order": 28,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-29-2nd-piece-of-staff-test-of-enlightenment-give-the-combined-sack-to-mizzle-gepple-clockwork-viix-",
           "className": "Enchanter",
           "section": "2nd Piece of Staff -- Test of Enlightenment",
           "text": "Give the combined sack to Mizzle Gepple (Clockwork VIIX) in Ak'Anon to get the 2nd Piece of Staff.",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-30-3rd-piece-of-staff-test-of-charm-obtain-the-four-dull-gems-from-nadia-starfeast-in-firiona-vie",
           "className": "Enchanter",
           "section": "3rd Piece of Staff -- Test of Charm",
           "text": "Obtain the four dull gems from Nadia Starfeast in Firiona Vie.",
-          "order": 30
+          "order": 30,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-31-3rd-piece-of-staff-test-of-charm-charm-a-spectral-librarian-in-kaesora-give-him-the-dull-diamond",
           "className": "Enchanter",
           "section": "3rd Piece of Staff -- Test of Charm",
           "text": "Charm a Spectral librarian in Kaesora. Give him the Dull Diamond to get the Enchanted Diamond.",
-          "order": 31
+          "order": 31,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-32-3rd-piece-of-staff-test-of-charm-upon-turn-in-an-aggro-enraged-spectral-librarian-will-spawn-it-",
           "className": "Enchanter",
           "section": "3rd Piece of Staff -- Test of Charm",
           "text": "Upon turn in an aggro Enraged spectral librarian will spawn. It is strongly recommended not to kill this see page for details.",
-          "order": 32
+          "order": 32,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-33-3rd-piece-of-staff-test-of-charm-charm-felia-goldenwing-in-skyfire-give-her-the-dull-sapphire-to",
           "className": "Enchanter",
           "section": "3rd Piece of Staff -- Test of Charm",
           "text": "Charm Felia Goldenwing in Skyfire. Give her the Dull Sapphire to get the Enchanted Sapphire.",
-          "order": 33
+          "order": 33,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-34-3rd-piece-of-staff-test-of-charm-charm-the-wraith-of-jaxion-in-the-city-of-mist-give-him-the-dul",
           "className": "Enchanter",
           "section": "3rd Piece of Staff -- Test of Charm",
           "text": "Charm the Wraith of Jaxion in the City of Mist. Give him the Dull Ruby to get the Enchanted Ruby.",
-          "order": 34
+          "order": 34,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-35-3rd-piece-of-staff-test-of-charm-charm-impaler-tzilug-in-the-overthere-give-him-the-dull-emerald",
           "className": "Enchanter",
           "section": "3rd Piece of Staff -- Test of Charm",
           "text": "Charm Impaler Tzilug in the Overthere. Give him the Dull Emerald to get the Enchanted Emerald.",
-          "order": 35
+          "order": 35,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-36-3rd-piece-of-staff-test-of-charm-combine-the-enchanted-diamond-enchanted-sapphire-enchanted-ruby",
           "className": "Enchanter",
           "section": "3rd Piece of Staff -- Test of Charm",
           "text": "Combine the Enchanted Diamond, Enchanted Sapphire, Enchanted Ruby and Enchanted Emerald in an Enchanters Sack.",
-          "order": 36
+          "order": 36,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-37-3rd-piece-of-staff-test-of-charm-give-the-combined-sack-to-nadia-starfeast-in-firiona-vie-to-get",
           "className": "Enchanter",
           "section": "3rd Piece of Staff -- Test of Charm",
           "text": "Give the combined sack to Nadia Starfeast in Firiona Vie to get the 3rd Piece of Staff.",
-          "order": 37
+          "order": 37,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-38-4th-piece-of-staff-test-of-the-phantasm-kill-the-wraith-of-a-shissir-in-the-plane-of-fear-and-lo",
           "className": "Enchanter",
           "section": "4th Piece of Staff -- Test of the Phantasm",
           "text": "Kill the Wraith of a Shissir in the Plane of Fear and loot Head of the Serpent.",
-          "order": 38
+          "order": 38,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-39-4th-piece-of-staff-test-of-the-phantasm-kill-the-ghost-of-kindle-in-the-hole-and-loot-the-essenc",
           "className": "Enchanter",
           "section": "4th Piece of Staff -- Test of the Phantasm",
           "text": "Kill the Ghost of Kindle in The Hole and loot the Essence of a Ghost.",
-          "order": 39
+          "order": 39,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-40-4th-piece-of-staff-test-of-the-phantasm-kill-a-forsaken-revenant-in-the-plane-of-hate-and-loot-t",
           "className": "Enchanter",
           "section": "4th Piece of Staff -- Test of the Phantasm",
           "text": "Kill a forsaken revenant in the Plane of Hate and loot the Essence of a Vampire.",
-          "order": 40
+          "order": 40,
+          "availableInClassic": true
         },
         {
           "id": "epic-enchanter-41-4th-piece-of-staff-test-of-the-phantasm-kill-the-tangrin-in-the-field-of-bone-and-loot-the-sands",
           "className": "Enchanter",
           "section": "4th Piece of Staff -- Test of the Phantasm",
           "text": "Kill The Tangrin in the Field of Bone and loot the Sands of the Mystics.",
-          "order": 41
+          "order": 41,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-42-4th-piece-of-staff-test-of-the-phantasm-combine-the-head-of-the-serpent-essence-of-a-ghost-essen",
           "className": "Enchanter",
           "section": "4th Piece of Staff -- Test of the Phantasm",
           "text": "Combine the Head of the Serpent, Essence of a Ghost, Essence of a Vampire and Sands of the Mystics in an Enchanters Sack.",
-          "order": 42
+          "order": 42,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-43-4th-piece-of-staff-test-of-the-phantasm-give-the-combined-sack-to-polzin-mrid-in-the-hole-to-get",
           "className": "Enchanter",
           "section": "4th Piece of Staff -- Test of the Phantasm",
           "text": "Give the combined sack to Polzin Mrid in The Hole to get the 4th Piece of Staff.",
-          "order": 43
+          "order": 43,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-44-staff-of-the-serpent-combine-the-four-pieces-of-staff-in-an-enchanters-sack-to-make-a-bundle-of-",
           "className": "Enchanter",
           "section": "Staff of the Serpent",
           "text": "Combine the four pieces of staff in an Enchanters Sack to make a Bundle of Staves.",
-          "order": 44
+          "order": 44,
+          "availableInClassic": false
         },
         {
           "id": "epic-enchanter-45-staff-of-the-serpent-give-the-bundle-of-staves-to-jeb-lumsed-a-sarnak-imitator-in-burning-woods-",
           "className": "Enchanter",
           "section": "Staff of the Serpent",
           "text": "Give the Bundle of Staves to Jeb Lumsed (a sarnak imitator) in Burning Woods to get the Staff of the Serpent!",
-          "order": 45
+          "order": 45,
+          "availableInClassic": false
         }
       ]
     },
@@ -1169,252 +1332,288 @@
           "className": "Magician",
           "section": "The Beginning (Optional)",
           "text": "Go find Rykas in Lake Rathetear. Receive Token of Mastery.",
-          "order": 0
+          "order": 0,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-1-the-beginning-optional-take-the-token-to-jahsohn-aksot-in-west-commonlands",
           "className": "Magician",
           "section": "The Beginning (Optional)",
           "text": "Take the Token to Jahsohn Aksot in West Commonlands.",
-          "order": 1
+          "order": 1,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-2-words-of-magi-kot-kill-an-enraged-dread-wolf-in-kithicor-forest-loot-torn-page-of-magi-kot-pg-1",
           "className": "Magician",
           "section": "Words of Magi'Kot",
           "text": "Kill an enraged dread wolf in Kithicor Forest. Loot Torn Page of Magi`kot pg. 1.",
-          "order": 2
+          "order": 2,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-3-words-of-magi-kot-kill-tentacle-terrors-in-the-estate-of-unrest-loot-torn-page-of-magi-kot-pg-2",
           "className": "Magician",
           "section": "Words of Magi'Kot",
           "text": "Kill Tentacle Terrors in the Estate of Unrest. Loot Torn Page of Magi`kot pg. 2.",
-          "order": 3
+          "order": 3,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-4-words-of-magi-kot-kill-a-bloodthirsty-ghoul-in-lower-guk-loot-torn-page-of-magi-kot-pg-3",
           "className": "Magician",
           "section": "Words of Magi'Kot",
           "text": "Kill a bloodthirsty ghoul in Lower Guk. Loot Torn Page of Magi`kot pg. 3.",
-          "order": 4
+          "order": 4,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-5-words-of-magi-kot-take-them-to-jahsohn-aksotin-west-commonlands-receive-words-of-magi-kot",
           "className": "Magician",
           "section": "Words of Magi'Kot",
           "text": "Take them to Jahsohn Aksotin West Commonlands. Receive Words of Magi`kot.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-6-power-of-the-elements-kill-a-gypsy-dancer-in-mistmoore-loot-the-power-of-wind",
           "className": "Magician",
           "section": "Power of the Elements",
           "text": "Kill a gypsy dancer in Mistmoore. Loot the Power of Wind.",
-          "order": 6
+          "order": 6,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-7-power-of-the-elements-kill-lava-elemental-or-blazing-elemental-in-solusek-s-eye-loot-the-power-o",
           "className": "Magician",
           "section": "Power of the Elements",
           "text": "Kill Lava elemental or Blazing Elemental in Solusek's Eye. Loot the Power of Fire.",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-8-power-of-the-elements-kill-famished-ravener-hungered-ravener-gorged-ravener-in-kaesora-loot-the-",
           "className": "Magician",
           "section": "Power of the Elements",
           "text": "Kill famished ravener/Hungered Ravener/Gorged Ravener in Kaesora. Loot the Power of Water.",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-9-power-of-the-elements-kill-a-fairy-guard-a-faerie-guard-in-lesser-faydark-loot-power-of-earth",
           "className": "Magician",
           "section": "Power of the Elements",
           "text": "Kill A Fairy Guard/a faerie guard in Lesser Faydark. Loot Power of Earth.",
-          "order": 9
+          "order": 9,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-10-power-of-the-elements-give-these-to-walnan-in-the-butcherblock-mountains-you-can-mq-this-step-re",
           "className": "Magician",
           "section": "Power of the Elements",
           "text": "Give these to Walnan in the Butcherblock Mountains. (You can MQ this step). Receive the Power of the Elements.",
-          "order": 10
+          "order": 10,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-11-words-of-mastery-torn-page-of-mastery-earth",
           "className": "Magician",
           "section": "Words of Mastery",
           "text": "Torn Page of Mastery Earth",
-          "order": 11
+          "order": 11,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-12-words-of-mastery-torn-page-of-mastery-fire",
           "className": "Magician",
           "section": "Words of Mastery",
           "text": "Torn Page of Mastery Fire",
-          "order": 12
+          "order": 12,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-13-words-of-mastery-torn-page-of-mastery-water",
           "className": "Magician",
           "section": "Words of Mastery",
           "text": "Torn Page of Mastery Water",
-          "order": 13
+          "order": 13,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-14-words-of-mastery-torn-page-of-mastery-wind",
           "className": "Magician",
           "section": "Words of Mastery",
           "text": "Torn Page of Mastery Wind.",
-          "order": 14
+          "order": 14,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-15-words-of-mastery-give-the-torn-pages-to-akksstaff-in-najena-receive-the-words-of-mastery",
           "className": "Magician",
           "section": "Words of Mastery",
           "text": "Give the torn pages to Akksstaff in Najena. Receive the Words of Mastery.",
-          "order": 15
+          "order": 15,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-16-power-of-the-orb-go-back-to-rykas-in-lake-rathetear-give-him-the-words-of-magi-kot-the-power-of-",
           "className": "Magician",
           "section": "Power of the Orb",
           "text": "Go back to Rykas in Lake Rathetear. Give him the Words of Magi`kot, the Power of the Elements, and the Words of Mastery. Receive the Power of the Orb.",
-          "order": 16
+          "order": 16,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-17-element-of-fire-kill-neh-ashiir-in-the-city-of-mist-loot-the-torch-of-the-elements",
           "className": "Magician",
           "section": "Element of Fire",
           "text": "Kill Neh'Ashiir in the City of Mist. Loot the Torch of the Elements.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-18-element-of-fire-kill-in-order-of-difficulty-gylton-phurzikon-or-nezekezena-in-the-burning-woods-",
           "className": "Magician",
           "section": "Element of Fire",
           "text": "Kill (in order of difficulty) Gylton, Phurzikon, or Nezekezena in the Burning Woods until one drops a Burning Embers.",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-19-element-of-fire-kill-undertow-in-kedge-keep-loot-the-blazing-wand",
           "className": "Magician",
           "section": "Element of Fire",
           "text": "Kill Undertow in Kedge Keep. Loot the Blazing Wand.",
-          "order": 19
+          "order": 19,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-20-element-of-fire-take-power-of-the-orb-and-these-items-to-jennus-lyklobar-in-skyfire-mountains-re",
           "className": "Magician",
           "section": "Element of Fire",
           "text": "Take Power of the Orb and these items to Jennus Lyklobar in Skyfire Mountains. Receive the Element of Fire.",
-          "order": 20
+          "order": 20,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-21-element-of-earth-kill-magi-p-tasa-in-the-plane-of-hate-loot-the-staff-of-elemental-mastery-earth",
           "className": "Magician",
           "section": "Element of Earth",
           "text": "Kill Magi P`Tasa in the Plane of Hate. Loot the Staff of Elemental Mastery: Earth.",
-          "order": 21
+          "order": 21,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-22-element-of-earth-kill-slixin-klex-in-the-burning-wood-loot-dirt-of-underfoot",
           "className": "Magician",
           "section": "Element of Earth",
           "text": "Kill Slixin Klex in the Burning Wood. Loot Dirt of Underfoot.",
-          "order": 22
+          "order": 22,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-23-element-of-earth-quest-for-shovel-of-ponz",
           "className": "Magician",
           "section": "Element of Earth",
           "text": "Quest for Shovel of Ponz.",
-          "order": 23
+          "order": 23,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-24-element-of-earth-quest-for-broom-of-trilon",
           "className": "Magician",
           "section": "Element of Earth",
           "text": "Quest for Broom of Trilon.",
-          "order": 24
+          "order": 24,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-25-element-of-earth-bring-these-all-to-tiblner-milnik-in-firiona-vie-receive-element-of-earth",
           "className": "Magician",
           "section": "Element of Earth",
           "text": "Bring these all to Tiblner Milnik in Firiona Vie. Receive Element of Earth.",
-          "order": 25
+          "order": 25,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-26-element-of-water-kill-phinigel-autropos-in-kedge-keep-loot-staff-of-elemental-mastery-water",
           "className": "Magician",
           "section": "Element of Water",
           "text": "Kill Phinigel Autropos in Kedge Keep. Loot Staff of Elemental Mastery: Water.",
-          "order": 26
+          "order": 26,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-27-element-of-water-kill-captain-rottgrime-in-the-overthere-loot-tears-of-erollisi",
           "className": "Magician",
           "section": "Element of Water",
           "text": "Kill Captain Rottgrime in The Overthere. Loot Tears of Erollisi.",
-          "order": 27
+          "order": 27,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-28-element-of-water-kill-tarbul-earthstrider-in-east-karana-loot-rain-of-karana",
           "className": "Magician",
           "section": "Element of Water",
           "text": "Kill Tarbul Earthstrider in East Karana. Loot Rain of Karana.",
-          "order": 28
+          "order": 28,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-29-element-of-water-takes-the-three-items-to-jinalis-andir-in-dagnor-s-cauldron-and-receive-the-ele",
           "className": "Magician",
           "section": "Element of Water",
           "text": "Takes the three items to Jinalis Andir in Dagnor's Cauldron and receive the Element of Water.",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-30-element-of-wind-kill-mobs-on-the-7th-island-on-the-plane-of-sky-loot-the-crown-of-elemental-mast",
           "className": "Magician",
           "section": "Element of Wind",
           "text": "Kill mobs on the 7th island on the Plane of Sky. Loot the Crown of Elemental Mastery.",
-          "order": 30
+          "order": 30,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-31-element-of-wind-kill-mobs-in-the-hole-loot-the-elemental-binder",
           "className": "Magician",
           "section": "Element of Wind",
           "text": "Kill mobs in the Hole. Loot the Elemental Binder.",
-          "order": 31
+          "order": 31,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-32-element-of-wind-kill-quillmane-in-south-karana-loot-the-pegasus-feather-cloak",
           "className": "Magician",
           "section": "Element of Wind",
           "text": "Kill Quillmane in South Karana. Loot the Pegasus Feather Cloak.",
-          "order": 32
+          "order": 32,
+          "availableInClassic": true
         },
         {
           "id": "epic-magician-33-element-of-wind-give-these-items-to-kihun-solstin-in-the-plane-of-air-and-receive-the-element-of",
           "className": "Magician",
           "section": "Element of Wind",
           "text": "Give these items to Kihun Solstin in the Plane of Air and receive the Element of Wind.",
-          "order": 33
+          "order": 33,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-34-spell-summon-orb-go-to-the-master-of-elements-and-give-him-the-four-elements-receive-spell-summo",
           "className": "Magician",
           "section": "Spell Summon Orb",
           "text": "Go to the Master of Elements and give him the four Elements. Receive Spell: Summon Orb.",
-          "order": 34
+          "order": 34,
+          "availableInClassic": false
         },
         {
           "id": "epic-magician-35-spell-summon-orb-scribe-your-spell-and-summon-the-orb-of-mastery",
           "className": "Magician",
           "section": "Spell Summon Orb",
           "text": "Scribe your spell and summon the Orb of Mastery!",
-          "order": 35
+          "order": 35,
+          "availableInClassic": false
         }
       ]
     },
@@ -1426,357 +1625,408 @@
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Kill Brother Zephyl or Brother Qwinn and loot Robe of the Lost Circle OR perform the following sub-quest.",
-          "order": 0
+          "order": 0,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-1-short-walkthrough-checklist-robe-of-the-lost-circle-sub-quest",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Robe of the Lost Circle sub-quest",
-          "order": 1
+          "order": 1,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-2-short-walkthrough-checklist-obtain-purple-headband-via-quests",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Obtain Purple Headband via quests.",
-          "order": 2
+          "order": 2,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-3-short-walkthrough-checklist-obtain-red-sash-of-order-via-quests",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Obtain Red Sash of Order via quests.",
-          "order": 3
+          "order": 3,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-4-short-walkthrough-checklist-kill-targin-the-rock-in-nagafen-s-lair-king-room-to-get-code-of-zan-",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Kill Targin the Rock in Nagafen's Lair King room to get Code of Zan Fi.",
-          "order": 4
+          "order": 4,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-5-short-walkthrough-checklist-kill-raster-of-guk-in-lower-guk-to-get-the-idol-it-should-be-noted-y",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Kill Raster of Guk in Lower Guk to get The Idol. It should be noted you CANNOT MQ the idol and sash to Brother Zephyl.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-6-short-walkthrough-checklist-turn-in-purple-headband-and-code-of-zan-fi-to-brother-qwinn-in-south",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Turn in Purple Headband and Code of Zan Fi to Brother Qwinn in Southern Karana to get Needle of the Void. This turn-in was successfully multiquested (MQ'd) as of 2024-09-14.",
-          "order": 6
+          "order": 6,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-7-short-walkthrough-checklist-turn-in-red-sash-of-order-and-the-idol-to-brother-zephyl-in-rathe-mo",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Turn in Red Sash of Order and The Idol to Brother Zephyl in Rathe Mountains to get Rare Robe Pattern.",
-          "order": 7
+          "order": 7,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-8-short-walkthrough-checklist-combine-shadow-wolf-pelt-silk-swatch-and-spell-gather-shadows-in-sew",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Combine Shadow Wolf Pelt, Silk Swatch, and Spell: Gather Shadows in sewing kit to make Shadow Silk (Tailoring 36).",
-          "order": 8
+          "order": 8,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-9-short-walkthrough-checklist-combine-shadow-silk-needle-of-the-void-rare-robe-pattern-and-song-jo",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Combine Shadow Silk, Needle of the Void, Rare Robe Pattern, and Song: Jonthan's Whistling Warsong in a sewing kit to make Robe of the Lost Circle (no skill check)",
-          "order": 9
+          "order": 9,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-10-short-walkthrough-checklist-robe-of-the-whistling-fists-sub-quest",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Robe of the Whistling Fists sub-quest",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-11-short-walkthrough-checklist-kill-an-iksar-betrayer-in-chardok-and-loot-a-metal-pipe-fi",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Kill an iksar betrayer in Chardok and loot A Metal Pipe (Fi).",
-          "order": 11
+          "order": 11,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-12-short-walkthrough-checklist-kill-a-drolvarg-pawbuster-in-karnor-s-castle-and-loot-a-metal-pipe-z",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Kill a drolvarg pawbuster in Karnor's Castle and loot A Metal Pipe (Zan).",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-13-short-walkthrough-checklist-turn-in-the-two-pipes-and-robe-of-the-lost-circle-to-brother-balatin",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Turn in the two pipes and Robe of the Lost Circle to Brother Balatin (must not be aggro'd. Charm and sneak both work, pacify does NOT work.) in Dreadlands to receive Robe of the Whistling Fists.",
-          "order": 13
+          "order": 13,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-14-short-walkthrough-checklist-first-book",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "First Book",
-          "order": 14
+          "order": 14,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-15-short-walkthrough-checklist-get-an-immortals-book-from-any-named-mob-in-skyfire",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Get an Immortals book from any named mob in Skyfire.",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-16-short-walkthrough-checklist-turn-in-immortals-to-tomekeeper-danl-in-the-erudin-library-for-danl-",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Turn in Immortals to Tomekeeper Danl in the Erudin library for Danl's Reference. Do not turn in while Feigned Death. Danl will eat your turn in.",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-17-short-walkthrough-checklist-save-this-until-the-final-turn-in-so-you-may-keep-your-robe-longer",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Save this until the final turn in so you may keep your robe longer.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-18-short-walkthrough-checklist-find-lheao-in-the-hidden-cove-in-timorous-deep-turn-in-danl-s-refere",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Find Lheao in the hidden cove in Timorous Deep. Turn in Danl's Reference and Robe of the Whistling Fists to get Celestial Fists (book).",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-19-short-walkthrough-checklist-fist-of-fire",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Fist of Fire",
-          "order": 19
+          "order": 19,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-20-short-walkthrough-checklist-find-a-fire-sprite-in-lavastorm-mountains-and-say-i-challenge-eejag-",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Find a fire sprite in Lavastorm Mountains and say \"I challenge Eejag\" to spawn Eejag. Kill Eejag and loot Charred Scale.",
-          "order": 20
+          "order": 20,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-21-short-walkthrough-checklist-fist-of-air",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Fist of Air",
-          "order": 21
+          "order": 21,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-22-short-walkthrough-checklist-go-to-dojorn-s-island-isle-1-5-in-plane-of-sky-hand-scale-to-a-prese",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Go to Dojorn's Island (Isle 1.5) in Plane of Sky. Hand Scale to a presence to spawn Gwan. Kill Gwan and loot Breath of Gwan.",
-          "order": 22
+          "order": 22,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-23-short-walkthrough-checklist-fist-of-earth",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Fist of Earth",
-          "order": 23
+          "order": 23,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-24-short-walkthrough-checklist-hand-breath-of-gwan-in-to-a-sleeping-ogre-in-mines-of-nurga-to-spawn",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Hand Breath of Gwan in to a sleeping ogre in Mines of Nurga to spawn Trunt. Kill Trunt and loot Trunt's Head (Note: a sleeping ogre must con indifferently, use sneak from behind to turn in).",
-          "order": 24
+          "order": 24,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-25-short-walkthrough-checklist-fist-of-water",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Fist of Water",
-          "order": 25
+          "order": 25,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-26-short-walkthrough-checklist-optional-find-dark-elf-named-deep-in-underwater-caverns-of-lake-rath",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "OPTIONAL Find dark elf named Deep in underwater caverns of Lake Rathetear and turn in the Head. She will give it back then despawn.",
-          "order": 26
+          "order": 26,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-27-short-walkthrough-checklist-go-to-overthere-and-locate-a-monk-named-astral-projection-overthere-",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Go to Overthere and locate a monk named Astral Projection (Overthere). Hand him Trunt's Head and receive Eye of Kaiaren.",
-          "order": 27
+          "order": 27,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-28-short-walkthrough-checklist-in-lake-of-ill-omen-it-s-not-on-the-platform-but-on-the-shore-loc-ne",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "In Lake of Ill Omen (It's not on the platform, but on the shore, loc neg 1900 neg 950), give an Astral Projection (LOIO) the Eye of Kaiaren to spawn Vorash and Deep. Once Vorash dies, Xenevorash will spawn. Kill Xenevorash and loot Demon Fangs.",
-          "order": 28
+          "order": 28,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-29-short-walkthrough-checklist-book-conversion-dealing-with-kaiaren",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Book Conversion (Dealing with Kaiaren):",
-          "order": 29
+          "order": 29,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-30-short-walkthrough-checklist-super-duper-important-if-you-are-doing-receiving-an-mq-or-you-do-not",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "SUPER DUPER IMPORTANT: If you are doing/receiving an MQ or you do not have your Demon Fangs in hand and ready, do NOT turn in Celestial Fists (book) to Sane Kaiaran and receive Book of Celestial Fists because Sane Kaiaren will despawn within 30 minutes. If you lose Celestial Fists (book) you can no longer spawn Sane Kaiaren for the final epic turn in and will have to either 1) wait for another monk to spawn Sane Kaiaren or 2) petition for reimbursement and wait a month or more for Sirken's response.",
-          "order": 30
+          "order": 30,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-31-short-walkthrough-checklist-give-celestial-fists-book-to-mad-kaiaren-at-the-ruins-near-sebilis-i",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Give Celestial Fists (book) to mad Kaiaren at the ruins near Sebilis in Trakanon's Teeth and he hands you back the book, then he punches you in the face - you can either kill him or feign off the aggro.",
-          "order": 31
+          "order": 31,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-32-short-walkthrough-checklist-go-to-sane-kaiaren-who-spawns-over-by-the-lake-in-tt-p305-p2470-in-a",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Go to sane Kaiaren, who spawns over by the lake in TT (p305, p2470 in an empty hut) after you hand in Celestial Fists (book) to mad Kaiaren.",
-          "order": 32
+          "order": 32,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-33-short-walkthrough-checklist-hand-celestial-fists-book-to-sane-kaiaren-and-he-hands-you-back-a-sl",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Hand Celestial Fists (book) to sane Kaiaren and he hands you back a slightly different book called Book of Celestial Fists.",
-          "order": 33
+          "order": 33,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-34-short-walkthrough-checklist-final-turn-in",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Final Turn-in",
-          "order": 34
+          "order": 34,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-35-short-walkthrough-checklist-turn-in-the-modified-book-of-celestial-fists-and-demon-fangs-to-sane",
           "className": "Monk",
           "section": "Short Walkthrough/Checklist",
           "text": "Turn in the modified Book of Celestial Fists and Demon Fangs to sane Kaiaren to receive the monk epic, Celestial Fists.",
-          "order": 35
+          "order": 35,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-36-long-walkthrough-with-dialogue-monk-sash-quests-to-obtain-red-sash-of-order",
           "className": "Monk",
           "section": "Long Walkthrough with dialogue",
           "text": "Monk Sash Quests to obtain Red Sash of Order",
-          "order": 36
+          "order": 36,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-37-long-walkthrough-with-dialogue-monk-headband-quests-to-obtain-purple-headband",
           "className": "Monk",
           "section": "Long Walkthrough with dialogue",
           "text": "Monk Headband Quests to obtain Purple Headband",
-          "order": 37
+          "order": 37,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-38-long-walkthrough-with-dialogue-monks-of-the-whistling-fist-to-obtain-robe-of-the-lost-circle",
           "className": "Monk",
           "section": "Long Walkthrough with dialogue",
           "text": "Monks of The Whistling Fist to obtain Robe of the Lost Circle",
-          "order": 38
+          "order": 38,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-39-long-walkthrough-with-dialogue-the-lost-circle-to-obtain-robe-of-the-whistling-fists-which-is-re",
           "className": "Monk",
           "section": "Long Walkthrough with dialogue",
           "text": "The Lost Circle to obtain Robe of the Whistling Fists, which is required in the next part of the monk epic",
-          "order": 39
+          "order": 39,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-40-final-turn-in-give-celestial-fists-book-to-mad-kaiaren-he-will-be-apprehensive-at-the-ruins-in-t",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "Give Celestial Fists (book) to mad Kaiaren (he will be apprehensive) at the ruins in Trakanon's Teeth and he hands you back the book.",
-          "order": 40
+          "order": 40,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-41-final-turn-in-go-to-sane-kaiaren-who-spawns-over-by-the-lake-in-tt-approx-300-2400-after-you-han",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "Go to sane Kaiaren, who spawns over by the lake in TT (approx +300, +2400) after you hand in Celestial Fists (book) to mad Kaiaren.",
-          "order": 41
+          "order": 41,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-42-final-turn-in-hand-celestial-fists-book-only-to-sane-kaiaren-and-he-hands-you-back-a-new-book-no",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "Hand Celestial Fists (book) ONLY to sane Kaiaren and he hands you back A NEW BOOK, now called Book of Celestial Fists.",
-          "order": 42
+          "order": 42,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-43-final-turn-in-turn-in-book-of-celestial-fists-and-demon-fangs-to-sane-kaiaren-to-receive-the-mon",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "Turn in Book of Celestial Fists and Demon Fangs to sane Kaiaren to receive the monk epic, Celestial Fists.",
-          "order": 43
+          "order": 43,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-44-final-turn-in-note-if-on-step-3-you-also-handed-in-demon-fangs-along-with-the-celestial-fists-bo",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "NOTE* If on step 3 you also handed in Demon Fangs along with the Celestial Fists (book), you can hand the Book of Celestial Fists back to Kaiaren to receive your epic.",
-          "order": 44
+          "order": 44,
+          "availableInClassic": false
         },
         {
           "id": "epic-monk-45-final-turn-in-quests",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "Quests",
-          "order": 45
+          "order": 45,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-46-final-turn-in-monk-quests",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "Monk Quests",
-          "order": 46
+          "order": 46,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-47-final-turn-in-this-page-was-last-edited-on-27-july-2026-at-18-13",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "This page was last edited on 27 July 2026, at 18:13.",
-          "order": 47
+          "order": 47,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-48-final-turn-in-privacy-policy",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "Privacy policy",
-          "order": 48
+          "order": 48,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-49-final-turn-in-about-everquest-legends-wiki",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "About EverQuest Legends Wiki",
-          "order": 49
+          "order": 49,
+          "availableInClassic": true
         },
         {
           "id": "epic-monk-50-final-turn-in-disclaimers",
           "className": "Monk",
           "section": "Final Turn-in",
           "text": "Disclaimers",
-          "order": 50
+          "order": 50,
+          "availableInClassic": true
         }
       ]
     },
@@ -1788,210 +2038,240 @@
           "className": "Necromancer",
           "section": "Symbol of the Apprentice",
           "text": "(optional) Hail Venenzi Oberzendi in Nektulos Forest",
-          "order": 0
+          "order": 0,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-1-symbol-of-the-apprentice-optional-hail-kazen-fecae-in-lake-rathetear",
           "className": "Necromancer",
           "section": "Symbol of the Apprentice",
           "text": "(optional) Hail Kazen Fecae in Lake Rathetear",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-2-symbol-of-the-apprentice-kill-sir-edwin-motte-and-loot-his-head",
           "className": "Necromancer",
           "section": "Symbol of the Apprentice",
           "text": "Kill Sir Edwin Motte and loot his Head",
-          "order": 2
+          "order": 2,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-3-symbol-of-the-apprentice-give-the-head-to-kazen-fecae-for-the-symbol-of-the-apprentice",
           "className": "Necromancer",
           "section": "Symbol of the Apprentice",
           "text": "Give the Head to Kazen Fecae for the Symbol of the Apprentice",
-          "order": 3
+          "order": 3,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-4-symbol-of-the-serpent-give-the-symbol-to-venenzi-oberzendi-in-nektulos-forest-for-the-twisted-sy",
           "className": "Necromancer",
           "section": "Symbol of the Serpent",
           "text": "Give the Symbol to Venenzi Oberzendi in Nektulos Forest for the Twisted Symbol of the Apprentice",
-          "order": 4
+          "order": 4,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-5-symbol-of-the-serpent-kill-najena-npc-and-loot-the-flowing-black-robe",
           "className": "Necromancer",
           "section": "Symbol of the Serpent",
           "text": "Kill Najena (NPC) and loot the Flowing Black Robe",
-          "order": 5
+          "order": 5,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-6-symbol-of-the-serpent-give-the-flowing-black-robe-to-venenzi-for-rolling-stone-moss",
           "className": "Necromancer",
           "section": "Symbol of the Serpent",
           "text": "Give the Flowing Black Robe to Venenzi for Rolling Stone Moss",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-7-symbol-of-the-serpent-head-to-lake-rathetear-give-the-rolling-stone-moss-and-the-twisted-symbol-",
           "className": "Necromancer",
           "section": "Symbol of the Serpent",
           "text": "Head to Lake Rathetear, Give the Rolling Stone Moss and the Twisted Symbol of the Apprentice to Emkel Kabae.",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-8-symbol-of-the-serpent-receive-symbol-of-the-serpent",
           "className": "Necromancer",
           "section": "Symbol of the Serpent",
           "text": "Receive Symbol of the Serpent",
-          "order": 8
+          "order": 8,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-9-symbol-of-testing-hail-ssessthrass-in-swamp-of-no-hope-and-give-him-the-symbol-of-the-serpent-fo",
           "className": "Necromancer",
           "section": "Symbol of Testing",
           "text": "Hail Ssessthrass in Swamp of No Hope and give him the Symbol of the Serpent for the Scaled Symbol of the Serpent",
-          "order": 9
+          "order": 9,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-10-symbol-of-testing-kill-grand-herbalist-mak-ha-royal-sarnak-herbalist-in-chardok-and-loot-the-man",
           "className": "Necromancer",
           "section": "Symbol of Testing",
           "text": "Kill Grand Herbalist Mak`ha/Royal Sarnak Herbalist in Chardok and loot the Manisi Herb",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-11-symbol-of-testing-give-the-manisi-herb-and-the-scaled-symbol-of-the-serpent-to-ssessthrass-for-a",
           "className": "Necromancer",
           "section": "Symbol of Testing",
           "text": "Give the Manisi Herb and the Scaled Symbol of the Serpent to Ssessthrass for a Refined Mainsi Herb",
-          "order": 11
+          "order": 11,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-12-symbol-of-testing-give-the-refined-mainsi-herb-to-emkel-kabae-for-the-symbol-of-testing",
           "className": "Necromancer",
           "section": "Symbol of Testing",
           "text": "Give the Refined Mainsi Herb to Emkel Kabae for the Symbol of Testing",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-13-symbol-of-insanity-optional-give-the-symbol-of-testing-to-kazen-fecae",
           "className": "Necromancer",
           "section": "Symbol of Insanity",
           "text": "OPTIONAL: Give the Symbol of Testing to Kazen Fecae",
-          "order": 13
+          "order": 13,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-14-symbol-of-insanity-or-kill-kazen-fecae-see-kazen-s-page-for-more-info-on-the-fight",
           "className": "Necromancer",
           "section": "Symbol of Insanity",
           "text": "OR Kill Kazen Fecae (see Kazen's page for more info on the fight)",
-          "order": 14
+          "order": 14,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-15-symbol-of-insanity-go-to-the-small-inlet-east-of-emkel-and-kill-a-bone-golem",
           "className": "Necromancer",
           "section": "Symbol of Insanity",
           "text": "Go to the small inlet east of Emkel and kill a bone golem",
-          "order": 15
+          "order": 15,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-16-symbol-of-insanity-kill-a-failed-apprentice",
           "className": "Necromancer",
           "section": "Symbol of Insanity",
           "text": "Kill a failed apprentice",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-17-symbol-of-insanity-kill-a-tortured-soul-and-loot-the-symbol-of-insanity",
           "className": "Necromancer",
           "section": "Symbol of Insanity",
           "text": "Kill A tortured soul and loot the Symbol of Insanity",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-18-gzallk-in-a-box-give-the-symbol-of-insanity-to-drendico-metalbones-in-timorous-deep-and-receive-",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Give the Symbol of Insanity to Drendico Metalbones in Timorous Deep and receive the Journal",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-19-gzallk-in-a-box-speak-to-jzil-gsix-in-plane-of-sky",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Speak to Jzil GSix in Plane of Sky",
-          "order": 19
+          "order": 19,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-20-gzallk-in-a-box-kill-an-azarack-s-and-other-second-isle-monsters-for-the-silver-disc",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Kill An azarack's and other second isle monsters for the Silver Disc",
-          "order": 20
+          "order": 20,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-21-gzallk-in-a-box-kill-a-gorgalask-and-other-third-isle-monsters-for-the-spiroc-feathers",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Kill A gorgalask and other third isle monsters for the Spiroc Feathers",
-          "order": 21
+          "order": 21,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-22-gzallk-in-a-box-kill-keeper-of-souls-for-the-black-silk-cape",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Kill Keeper of Souls for the Black Silk Cape",
-          "order": 22
+          "order": 22,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-23-gzallk-in-a-box-give-the-items-to-jzil-gsix-for-the-cloak-of-spiroc-feathers",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Give the items to Jzil GSix for the Cloak of Spiroc Feathers",
-          "order": 23
+          "order": 23,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-24-gzallk-in-a-box-kill-mini-bosses-formerly-innoruuk-god-from-plane-of-hate-for-the-eye-of-innoruu",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Kill Mini-Bosses formerly Innoruuk (God) from Plane of Hate for the Eye of Innoruuk",
-          "order": 24
+          "order": 24,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-25-gzallk-in-a-box-kill-cazic-thule-god-or-the-golems-from-plane-of-fear-for-the-slime-blood-of-caz",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Kill Cazic Thule (God) or the golems from Plane of Fear for the Slime Blood of Cazic Thule",
-          "order": 25
+          "order": 25,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-26-gzallk-in-a-box-give-the-cloak-of-spiroc-feathers-eye-of-innoruuk-slime-blood-of-cazic-thule-and",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Give the Cloak of Spiroc Feathers, Eye of Innoruuk, Slime Blood of Cazic Thule, and Journal to Drendico Metalbones and receive the Prepared Regents Box",
-          "order": 26
+          "order": 26,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-27-gzallk-in-a-box-give-the-prepared-regents-box-to-kazen-for-the-tome-of-instruction",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Give the Prepared Regents Box to Kazen for the Tome of Instruction",
-          "order": 27
+          "order": 27,
+          "availableInClassic": true
         },
         {
           "id": "epic-necromancer-28-gzallk-in-a-box-give-the-tome-of-instruction-to-gkzzallk-for-gkzzallk-in-a-box-see-the-note-belo",
           "className": "Necromancer",
           "section": "Gzallk in a Box",
           "text": "Give the Tome of Instruction to Gkzzallk for Gkzzallk in a Box -- See the note below. Do not do this step on someone else's (or your own Guild's) Sky slot without contacting their officers first. This will despawn the island 1 boss AND prevent them from raiding normally until respawn.",
-          "order": 28
+          "order": 28,
+          "availableInClassic": false
         },
         {
           "id": "epic-necromancer-29-scythe-of-the-shadowed-soul-give-gkzzallk-in-a-box-to-kazen-fecae-for-scythe-of-the-shadowed-sou",
           "className": "Necromancer",
           "section": "Scythe of the Shadowed Soul",
           "text": "Give Gkzzallk in a Box to Kazen Fecae for Scythe of the Shadowed Soul",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         }
       ]
     },
@@ -2003,98 +2283,112 @@
           "className": "Paladin",
           "section": "Checklist",
           "text": "Complete quest for The Fiery Avenger, which includes the quest for SoulFire and camping (or questing) Ghoulbane",
-          "order": 0
+          "order": 0,
+          "availableInClassic": true
         },
         {
           "id": "epic-paladin-1-checklist-tainted-darksteel-breastplate-thought-destroyer-in-plane-of-hate",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Tainted Darksteel Breastplate - thought destroyer in Plane of Hate.",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-2-checklist-do-the-pure-crystal-quest-or-in-other-words-find-jark-in-north-kaladim-tell-him-i-will",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Do the Pure Crystal Quest or in other words Find Jark in North Kaladim. Tell him \"I will get your dinner\". Nella Stonebraids will spawn in the temple area, tell her \"Do you have Jark's Dinner-\" Receive: Cold Plate of Beef and Bread",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-3-checklist-give-cold-plate-of-beef-and-bread-to-jark-receive-pure-crystal",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Give Cold Plate of Beef and Bread to Jark Receive: Pure Crystal.",
-          "order": 3
+          "order": 3,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-4-checklist-give-tainted-darksteel-breastplate-and-pure-crystal-to-reklon-gnallen-in-quellious-tem",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Give Tainted Darksteel Breastplate and Pure Crystal to Reklon Gnallen in Quellious Temple in Erudin for Gleaming Crested Breastplate.",
-          "order": 4
+          "order": 4,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-5-checklist-tainted-darksteel-sword-keeper-of-the-tombs-the-hole",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Tainted Darksteel Sword - Keeper of the Tombs, the Hole.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-6-checklist-tell-a-peasant-woman-in-west-freeport-at-190-725-i-will-take-it-to-him-receive-bucket-",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Tell a peasant woman in West Freeport at -190, -725 \"I will take it to him.\" Receive: Bucket of Water",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-7-checklist-give-the-bucket-of-water-to-joshua-in-west-freeport-at-245-710-in-the-back-of-the-bake",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Give the Bucket of Water to Joshua in West Freeport at -245, -710 in the back of the bakery. Receive: Bucket of Pure Water",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-8-checklist-give-the-tainted-darksteel-sword-and-bucket-of-pure-water-to-reklon-gnallen-in-quellio",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Give the Tainted Darksteel Sword and Bucket of Pure Water to Reklon Gnallen in Quellious Temple in Erudin Recieve: Gleaming Crested Sword.",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-9-checklist-tainted-darksteel-shield-kirak-vil-56th-level-nektulous-forest",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Tainted Darksteel Shield - Kirak Vil (56th level), Nektulous Forest.",
-          "order": 9
+          "order": 9,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-10-checklist-give-to-elia-the-pure-in-felwithe-for-gleaming-crested-shield",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Give to Elia the Pure, in Felwithe, for Gleaming Crested Shield.",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-11-checklist-turn-in-the-three-purified-items-gleaming-crested-shield-gleaming-crested-breastplate-",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Turn in the three purified items (Gleaming Crested Shield, Gleaming Crested Breastplate, and Gleaming Crested Sword) to Reklon Gnallen for the Mark of Atonement.",
-          "order": 11
+          "order": 11,
+          "availableInClassic": true
         },
         {
           "id": "epic-paladin-12-checklist-turn-in-mark-of-atonement-and-fiery-avenger-to-irak-altil-a-wandering-skeleton-in-plan",
           "className": "Paladin",
           "section": "Checklist",
           "text": "Turn in Mark of Atonement and Fiery Avenger to Irak Altil, a wandering skeleton in Plane of Fear to receive your Fiery Defender.",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-paladin-13-resources-the-white-cross-fiery-defender-walkthrough-with-pictures",
           "className": "Paladin",
           "section": "Resources",
           "text": "The White Cross - Fiery Defender Walkthrough (with pictures)",
-          "order": 13
+          "order": 13,
+          "availableInClassic": true
         }
       ]
     },
@@ -2106,322 +2400,368 @@
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Ask Telin Darkforest in Burning Wood \"what action\" and receive a Worn Note.",
-          "order": 0
+          "order": 0,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-1-making-the-hardened-mixture-spawn-faelin-bloodbriar-in-greater-faydark-and-give-her-the-worn-not",
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Spawn Faelin Bloodbriar in Greater Faydark and give her the Worn Note, receiving Faelin`s Ring.",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-2-making-the-hardened-mixture-find-giz-x-tin-in-kithicor-forest-and-give-him-faelin-s-ring-receivi",
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Find Giz X`Tin in Kithicor Forest and give him Faelin`s Ring, receiving a Dark Metal Coin.",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-3-making-the-hardened-mixture-give-coin-to-telin-darkforest-receive-worn-dark-metal-coin",
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Give coin to Telin Darkforest, receive Worn Dark Metal Coin",
-          "order": 3
+          "order": 3,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-4-making-the-hardened-mixture-give-sionae-the-braided-grass-amulet-frayed-braided-grass-amulet-is-",
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Give Sionae the Braided Grass Amulet, Frayed Braided Grass Amulet is returned.",
-          "order": 4
+          "order": 4,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-5-making-the-hardened-mixture-give-nuien-the-frayed-braided-grass-amulet-frayed-braided-grass-amul",
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Give Nuien the Frayed Braided Grass Amulet, Frayed Braided Grass Amulet is returned.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-6-making-the-hardened-mixture-give-teloa-the-frayed-braided-grass-amulet-spawning-a-dark-elf-corru",
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Give Teloa the Frayed Braided Grass Amulet, spawning a Dark Elf Corruptor and two Dark Elf Reavers and they run really fast when spawned, almost SOW fast.",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-7-making-the-hardened-mixture-kill-the-dark-elf-corruptor-loot-fleshbound-tome-give-to-althele-rec",
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Kill the Dark Elf Corruptor, loot Fleshbound Tome, give to Althele, receive a Earth Stained Note.",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-8-making-the-hardened-mixture-give-ella-foodcrafter-in-misty-thicket-the-earth-stained-note-and-re",
           "className": "Ranger",
           "section": "Making the Hardened Mixture",
           "text": "Give Ella Foodcrafter in Misty Thicket the Earth Stained Note and receive a Shiny Tin Bowl.",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-9-acquiring-the-shiny-tin-bowl-chilled-tundra-root-from-everfrost-note-if-you-forage-a-rose-of-fir",
           "className": "Ranger",
           "section": "Acquiring the Shiny Tin Bowl",
           "text": "Chilled Tundra Root from Everfrost. NOTE: If you forage a Rose of Firiona before coming here, you can stop by Surefall Glade while you're in this neck of the woods and give the rose to Merdan Fleetfoot for a later step",
-          "order": 9
+          "order": 9,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-10-acquiring-the-shiny-tin-bowl-ripened-heartfruit-from-greater-faydark",
           "className": "Ranger",
           "section": "Acquiring the Shiny Tin Bowl",
           "text": "Ripened Heartfruit from Greater Faydark.",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-11-acquiring-the-shiny-tin-bowl-speckled-molded-mushroom-from-innothule-swamp",
           "className": "Ranger",
           "section": "Acquiring the Shiny Tin Bowl",
           "text": "Speckled Molded Mushroom from Innothule Swamp.",
-          "order": 11
+          "order": 11,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-12-acquiring-the-shiny-tin-bowl-sweetened-mudroot-from-misty-thicket",
           "className": "Ranger",
           "section": "Acquiring the Shiny Tin Bowl",
           "text": "Sweetened Mudroot from Misty Thicket.",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-13-forage-the-following-four-items-combine-all-four-items-in-the-shiny-tin-bowl-to-make-a-hardened-",
           "className": "Ranger",
           "section": "Forage the following four items:",
           "text": "Combine all four items in the Shiny Tin Bowl to make a Hardened Mixture. Don't destroy the Shiny Tin Bowl you'll need it later in the quest.",
-          "order": 13
+          "order": 13,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-14-making-the-runecrested-bowl-talk-to-alrik-farsight-in-timorous-deep-and-receive-a-crushed-pot",
           "className": "Ranger",
           "section": "Making the Runecrested Bowl",
           "text": "Talk to Alrik Farsight in Timorous Deep and receive a Crushed Pot.",
-          "order": 14
+          "order": 14,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-15-making-the-runecrested-bowl-give-farios-elianos-in-felwithe-the-crushed-pot-and-receive-a-grocer",
           "className": "Ranger",
           "section": "Making the Runecrested Bowl",
           "text": "Give Farios Elianos in Felwithe the Crushed Pot and receive a Grocery List.",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-16-making-the-runecrested-bowl-give-merchant-nora-in-northern-felwithe-the-grocery-list-and-receive",
           "className": "Ranger",
           "section": "Making the Runecrested Bowl",
           "text": "Give Merchant Nora in Northern Felwithe the Grocery List and receive a Bag of Provisions.",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-17-making-the-runecrested-bowl-give-the-bag-of-provisions-to-farios-elianos-and-receive-a-receipt",
           "className": "Ranger",
           "section": "Making the Runecrested Bowl",
           "text": "Give the Bag of Provisions to Farios Elianos and receive a Receipt.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-18-making-the-runecrested-bowl-give-the-receipt-to-alrik-farsight-and-receive-an-ancient-pattern",
           "className": "Ranger",
           "section": "Making the Runecrested Bowl",
           "text": "Give the Receipt to Alrik Farsight and receive an Ancient Pattern.",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-19-the-ancient-pattern-forage-a-rose-of-firiona-from-firiona-vie",
           "className": "Ranger",
           "section": "The Ancient Pattern",
           "text": "Forage a Rose of Firiona from Firiona Vie.",
-          "order": 19
+          "order": 19,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-20-the-ancient-pattern-hail-merdan-fleetfoot-ask-him-who-is-niera-then-hand-him-the-rose-of-firiona",
           "className": "Ranger",
           "section": "The Ancient Pattern",
           "text": "Hail Merdan Fleetfoot, ask him \"Who is Niera-\", then hand him the Rose of Firiona receiving a Wood Painting.",
-          "order": 20
+          "order": 20,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-21-the-ancient-pattern-track-down-a-human-skeleton-in-frontier-mountains-give-it-the-wood-painting-",
           "className": "Ranger",
           "section": "The Ancient Pattern",
           "text": "Track down a human skeleton in Frontier Mountains, give it the Wood Painting receiving a Silver Chained Locket.",
-          "order": 21
+          "order": 21,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-22-the-ancient-pattern-give-niera-farbreeze-in-surefall-glade-the-silver-chained-locket-receiving-p",
           "className": "Ranger",
           "section": "The Ancient Pattern",
           "text": "Give Niera Farbreeze in Surefall Glade the Silver Chained Locket receiving Platinum Speckled Powder.",
-          "order": 22
+          "order": 22,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-23-the-platinum-speckled-powder-slay-black-reavers-in-city-of-mist-and-loot-a-jade-reaver",
           "className": "Ranger",
           "section": "The Platinum Speckled Powder",
           "text": "Slay black reavers in City of Mist and loot a Jade Reaver.",
-          "order": 23
+          "order": 23,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-24-the-platinum-speckled-powder-speak-to-kinlo-strongarm-in-north-kaladim-and-give-him-the-jade-rea",
           "className": "Ranger",
           "section": "The Platinum Speckled Powder",
           "text": "Speak to Kinlo Strongarm in North Kaladim and give him the Jade Reaver receiving Enchanted Clay.",
-          "order": 24
+          "order": 24,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-25-the-enchanted-clay-combine-the-ancient-pattern-platinum-speckled-powder-and-enchanted-clay-in-a-",
           "className": "Ranger",
           "section": "The Enchanted Clay",
           "text": "Combine the Ancient Pattern, Platinum Speckled Powder, and Enchanted Clay in a pottery wheel creating a Runecrested Bowl.",
-          "order": 25
+          "order": 25,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-26-making-swiftwind-give-the-hardened-mixture-and-runecrested-bowl-to-ella-foodcrafter-receiving-a-",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Give the Hardened Mixture and Runecrested Bowl to Ella Foodcrafter, receiving a Softly glowing stone.",
-          "order": 26
+          "order": 26,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-27-making-swiftwind-create-a-summoned-firefly-globe-level-1-druid-spell-no-rent-only-castable-at-ni",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Create a Summoned: Firefly Globe (level 1 Druid spell, NO RENT, only castable at night: 7p - 4a).",
-          "order": 27
+          "order": 27,
+          "availableInClassic": true
         },
         {
           "id": "epic-ranger-28-making-swiftwind-purchase-scroll-of-resurrection-level-49-cleric-spell",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Purchase Scroll of Resurrection (level 49 Cleric spell).",
-          "order": 28
+          "order": 28,
+          "availableInClassic": true
         },
         {
           "id": "epic-ranger-29-making-swiftwind-give-venril-sathir-remains-in-karnor-s-castle-the-summoned-firefly-globe-to-spa",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Give Venril Sathir Remains in Karnor's Castle the Summoned: Firefly Globe to spawn Spirit of Venril Sathir.",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-30-making-swiftwind-give-spirit-of-venril-sathir-in-karnor-s-castle-the-spell-resurrection-to-spawn",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Give Spirit of Venril Sathir in Karnor's Castle the Spell: Resurrection to spawn Venril Sathir.",
-          "order": 30
+          "order": 30,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-31-making-swiftwind-slay-venril-sathir-in-karnor-s-castle-and-loot-a-pulsing-green-stone",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Slay Venril Sathir in Karnor's Castle and loot a Pulsing Green Stone.",
-          "order": 31
+          "order": 31,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-32-making-swiftwind-give-foloal-stormforest-in-firiona-vie-the-pulsing-green-stone-and-softly-glowi",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Give Foloal Stormforest in Firiona Vie the Pulsing Green Stone and Softly Glowing Stone, receiving a Warmly Glowing Stone.",
-          "order": 32
+          "order": 32,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-33-making-swiftwind-give-telin-darkforest-the-warmly-glowing-stone-receiving-an-ancient-longsword",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Give Telin Darkforest the Warmly Glowing Stone receiving an Ancient Longsword.",
-          "order": 33
+          "order": 33,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-34-making-swiftwind-check-below-for-how-to-spawn-usbak-the-old",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Check Below for How to Spawn Usbak the Old",
-          "order": 34
+          "order": 34,
+          "availableInClassic": true
         },
         {
           "id": "epic-ranger-35-making-swiftwind-hail-usbak-the-old-and-give-him-the-ancient-longsword-receiving-a-refined-ancie",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Hail Usbak the Old and give him the Ancient Longsword receiving a Refined Ancient Sword.",
-          "order": 35
+          "order": 35,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-36-making-swiftwind-give-telin-darkforest-the-refined-ancient-sword-spawning-faelin-bloodbriar-then",
           "className": "Ranger",
           "section": "Making Swiftwind",
           "text": "Give Telin Darkforest the Refined Ancient Sword spawning Faelin Bloodbriar, then give her the Refined Ancient Sword receiving Swiftwind.",
-          "order": 36
+          "order": 36,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-37-making-refined-mithril-blade-slay-essence-tamers-in-plane-of-sky-and-loot-a-swirling-sphere-of-c",
           "className": "Ranger",
           "section": "Making Refined Mithril Blade",
           "text": "Slay essence tamers in Plane of Sky and loot a Swirling Sphere of Color.",
-          "order": 37
+          "order": 37,
+          "availableInClassic": true
         },
         {
           "id": "epic-ranger-38-making-refined-mithril-blade-spawn-jaeil-the-insane-by-giving-jaeil-the-wretched-in-the-hole-ell",
           "className": "Ranger",
           "section": "Making Refined Mithril Blade",
           "text": "Spawn Jaeil the Insane by giving Jaeil the Wretched in The Hole Ella's Shiny Tin Bowl and slay him. Loot a Soulbound Hammer.",
-          "order": 38
+          "order": 38,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-39-making-refined-mithril-blade-speak-to-mairee-silentone-in-erudin-palace-and-give-her-the-soulbou",
           "className": "Ranger",
           "section": "Making Refined Mithril Blade",
           "text": "Speak to Mairee Silentone in Erudin Palace and give her the Soulbound Hammer, receiving a Dwarven Smiths Hammer.",
-          "order": 39
+          "order": 39,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-40-making-refined-mithril-blade-give-mairee-silentone-the-dwarven-smiths-hammer-and-swirling-sphere",
           "className": "Ranger",
           "section": "Making Refined Mithril Blade",
           "text": "Give Mairee Silentone the Dwarven Smiths Hammer and Swirling Sphere of Color, receiving Hammer of the Ancients.",
-          "order": 40
+          "order": 40,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-41-making-refined-mithril-blade-stop-obtain-ancient-longsword-from-telin-see-making-swiftwind-above",
           "className": "Ranger",
           "section": "Making Refined Mithril Blade",
           "text": "STOP! OBTAIN Ancient Longsword FROM TELIN (see Making Swiftwind above). YOU NEED TO HAND THAT IN TO USBAK, WHO WILL DESPAWN!",
-          "order": 41
+          "order": 41,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-42-making-refined-mithril-blade-give-kinlo-strongarm-the-hammer-of-the-ancients-spawning-usbak-the-",
           "className": "Ranger",
           "section": "Making Refined Mithril Blade",
           "text": "Give Kinlo Strongarm the Hammer of the Ancients spawning Usbak the Old who gives you a Small bit of Mithril Ore.",
-          "order": 42
+          "order": 42,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-43-making-refined-mithril-blade-give-kinlo-strongarm-the-small-bit-of-mithril-ore-receiving-a-refin",
           "className": "Ranger",
           "section": "Making Refined Mithril Blade",
           "text": "Give Kinlo Strongarm the Small bit of Mithril Ore receiving a Refined Mithril Blade.",
-          "order": 43
+          "order": 43,
+          "availableInClassic": false
         },
         {
           "id": "epic-ranger-44-making-earthcaller-loot-a-shattered-emerald-of-corruption-from-the-plane-of-hate-mini-bosses-72-",
           "className": "Ranger",
           "section": "Making Earthcaller",
           "text": "Loot a Shattered Emerald of Corruption from the Plane of Hate \"mini bosses\" (72 hour respawn) or Innoruuk.",
-          "order": 44
+          "order": 44,
+          "availableInClassic": true
         },
         {
           "id": "epic-ranger-45-making-earthcaller-give-xanuusus-in-north-karana-the-shattered-emerald-of-corruption-and-refined",
           "className": "Ranger",
           "section": "Making Earthcaller",
           "text": "Give Xanuusus in North Karana the Shattered Emerald of Corruption and Refined Mithril Blade receiving Earthcaller.",
-          "order": 45
+          "order": 45,
+          "availableInClassic": false
         }
       ]
     },
@@ -2433,224 +2773,256 @@
           "className": "Rogue",
           "section": "Checklist",
           "text": "Obtain Stanos' Pouch",
-          "order": 0
+          "order": 0,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-1-checklist-optional-acquire-level-50-will-need-assistance-from-a-50-rogue-if-you-are-not-high-eno",
           "className": "Rogue",
           "section": "Checklist",
           "text": "(OPTIONAL) Acquire level 50 (will need assistance from a 50+ rogue if you are not high enough)",
-          "order": 1
+          "order": 1,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-2-checklist-optional-go-to-the-qeynos-aqueducts-and-find-malka-rale-at-380-210-spawns-at-8pm-game-",
           "className": "Rogue",
           "section": "Checklist",
           "text": "(OPTIONAL) Go to the Qeynos Aqueducts and find Malka Rale at +380, -210 (spawns at 8PM game time), tell her 'I can help' to receive Stanos' Pouch.",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-3-checklist-pickpocketing-and-travel",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Pickpocketing and Travel",
-          "order": 3
+          "order": 3,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-4-checklist-pickpocket-stained-parchment-top-from-founy-jestands-in-north-kaladim",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Pickpocket Stained Parchment Top from Founy Jestands in North Kaladim.",
-          "order": 4
+          "order": 4,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-5-checklist-pickpocket-stained-parchment-bottom-from-tani-n-mar-in-neriak-third-gate",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Pickpocket Stained Parchment Bottom from Tani N`Mar in Neriak Third Gate.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-6-checklist-hand-stanos-pouch-to-anson-mcbale-and-say-i-need-to-see-stanos-to-spawn-stanos-herkano",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Hand Stanos' Pouch to Anson Mcbale and say \"I need to see Stanos\" to spawn Stanos Herkanor and then turn both parchment pieces into Stanos in Highpass Hold to receive Combined Parchment.",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-7-checklist-give-combined-parchment-100pp-and-2-unstacked-bottle-of-milk-to-eldreth-in-lake-rathet",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Give Combined Parchment, 100pp, and 2 unstacked Bottle of Milk to Eldreth in Lake Rathetear. Receive Scribbled Parchment.",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-8-checklist-take-scribbled-parchment-to-yendar-starpyre-in-steamfont-mountains-receive-tattered-pa",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Take Scribbled Parchment to Yendar Starpyre in Steamfont Mountains. Receive Tattered Parchment.",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-9-checklist-book-of-souls",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Book of Souls",
-          "order": 9
+          "order": 9,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-10-checklist-wizard-teleport-to-plane-of-hate-obtain-book-of-souls-10-hr-ground-spawn-at-60-325-56",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Wizard teleport to Plane of Hate, obtain Book of Souls (10 hr ground spawn at -60, +325, 56).",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-11-checklist-renux",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Renux",
-          "order": 11
+          "order": 11,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-12-checklist-give-tattered-parchment-and-book-of-souls-to-yendar-starpyre-to-spawn-renux-kill-renux",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Give Tattered Parchment and Book of Souls to Yendar Starpyre to spawn Renux. Kill Renux Herkanor, loot Translated Parchment and, if it drops, Jagged Diamond Dagger*.",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-13-checklist-general-v-ghera",
           "className": "Rogue",
           "section": "Checklist",
           "text": "General V`Ghera",
-          "order": 13
+          "order": 13,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-14-checklist-return-translated-parchment-to-stanos-receive-a-sealed-box-from-stanos",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Return Translated Parchment to Stanos. Receive a Sealed Box from Stanos.",
-          "order": 14
+          "order": 14,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-15-checklist-travel-to-kithicor-forest-hand-in-a-sealed-box-to-any-of-the-dark-elves-to-spawn-gener",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Travel to Kithicor Forest, hand in a Sealed Box to any of the Dark Elves to spawn General V`ghera. IMPORTANT: Do not use hide or invisibility / IVU while turning in the box, but do use sneak. Verify that you are sneaking but not hidden and that the mob cons indifferent before turning-in or you may lose your progress!",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-16-checklist-kill-general-v-ghera-loot-general-s-pouch-and-if-it-drops-cazic-quill",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Kill General V`ghera. Loot General's Pouch and, if it drops, Cazic Quill*.",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-17-checklist-auxiliary-questing-if-they-did-not-previously-drop",
           "className": "Rogue",
           "section": "Checklist",
           "text": "*Auxiliary Questing (if they did not previously drop)",
-          "order": 17
+          "order": 17,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-18-checklist-cazic-quill",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Cazic Quill",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-19-checklist-get-robe-of-the-kedge-from-phinigel-autropos-in-kedge-keep-or-a-rare-drop-from-coercer",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Get Robe of the Kedge from Phinigel Autropos in Kedge Keep or a rare drop from Coercer Q`ioul in Kithicor Forest.",
-          "order": 19
+          "order": 19,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-20-checklist-get-robe-of-the-ishva-from-the-ishva-mal-in-splitpaw-or-a-rare-drop-from-coercer-q-iou",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Get Robe of the Ishva from The Ishva Mal in Splitpaw or a rare drop from Coercer Q`ioul in Kithicor Forest.",
-          "order": 20
+          "order": 20,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-21-checklist-get-shining-metallic-robes-from-ghoul-archmagus-in-lower-guk-or-a-much-harder-yendar-s",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Get Shining Metallic Robes from Ghoul Archmagus in Lower Guk or a much harder Yendar Starpyre in Steamfont Mountains.",
-          "order": 21
+          "order": 21,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-22-checklist-get-robe-of-the-oracle-from-oracle-of-k-arnon-in-ocean-of-tears",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Get Robe of the Oracle from Oracle of K`Arnon in Ocean of Tears.",
-          "order": 22
+          "order": 22,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-23-checklist-turn-in-all-four-robes-to-vilnius-the-small-in-western-plains-of-karana-to-receive-caz",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Turn in all four robes to Vilnius the Small in Western Plains of Karana to receive Cazic Quill.",
-          "order": 23
+          "order": 23,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-24-checklist-jagged-diamond-dagger",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Jagged Diamond Dagger",
-          "order": 24
+          "order": 24,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-25-checklist-get-fleshripper-from-solusek-kobold-king-in-nagafen-s-lair",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Get Fleshripper from Solusek kobold king in Nagafen's Lair.",
-          "order": 25
+          "order": 25,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-26-checklist-get-painbringer-from-kobold-champion-in-nagafen-s-lair",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Get Painbringer from Kobold champion in Nagafen's Lair.",
-          "order": 26
+          "order": 26,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-27-checklist-get-mithril-two-handed-sword-from-the-froglok-king-in-lower-guk-live-side",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Get Mithril Two-Handed Sword from The froglok king in Lower Guk (live side).",
-          "order": 27
+          "order": 27,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-28-checklist-get-gigantic-zweihander-from-karg-icebear-in-everfrost-peaks",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Get Gigantic Zweihander from Karg Icebear in Everfrost Peaks.",
-          "order": 28
+          "order": 28,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-29-checklist-turn-in-all-four-blades-to-vilnius-the-small-in-western-plains-of-karana-to-receive-ja",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Turn in all four blades to Vilnius the Small in Western Plains of Karana to receive Jagged Diamond Dagger.",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         },
         {
           "id": "epic-rogue-30-checklist-final-turn-in",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Final Turn in",
-          "order": 30
+          "order": 30,
+          "availableInClassic": true
         },
         {
           "id": "epic-rogue-31-checklist-turn-in-general-s-pouch-jagged-diamond-dagger-and-cazic-quill-to-stanos-herkanor-to-re",
           "className": "Rogue",
           "section": "Checklist",
           "text": "Turn in General's Pouch, Jagged Diamond Dagger, and Cazic Quill to Stanos Herkanor to receive Ragebringer!",
-          "order": 31
+          "order": 31,
+          "availableInClassic": false
         }
       ]
     },
@@ -2662,238 +3034,272 @@
           "className": "Shadow Knight",
           "section": "The Letter to Duriek",
           "text": "Hail Kurron Ni in Overthere Outpost",
-          "order": 0
+          "order": 0,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-1-the-letter-to-duriek-give-kurron-ni-darkforge-breastplate-darkforge-greaves-darkforge-helm-and-9",
           "className": "Shadow Knight",
           "section": "The Letter to Duriek",
           "text": "Give Kurron Ni Darkforge Breastplate, Darkforge Greaves, Darkforge Helm and 900 Platinum. You can get the armor through the Darkforge Armor Quests.",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-2-the-letter-to-duriek-kill-kurron-ni-and-loot-the-letter-to-duriek",
           "className": "Shadow Knight",
           "section": "The Letter to Duriek",
           "text": "Kill Kurron Ni and Loot the Letter to Duriek",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-3-the-dusty-tome-give-the-letter-to-duriek-bloodpool-in-paineel",
           "className": "Shadow Knight",
           "section": "The Dusty Tome",
           "text": "Give the letter to Duriek Bloodpool in Paineel",
-          "order": 3
+          "order": 3,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-4-the-dusty-tome-hail-smaka-in-neriak-foreign-quarter",
           "className": "Shadow Knight",
           "section": "The Dusty Tome",
           "text": "Hail Smaka in Neriak Foreign Quarter",
-          "order": 4
+          "order": 4,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-5-the-dusty-tome-give-smaka-1000-platinum-for-a-cough-elixir",
           "className": "Shadow Knight",
           "section": "The Dusty Tome",
           "text": "Give Smaka 1000 Platinum for a Cough Elixir",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-6-the-dusty-tome-give-the-cough-elixir-to-duriek",
           "className": "Shadow Knight",
           "section": "The Dusty Tome",
           "text": "Give the Cough Elixir to Duriek",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-7-the-dusty-tome-kill-a-ratman-guard-in-the-hole-and-loot-a-dusty-tome",
           "className": "Shadow Knight",
           "section": "The Dusty Tome",
           "text": "Kill a ratman guard in The Hole and loot a Dusty Tome",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-8-the-dusty-tome-give-the-dusty-tome-to-duriek",
           "className": "Shadow Knight",
           "section": "The Dusty Tome",
           "text": "Give the Dusty Tome to Duriek",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-9-the-corrupted-ghoulbane-kill-the-the-froglok-shin-lord-in-ruins-of-upper-guk-and-loot-the-ghoulb",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Kill the The froglok shin lord in Ruins of Upper Guk and loot The Ghoulbane",
-          "order": 9
+          "order": 9,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-10-the-corrupted-ghoulbane-kill-cazic-thule-and-loot-the-soul-leech-dark-sword-of-blood-note-post-f",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Kill Cazic-Thule and Loot The Soul Leech, Dark Sword of Blood (NOTE: Post Fear Revamp this now drops off Fear Golems Fright, Dread, and Terror)",
-          "order": 10
+          "order": 10,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-11-the-corrupted-ghoulbane-kill-monsters-in-plane-of-sky-for-the-blade-of-abrogation",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Kill monsters in Plane of Sky for the Blade of Abrogation",
-          "order": 11
+          "order": 11,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-12-the-corrupted-ghoulbane-kill-rharzar-in-rathe-mountains-for-a-drake-spine",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Kill Rharzar in Rathe Mountains for a Drake Spine",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-13-the-corrupted-ghoulbane-kill-an-ashenbone-drakes-in-plane-of-hate-for-a-decrepit-hide",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Kill An ashenbone drakes in Plane of Hate for a Decrepit Hide",
-          "order": 13
+          "order": 13,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-14-the-corrupted-ghoulbane-buy-a-platinum-bar-and-find-an-enchanter-to-make-an-enchanted-platinum-b",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Buy a Platinum Bar and find an enchanter to make an Enchanted Platinum Bar",
-          "order": 14
+          "order": 14,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-15-the-corrupted-ghoulbane-open-trade-window-click-hide-and-make-sure-you-con-indifferent-status-hi",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Open trade window, click Hide and make sure you con INDIFFERENT STATUS (Hiding is not needed if you have better faction). SUPER IMPORTANT! DO NOT HAND IN ITEMS W/O indifferent status or better. Teydar in the evil guild area of the Qeynos Aqueducts",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-16-the-corrupted-ghoulbane-give-the-drake-spine-decrepit-hide-and-enchanted-platinum-bar-to-teydar-",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Give the Drake Spine, Decrepit Hide and Enchanted Platinum Bar to Teydar for a Decrepit Sheath",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-17-the-corrupted-ghoulbane-go-to-duriek-open-trade-window-click-hide-and-make-sure-you-con-indiffer",
           "className": "Shadow Knight",
           "section": "The Corrupted Ghoulbane",
           "text": "Go to Duriek. Open trade window, click Hide and make sure you con INDIFFERENT STATUS (Hiding is not needed if you have better faction). SUPER IMPORTANT! DO NOT HAND IN ITEMS W/O indifferent status or better. Give the Ghoulbane, the Soul Leech, Dark Sword of Blood, the Blade of Abrogation and the Decrepit Sheath to Duriek for the Corrupted Ghoulbane.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-18-the-dark-shroud-optional-hail-lhranc-in-the-city-of-mist",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "(Optional) Hail Lhranc in the City of Mist",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-19-the-dark-shroud-optional-hail-marl-kastane-in-kerra-isle-and-say-i-have-the-will-of-innoruuk-and",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "(Optional) Hail Marl Kastane in Kerra Isle and say 'I have the will of innoruuk' and 'What prophecy-' to get a Seal of Kastane",
-          "order": 19
+          "order": 19,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-20-the-dark-shroud-optional-hail-gerot-kastane-in-paineel-and-give-him-the-seal-of-kastane-to-get-t",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "(Optional) Hail Gerot Kastane in Paineel and give him the Seal of Kastane to get the Note to Marl",
-          "order": 20
+          "order": 20,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-21-the-dark-shroud-optional-give-the-note-to-marl-to-marl-kastane",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "(Optional) Give the Note to Marl to Marl Kastane",
-          "order": 21
+          "order": 21,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-22-the-dark-shroud-hail-knarthenne-skurl-in-toxxulia-forest-and-say-what-heart-of-an-innocent-to-ge",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "Hail Knarthenne Skurl in Toxxulia Forest and say 'what heart of an innocent-' to get a Soulcase",
-          "order": 22
+          "order": 22,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-23-the-dark-shroud-gather-a-cell-key-from-a-mimic-looks-like-a-chest-in-the-city-bank-of-the-hole",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "Gather a Cell Key from a mimic (looks like a chest) in the city bank of the Hole",
-          "order": 23
+          "order": 23,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-24-the-dark-shroud-give-the-cell-key-to-caradon-you-must-be-indifferent-for-this-turn-in-use-hide-s",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "Give the Cell Key to Caradon (You must be indifferent for this turn-in) - Use \"Hide\" Skill.",
-          "order": 24
+          "order": 24,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-25-the-dark-shroud-kill-kyrenna-not-caradon-if-it-can-be-avoided-and-loot-blood-of-kyrenna-and-hear",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "Kill Kyrenna NOT Caradon (if it can be avoided) and Loot Blood of Kyrenna and Heart of Kyrenna",
-          "order": 25
+          "order": 25,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-26-the-dark-shroud-give-the-blood-of-kyrenna-to-marl-kastane-and-receive-the-dark-shroud-dont-feign",
           "className": "Shadow Knight",
           "section": "The Dark Shroud",
           "text": "Give the Blood of Kyrenna to Marl Kastane and receive the Dark Shroud DONT FEIGN DEATH FOR THIS TURN-IN You must be Indifferent for this turn in (use \"Hide\" skill). Make sure to be Hidden for this turn in.",
-          "order": 26
+          "order": 26,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-27-lhranc-s-coin-give-the-dark-shroud-to-the-ghost-of-glohnor-in-the-hole-make-sure-to-con-indiff-w",
           "className": "Shadow Knight",
           "section": "Lhranc's Coin",
           "text": "Give the Dark Shroud to the Ghost of Glohnor in the Hole (Make sure to con indiff w/ IVU!)",
-          "order": 27
+          "order": 27,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-28-lhranc-s-coin-kill-mummy-of-glohnor-and-loot-the-head-of-glohnor-and-the-glohnor-wrappings",
           "className": "Shadow Knight",
           "section": "Lhranc's Coin",
           "text": "Kill Mummy of Glohnor and loot the Head of Glohnor and the Glohnor wrappings",
-          "order": 28
+          "order": 28,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-29-lhranc-s-coin-give-the-head-of-glohnor-to-gerot-kastane-and-receive-the-head-of-the-valiant-make",
           "className": "Shadow Knight",
           "section": "Lhranc's Coin",
           "text": "Give the Head of Glohnor to Gerot Kastane and receive the Head of the Valiant (Make sure to con indifferent w/ hide!)",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-30-lhranc-s-coin-give-the-glohnor-wrappings-to-marl-kastane-and-receive-the-will-of-innoruuk-make-s",
           "className": "Shadow Knight",
           "section": "Lhranc's Coin",
           "text": "Give the Glohnor wrappings to Marl Kastane and receive the Will of Innoruuk (Make sure to con indifferent w/ hide!)",
-          "order": 30
+          "order": 30,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-31-lhranc-s-coin-combine-the-heart-of-kyrenna-with-the-soulcase-to-produce-the-heart-of-the-innocen",
           "className": "Shadow Knight",
           "section": "Lhranc's Coin",
           "text": "Combine the Heart of Kyrenna with the Soulcase to produce the Heart of the Innocent",
-          "order": 31
+          "order": 31,
+          "availableInClassic": true
         },
         {
           "id": "epic-shadow-knight-32-lhranc-s-coin-give-the-corrupted-ghoulbane-the-heart-of-the-innocent-the-head-of-the-valiant-and",
           "className": "Shadow Knight",
           "section": "Lhranc's Coin",
           "text": "Give the Corrupted Ghoulbane, the Heart of the Innocent, the Head of the Valiant and the Will of Innoruuk to Lhranc - Make sure you are indifferent to him before you do the hand in, have someone else cast IVU on you before you hit trade. He will respawn with the sword... prepare for a fight. If you wipe in fight, Lhranc won't despawn. Bring at least 2 groups.",
-          "order": 32
+          "order": 32,
+          "availableInClassic": false
         },
         {
           "id": "epic-shadow-knight-33-lhranc-s-coin-kill-lhranc-and-loot-innoruuk-s-curse-gratz",
           "className": "Shadow Knight",
           "section": "Lhranc's Coin",
           "text": "Kill Lhranc and LOOT Innoruuk's Curse! Gratz!",
-          "order": 33
+          "order": 33,
+          "availableInClassic": false
         }
       ]
     },
@@ -2905,182 +3311,208 @@
           "className": "Shaman",
           "section": "Checklist",
           "text": "Begin quest by talking to a lesser spirit after killing one of the mobs in RM, OoT, BBM, or FoB, receive Tiny Gem from a Lesser Spirit (do not kill him).",
-          "order": 0
+          "order": 0,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-1-checklist-take-gem-to-north-freeport-and-give-the-gem-to-bondl-felligan-who-will-lead-you-to-the",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Take gem to North Freeport and give the gem to Bondl Felligan who will lead you to the Jade Tiger and spawn Greater Spirits.",
-          "order": 1
+          "order": 1,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-2-checklist-talk-to-the-proper-greater-spirit-for-your-god-until-you-get-an-opaque-gem",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Talk to the proper Greater Spirit for your god until you get an Opaque Gem.",
-          "order": 2
+          "order": 2,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-3-checklist-test-of-patience-in-erud-s-crossing-receive-a-small-gem-from-a-greater-spirit",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Test of Patience in Erud\u2019s Crossing, receive a small gem from a Greater Spirit.",
-          "order": 3
+          "order": 3,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-4-checklist-turn-gem-into-a-wandering-spirit-in-west-karana",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Turn gem into a wandering spirit in West Karana.",
-          "order": 4
+          "order": 4,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-5-checklist-kill-glaron-the-wicked-drops-envy-woe-and-tabien-the-goodly-drops-marr-s-promise-in-ra",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Kill Glaron the Wicked (drops Envy & Woe) and Tabien the Goodly (drops Marr's Promise) in Rathe Mountains.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-6-checklist-take-envy-woe-and-marr-s-promise-to-the-wandering-spirit-in-west-karana-generally-betw",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Take Envy, Woe, and Marr\u2019s Promise to the Wandering Spirit in West Karana (generally between Qeynos hills and bandit camp in the mountains,) receive Shield of Falsehood and gem in return.",
-          "order": 6
+          "order": 6,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-7-checklist-take-gem-to-spirit-sentinel-in-emerald-jungle",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Take gem to Spirit Sentinel in Emerald Jungle.",
-          "order": 7
+          "order": 7,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-8-checklist-kill-black-dire-in-mistmoore-minimum-level-5-to-zone-into-mistmoore-loot-black-dire-pe",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Kill Black Dire in Mistmoore (minimum level 5 to zone into Mistmoore), loot Black Dire Pelt.",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-9-checklist-turn-in-pelt-to-spirit-sentinel-in-emerald-jungle-you-need-faction-for-this-turn-in-re",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Turn in pelt to Spirit Sentinel in Emerald Jungle (you need faction for this turn in) Receive Black Fur Boots! Get 6 slot booklet from the spirit.",
-          "order": 9
+          "order": 9,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-10-checklist-collect-6-reports-from-the-city-of-mist-for-booklet-turn-in-is-kindly-or-better",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Collect 6 reports from the City of Mist for booklet. (turn in is KINDLY or better)",
-          "order": 10
+          "order": 10,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-11-checklist-combine-and-turn-in-completed-booklet-to-spirit-sentinel-in-emerald-jungle",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Combine and turn in completed booklet to Spirit Sentinel in Emerald Jungle.",
-          "order": 11
+          "order": 11,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-12-checklist-kill-lord-ghiosk-in-the-city-of-mist-and-loot-the-3-books",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Kill Lord Ghiosk in the City of Mist and loot the 3 books.",
-          "order": 12
+          "order": 12,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-13-checklist-turn-in-books-to-spirit-in-lake-in-emerald-jungle",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Turn in books to Spirit (in lake) in Emerald Jungle.",
-          "order": 13
+          "order": 13,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-14-checklist-obtain-icon-of-the-high-scale-from-the-city-of-mist-ground-spawn-in-the-temple",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Obtain Icon of the High Scale from the City of Mist (ground spawn in the temple).",
-          "order": 14
+          "order": 14,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-15-checklist-give-icon-to-high-scale-kirn-in-the-hole-kill-him-and-loot-his-ring",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Give Icon to High Scale Kirn in the Hole, kill him and loot his ring.",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-16-checklist-give-the-ring-to-neh-ashiir-in-the-city-of-mist-kill-her-loot-her-diary",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Give the ring to Neh`Ashiir in the City of Mist, kill her, loot her diary.",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-17-checklist-turn-in-the-diary-to-spirit-sentinel-in-emerald-jungle",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Turn in the diary to Spirit Sentinel in Emerald Jungle.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-18-checklist-go-to-fear-to-kill-the-iksar-broodling-loot-child-s-tear-random-spawn-from-killing-gol",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Go to Fear to kill the Iksar Broodling, loot Child's Tear (random spawn from killing Golems, slay either Dread, Fright, or Terror).",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-19-checklist-give-the-tear-to-lord-rak-ashiir-in-city-of-mist-kill-him-and-loot-his-iksar-scale-you",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Give the tear to Lord Rak`Ashiir in City of Mist, kill him and loot his Iksar Scale. YOU NEED ALLY FACTION FOR THIS TURN IN -- JUST NOT MAXED ALLY",
-          "order": 19
+          "order": 19,
+          "availableInClassic": false
         },
         {
           "id": "epic-shaman-20-checklist-take-scale-to-spirit-sentinel-wolf-in-emerald-jungle-in-the-pond-to-receive-your-epic-",
           "className": "Shaman",
           "section": "Checklist",
           "text": "Take Scale to Spirit Sentinel wolf in Emerald Jungle IN THE POND to receive your epic! YOU NEED MAX ALLY, NOT JUST ALLY",
-          "order": 20
+          "order": 20,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-21-faction-based-completions-if-one-does-the-quest-with-all-the-steps-up-to-finishing-one-turn-in-o",
           "className": "Shaman",
           "section": "Faction-Based Completions",
           "text": "If one does the quest with all the steps up to finishing one turn in of CoM pages, it takes 25 turn-ins of Envy, Woe, and Marr's Promise to the wandering spirit in West Karana to reach max Truespirit faction.",
-          "order": 21
+          "order": 21,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-22-faction-based-completions-ogre-rallos-zek-shaman-went-from-indifferent-to-max-faction-by-doing-t",
           "className": "Shaman",
           "section": "Faction-Based Completions",
           "text": "Ogre Rallos Zek Shaman went from indifferent to max faction by doing the Tiny Gem turn in 13 times, 1 turn in of Woe/Envy/Marr, 1 turn in of 6 CoM letters, 1 turn in of 3 CoM books, 1 turn in of Dire Pelt.",
-          "order": 22
+          "order": 22,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-23-faction-based-completions-iksar-shaman-lvl-14-2x-turn-ins-of-envy-woe-and-marr-s-promise-got-me-",
           "className": "Shaman",
           "section": "Faction-Based Completions",
           "text": "Iksar Shaman lvl 14 - 2x turn-ins of Envy, Woe, and Marr's Promise got me to amiable. I then went to turn in the resulting gem from the Wandering Spirit and was also able to complete the Black Fur Boots portion directly afterward (still amiable).",
-          "order": 23
+          "order": 23,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-24-faction-based-completions-repeating-part-2-the-drunken-shaman-took-approximately-76-turn-ins-of-",
           "className": "Shaman",
           "section": "Faction-Based Completions",
           "text": "Repeating Part 2 - The Drunken Shaman took approximately 76 turn ins of the 'Tiny Gem' to Bondl Felligan to go from start to max faction with Truespirit.",
-          "order": 24
+          "order": 24,
+          "availableInClassic": true
         },
         {
           "id": "epic-shaman-25-faction-based-completions-for-a-rallos-zek-ogre-it-only-took-me-20-hand-ins-to-bondl-felligan-to",
           "className": "Shaman",
           "section": "Faction-Based Completions",
           "text": "For a Rallos Zek Ogre, it only took me 20 hand ins to Bondl Felligan to get to max ally.",
-          "order": 25
+          "order": 25,
+          "availableInClassic": true
         }
       ]
     },
@@ -3092,210 +3524,240 @@
           "className": "Warrior",
           "section": "Checklist",
           "text": "Hail Kargek Redblade and Wenden Blackhammer in East Freeport",
-          "order": 0
+          "order": 0,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-1-checklist-retrieve-unjeweled-dragon-head-hilt-from-the-bottom-of-lake-rathetear",
           "className": "Warrior",
           "section": "Checklist",
           "text": "Retrieve Unjeweled Dragon Head Hilt from the bottom of Lake Rathetear",
-          "order": 1
+          "order": 1,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-2-checklist-give-the-unjeweled-dragon-head-hilt-a-diamond-a-jacinth-and-a-black-sapphire-to-wenden",
           "className": "Warrior",
           "section": "Checklist",
           "text": "Give the Unjeweled Dragon Head Hilt, a Diamond, a Jacinth, and a Black Sapphire to Wenden Blackhammer",
-          "order": 2
+          "order": 2,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-3-checklist-receive-the-jeweled-dragon-head-hilt",
           "className": "Warrior",
           "section": "Checklist",
           "text": "Receive the Jeweled Dragon Head Hilt",
-          "order": 3
+          "order": 3,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-4-jeweled-dragon-head-hilt-retrieve-severely-damaged-dragon-head-hilt-from-the-chessboard-in-timor",
           "className": "Warrior",
           "section": "Jeweled Dragon Head Hilt",
           "text": "Retrieve Severely Damaged Dragon Head Hilt from the chessboard in Timorous Deep",
-          "order": 4
+          "order": 4,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-5-jeweled-dragon-head-hilt-get-a-giant-sized-monocle-from-a-mountain-giant-patriarch-in-dreadlands",
           "className": "Warrior",
           "section": "Jeweled Dragon Head Hilt",
           "text": "Get a Giant Sized Monocle from A mountain giant patriarch in Dreadlands",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-6-jeweled-dragon-head-hilt-give-the-giant-sized-monocle-to-mentrax-mountainbone-in-frontier-mounta",
           "className": "Warrior",
           "section": "Jeweled Dragon Head Hilt",
           "text": "Give the Giant Sized Monocle to Mentrax Mountainbone in Frontier Mountains and receive Rejesiam Ore.",
-          "order": 6
+          "order": 6,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-7-jeweled-dragon-head-hilt-kill-fright-dread-or-terror-and-loot-ball-of-everliving-golem-in-plane-",
           "className": "Warrior",
           "section": "Jeweled Dragon Head Hilt",
           "text": "Kill Fright, Dread, or Terror and loot Ball of Everliving Golem in Plane of Fear",
-          "order": 7
+          "order": 7,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-8-jeweled-dragon-head-hilt-give-severely-damaged-dragon-head-hilt-rejesiam-ore-and-ball-of-everliv",
           "className": "Warrior",
           "section": "Jeweled Dragon Head Hilt",
           "text": "Give Severely Damaged Dragon Head Hilt, Rejesiam Ore, and Ball of Everliving Golem to Wenden Blackhammer (MQable)",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-9-jeweled-dragon-head-hilt-receive-finely-crafted-dragon-head-hilt",
           "className": "Warrior",
           "section": "Jeweled Dragon Head Hilt",
           "text": "Receive Finely Crafted Dragon Head Hilt",
-          "order": 9
+          "order": 9,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-10-finely-crafted-dragon-head-hilt-purchase-a-keg-of-vox-tail-ale-from-various-merchants-across-nor",
           "className": "Warrior",
           "section": "Finely Crafted Dragon Head Hilt",
           "text": "Purchase A Keg of Vox Tail Ale from various merchants across Norrath.",
-          "order": 10
+          "order": 10,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-11-finely-crafted-dragon-head-hilt-purchase-two-2-rebreathers-from-other-players-or-craft-as-a-gnom",
           "className": "Warrior",
           "section": "Finely Crafted Dragon Head Hilt",
           "text": "Purchase two(2) Rebreathers from other players, or craft as a Gnome with Tinkering Skill, Trivial 175.",
-          "order": 11
+          "order": 11,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-12-finely-crafted-dragon-head-hilt-kill-ice-giants-and-loot-block-of-permafrost-in-permafrost",
           "className": "Warrior",
           "section": "Finely Crafted Dragon Head Hilt",
           "text": "Kill Ice Giants and Loot Block of Permafrost in Permafrost",
-          "order": 12
+          "order": 12,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-13-finely-crafted-dragon-head-hilt-give-block-of-permafrost-a-keg-of-vox-tail-ale-and-the-two-2-reb",
           "className": "Warrior",
           "section": "Finely Crafted Dragon Head Hilt",
           "text": "Give Block of Permafrost, A Keg of Vox Tail Ale, and the two(2) Rebreathers to Denken Strongpick in Ocean of Tears.",
-          "order": 13
+          "order": 13,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-14-finely-crafted-dragon-head-hilt-receive-ancient-sword-blade",
           "className": "Warrior",
           "section": "Finely Crafted Dragon Head Hilt",
           "text": "Receive Ancient Sword Blade",
-          "order": 14
+          "order": 14,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-15-finely-crafted-dragon-head-hilt-kill-queen-velazul-di-zok-in-chardok-and-loot-ancient-blade",
           "className": "Warrior",
           "section": "Finely Crafted Dragon Head Hilt",
           "text": "Kill Queen Velazul Di`zok in Chardok and loot Ancient Blade",
-          "order": 15
+          "order": 15,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-16-the-blades-hail-kargek-redblade-and-get-wax-sealed-note-by-saying-what-favor",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Hail Kargek Redblade and get Wax Sealed Note by saying \"what favor\"",
-          "order": 16
+          "order": 16,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-17-the-blades-give-wax-sealed-note-to-oknoggin-stonesmacker-in-feerrott-and-receive-tiny-lute",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Give Wax Sealed Note to Oknoggin Stonesmacker in Feerrott and receive Tiny Lute",
-          "order": 17
+          "order": 17,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-18-the-blades-give-tiny-lute-to-kargek-redblade-and-receive-the-book-redblade-s-legacy",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Give Tiny Lute to Kargek Redblade and receive the book Redblade's Legacy",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-19-the-blades-give-book-to-tenal-redblade-in-east-karana-and-receive-totem-of-the-freezing-war",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Give book to Tenal Redblade in East Karana and receive Totem of the Freezing War",
-          "order": 19
+          "order": 19,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-20-the-blades-kill-goblin-wizards-in-permafrost-loot-heart-of-frost",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Kill goblin wizards in Permafrost, loot Heart of Frost",
-          "order": 20
+          "order": 20,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-21-the-blades-give-totem-of-the-freezing-war-and-heart-of-frost-to-tenal-redblade-and-receive-totem",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Give Totem of the Freezing War and Heart of Frost to Tenal Redblade and receive Totem of Fiery War",
-          "order": 21
+          "order": 21,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-22-the-blades-kill-lord-nagafen-or-ragefire-in-nagafen-s-lair-nortlav-the-scalekeeper-in-the-hole-o",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Kill Lord Nagafen or Ragefire in Nagafen's Lair, Nortlav the Scalekeeper in The Hole or Talendor in Skyfire Mountains and loot Red Dragon Scales",
-          "order": 22
+          "order": 22,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-23-the-blades-kill-severilous-in-emerald-jungle-or-hoshkar-in-veeshan-s-peak-and-loot-green-dragon-",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Kill Severilous in Emerald Jungle or Hoshkar in Veeshan's Peak and loot Green Dragon Scales",
-          "order": 23
+          "order": 23,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-24-the-blades-give-totem-of-fiery-war-red-dragon-scales-and-green-dragon-scales-to-tenal-redblade-a",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Give Totem of Fiery War, Red Dragon Scales, and Green Dragon Scales to Tenal Redblade and receive Mark of the Sword",
-          "order": 24
+          "order": 24,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-25-the-blades-kill-maestro-in-plane-of-hate-and-loot-hand-of-the-maestro",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Kill Maestro in Plane of Hate and loot Hand of the Maestro",
-          "order": 25
+          "order": 25,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-26-the-blades-give-mark-of-the-sword-and-hand-of-the-maestro-to-tenal-redblade-and-receive-tenal-s-",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Give Mark of the Sword and Hand of the Maestro to Tenal Redblade and receive Tenal`s note to Kargek",
-          "order": 26
+          "order": 26,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-27-the-blades-kill-spiroc-lord-in-plane-of-air-and-loot-spiroc-wingblade",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Kill Spiroc Lord in Plane of Air and Loot Spiroc Wingblade",
-          "order": 27
+          "order": 27,
+          "availableInClassic": true
         },
         {
           "id": "epic-warrior-28-the-blades-give-tenal-s-note-to-kargek-and-spiroc-wingblade-to-kargek-redblade-and-receive-red-s",
           "className": "Warrior",
           "section": "The Blades",
           "text": "Give Tenal`s note to Kargek and Spiroc Wingblade to Kargek Redblade and receive Red Scabbard",
-          "order": 28
+          "order": 28,
+          "availableInClassic": false
         },
         {
           "id": "epic-warrior-29-the-red-scabbard-combine-both-hilts-and-both-blades-in-red-scabbard-to-receive-the-jagged-blade-",
           "className": "Warrior",
           "section": "The Red Scabbard",
           "text": "Combine both hilts and both blades in Red Scabbard to receive the Jagged Blade of War.",
-          "order": 29
+          "order": 29,
+          "availableInClassic": false
         }
       ]
     },
@@ -3307,168 +3769,192 @@
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Hand the note to Camin at the Vasty Deep Inn in Erudin. Hail him, then hand him 1000pp. [OPTIONAL if using Ornate Velium Pendant][NOTE: Doing this part twice is NOT enough faction to get you to indifferent.]",
-          "order": 0
+          "order": 0,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-1-post-revamp-checklist-take-the-potion-to-camin-receive-potion-back-with-the-charge-missing",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Take the potion to Camin, receive potion back with the charge missing.",
-          "order": 1
+          "order": 1,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-2-post-revamp-checklist-hand-the-used-potion-to-dargon-who-turns-into-arantir-karondor-hail-him-an",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Hand the used potion to Dargon, who turns into Arantir Karondor. Hail him and receive the ring (note more than one wizard can hail Arantir after he has been triggered and each receive a ring).",
-          "order": 2
+          "order": 2,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-3-post-revamp-checklist-hand-challice-the-ring-in-the-basement-of-the-paladin-guild-in-felwithe-re",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Hand Challice the ring in the basement of the Paladin Guild in Felwithe, receive another ring back.",
-          "order": 3
+          "order": 3,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-4-post-revamp-checklist-hand-the-ring-to-dargon-arantir-karondor-talk-to-him-of-the-other-wizards-",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Hand the ring to Dargon/Arantir Karondor. Talk to him of the other wizards and receive Note from Arantir. (Say 'Who is the gnome-' to skip to the end of the conversation)",
-          "order": 4
+          "order": 4,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-5-post-revamp-checklist-talk-to-kandin-firepot-in-butcherblock-hand-him-note-from-arantir-say-what",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Talk to Kandin Firepot in Butcherblock. Hand him Note from Arantir, say \"what oil-\" to receive Golem Sprocket.",
-          "order": 5
+          "order": 5,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-6-post-revamp-checklist-kill-phinigel-autropos-in-kedge-keep-loot-the-blue-crystal-staff",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Kill Phinigel Autropos in Kedge Keep. Loot the Blue Crystal Staff.",
-          "order": 6
+          "order": 6,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-7-post-revamp-checklist-kill-venril-sathir-in-karnors-s-castle-loot-gnarled-staff",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Kill Venril Sathir in Karnors's Castle, loot Gnarled Staff.",
-          "order": 7
+          "order": 7,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-8-post-revamp-checklist-give-the-golem-sprocket-to-a-broken-golem-in-fear-this-spawns-an-enraged-g",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Give the Golem Sprocket to a broken golem in Fear. This spawns an enraged golem. Kill him and loot Green Oil.",
-          "order": 8
+          "order": 8,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-9-post-revamp-checklist-give-the-oil-to-kandin-firepot-receive-the-staff-of-gabstik-and-note-to-ar",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Give the oil to Kandin Firepot. Receive the Staff of Gabstik and Note to Arantir.",
-          "order": 9
+          "order": 9,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-10-post-revamp-checklist-give-note-to-arantir-to-dargon-to-spawn-arantir-karondor-then-hail-him-giv",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Give Note to Arantir to Dargon to spawn Arantir Karondor, then hail him. Give him the Blue Crystal Staff, Gnarled Staff, and Staff of Gabstik. Receive a bag.",
-          "order": 10
+          "order": 10,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-11-post-revamp-checklist-give-the-bag-to-solomen-receive-the-staff-of-the-four",
           "className": "Wizard",
           "section": "Post-Revamp Checklist",
           "text": "Give the bag to Solomen, receive the Staff of the Four",
-          "order": 11
+          "order": 11,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-12-pre-revamp-checklist-hand-the-note-to-camin-at-the-vasty-deep-inn-in-erudin-hail-him-then-hand-h",
           "className": "Wizard",
           "section": "Pre-Revamp Checklist",
           "text": "Hand the note to Camin at the Vasty Deep Inn in Erudin. Hail him, then hand him 1000pp. [OPTIONAL]",
-          "order": 12
+          "order": 12,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-13-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-take-the-potion-to-camin-rec",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "Take the potion to Camin, receive potion back with the charge missing.",
-          "order": 13
+          "order": 13,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-14-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-hand-the-used-potion-to-darg",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "Hand the used potion to Dargon, who turns into Arantir Karondor, and receive the ring.",
-          "order": 14
+          "order": 14,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-15-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-hand-challice-the-ring-in-th",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "Hand Challice the ring in the basement of the Paladin Guild in Felwithe, receive another ring back.",
-          "order": 15
+          "order": 15,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-16-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-hand-the-ring-to-dargon-aran",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "Hand the ring to Dargon/Arantir. Talk to him of the other wizards and receive a note.",
-          "order": 16
+          "order": 16,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-17-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-kill-phinigel-autropos-in-ke",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "Kill Phinigel Autropos in Kedge Keep. Loot the Blue Crystal Staff.",
-          "order": 17
+          "order": 17,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-18-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-kill-venril-sathir-in-karnor",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "Kill Venril Sathir in Karnors's Castle, loot Gnarled Staff.",
-          "order": 18
+          "order": 18,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-19-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-1-give-him-cazic-s-skin-from",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "1. Give him Cazic's Skin from CT to recieve Kandin's Bag.",
-          "order": 19
+          "order": 19,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-20-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-2-give-him-mistletoe-powder-",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "2. Give him Mistletoe Powder to obtain the Staff of Gabstik",
-          "order": 20
+          "order": 20,
+          "availableInClassic": false
         },
         {
           "id": "epic-wizard-21-talk-to-solomen-in-the-temple-of-solusek-ro-receive-a-note-optional-3-give-him-back-kandin-s-bag",
           "className": "Wizard",
           "section": "Talk to Solomen in the Temple of Solusek Ro, receive a note. [OPTIONAL]",
           "text": "3. Give him back Kandin's Bag to get a new note.",
-          "order": 21
+          "order": 21,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-22-take-the-note-to-kandin-firepot-then-give-note-to-dargon-to-spawn-arantir-then-hail-him-give-him",
           "className": "Wizard",
           "section": "Take the note to Kandin Firepot, then:",
           "text": "Give note to Dargon to spawn Arantir, then hail him. Give him the Blue Crystal Staff, Gnarled Staff, and Staff of Gabstik. Receive a bag.",
-          "order": 22
+          "order": 22,
+          "availableInClassic": true
         },
         {
           "id": "epic-wizard-23-take-the-note-to-kandin-firepot-then-give-the-bag-to-solomen-receive-the-staff-of-the-four",
           "className": "Wizard",
           "section": "Take the note to Kandin Firepot, then:",
           "text": "Give the bag to Solomen, receive the Staff of the Four",
-          "order": 23
+          "order": 23,
+          "availableInClassic": true
         }
       ]
     }

--- a/src/EQBuddy.Core/EQBuddy.Core.csproj
+++ b/src/EQBuddy.Core/EQBuddy.Core.csproj
@@ -34,6 +34,7 @@
     <EmbeddedResource Include="Data\BuffDurations.json" />
     <EmbeddedResource Include="Data\RaidTargets.json" />
     <EmbeddedResource Include="Data\QuestCatalog.json" />
+    <EmbeddedResource Include="Data\EpicQuestChecklist.json" />
     <EmbeddedResource Include="Data\ZoneGraph.json" />
     <!-- ~11k items from Category:Items, gzipped (items-harvest.py + itemcatalog-build). -->
     <EmbeddedResource Include="Data\ItemCatalog.json.gz" />

--- a/src/EQBuddy.Core/EpicQuestChecklistCatalog.cs
+++ b/src/EQBuddy.Core/EpicQuestChecklistCatalog.cs
@@ -38,4 +38,5 @@ public sealed class EpicQuestChecklistRow
     public string Section { get; set; } = "";
     public string Text { get; set; } = "";
     public int Order { get; set; }
+    public bool AvailableInClassic { get; set; } = true;
 }

--- a/src/EQBuddy.Core/EpicQuestChecklistCatalog.cs
+++ b/src/EQBuddy.Core/EpicQuestChecklistCatalog.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace EQBuddy.Core;
+
+public sealed class EpicQuestChecklistCatalog
+{
+    public List<EpicQuestClassChecklist> Classes { get; set; } = [];
+
+    public static EpicQuestChecklistCatalog LoadEmbedded()
+    {
+        using var stream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("EQBuddy.Core.Data.EpicQuestChecklist.json");
+        if (stream is null) return new EpicQuestChecklistCatalog();
+        try
+        {
+            return JsonSerializer.Deserialize<EpicQuestChecklistCatalog>(stream,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? new EpicQuestChecklistCatalog();
+        }
+        catch (Exception ex)
+        {
+            CoreLog.Error(ex);
+            return new EpicQuestChecklistCatalog();
+        }
+    }
+}
+
+public sealed class EpicQuestClassChecklist
+{
+    public string ClassName { get; set; } = "";
+    public List<EpicQuestChecklistRow> Rows { get; set; } = [];
+}
+
+public sealed class EpicQuestChecklistRow
+{
+    public string Id { get; set; } = "";
+    public string ClassName { get; set; } = "";
+    public string Section { get; set; } = "";
+    public string Text { get; set; } = "";
+    public int Order { get; set; }
+}

--- a/src/EQBuddy.Core/EpicQuestDefaults.cs
+++ b/src/EQBuddy.Core/EpicQuestDefaults.cs
@@ -1,71 +1,37 @@
 namespace EQBuddy.Core;
 
-public sealed record EpicQuestGuide(string ClassName, string Summary, string[] Steps);
-
 public static class EpicQuestDefaults
 {
     public static List<EpicQuestChecklistItem> Items()
     {
-        var catalog = QuestCatalog.LoadEmbedded();
+        var questCatalog = QuestCatalog.LoadEmbedded();
+        var checklist = EpicQuestChecklistCatalog.LoadEmbedded();
         var items = new List<EpicQuestChecklistItem>();
 
-        foreach (var className in QuestClassFilter.Classes)
+        foreach (var classChecklist in checklist.Classes)
         {
-            var quest = FindQuest(catalog, className);
-            if (quest is null) continue;
+            var className = classChecklist.ClassName;
+            var quest = FindQuest(questCatalog, className);
+            var reward = quest is null ? "" :
+                string.Join(", ", quest.Rewards.Where(r => r.Length > 0).Distinct(StringComparer.OrdinalIgnoreCase));
 
-            var reward = string.Join(", ", quest.Rewards.Where(r => r.Length > 0).Distinct(StringComparer.OrdinalIgnoreCase));
-            var grouped = quest.Items
-                .Where(i => i.Name.Length > 0)
-                .GroupBy(i => QuestCatalog.BaseItemName(i.Name), StringComparer.OrdinalIgnoreCase)
-                .Select(g => new QuestItemNeed { Name = g.First().Name, Qty = g.Max(i => Math.Max(1, i.Qty)) })
-                .OrderBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            for (var i = 0; i < grouped.Count; i++)
+            foreach (var row in classChecklist.Rows.OrderBy(r => r.Order))
             {
-                var need = grouped[i];
                 items.Add(new EpicQuestChecklistItem
                 {
-                    Id = $"epic-{QuestClassFilter.Abbrev(className).ToLowerInvariant()}-{i:000}-{StableKey(need.Name)}",
+                    Id = row.Id,
                     ClassName = className,
-                    QuestName = quest.Name,
+                    QuestName = quest?.Name ?? $"{className} Epic Quest",
                     Reward = reward,
-                    QuestItem = need.Name,
-                    Qty = need.Qty,
-                    Order = OrderFor(className, need.Name, i),
-                    Source = SourceFor(className, need.Name, quest),
+                    Section = row.Section.Length > 0 ? row.Section : "Checklist",
+                    QuestItem = row.Text,
+                    Qty = 1,
+                    Order = row.Order,
                 });
             }
         }
 
         return items;
-    }
-
-    public static EpicQuestGuide? GuideFor(string className) =>
-        Guides.FirstOrDefault(g => g.ClassName.Equals(className, StringComparison.OrdinalIgnoreCase));
-
-    public static string SourceFor(string className, string itemName, QuestEntry quest)
-    {
-        var baseName = QuestCatalog.BaseItemName(itemName);
-        if (ItemSources.TryGetValue($"{className}|{baseName}", out var source))
-            return source;
-
-        var guide = GuideFor(className);
-        var step = guide?.Steps.FirstOrDefault(s => s.Contains(baseName, StringComparison.OrdinalIgnoreCase));
-        return step ?? SourceLine(quest);
-    }
-
-    public static int OrderFor(string className, string itemName, int fallback)
-    {
-        var baseName = QuestCatalog.BaseItemName(itemName);
-        var guide = GuideFor(className);
-        if (guide is not null)
-            for (var i = 0; i < guide.Steps.Length; i++)
-                if (guide.Steps[i].Contains(baseName, StringComparison.OrdinalIgnoreCase))
-                    return i * 100;
-
-        return 10_000 + fallback;
     }
 
     public static QuestEntry? FindQuest(QuestCatalog catalog, string className) =>
@@ -80,196 +46,5 @@ public static class EpicQuestDefaults
         var zones = quest.Zones.Where(z => z.Length > 0).Distinct(StringComparer.OrdinalIgnoreCase).Take(5).ToList();
         var zoneText = zones.Count == 0 ? "" : "Zones: " + string.Join(", ", zones);
         return start.Length > 0 && zoneText.Length > 0 ? $"{start} | {zoneText}" : start + zoneText;
-    }
-
-    private static readonly EpicQuestGuide[] Guides =
-    [
-        new("Bard",
-            "Long travel chain with several named kills, then the Trakanon/Phinigel/VS pieces for Singing Short Sword.",
-            [
-                "Run the torch relay: Konia Swiftfoot in West Karana -> Fajio Knejo in Misty Thicket -> Andad Filla in South Ro -> Misty Tekchita in Lake Rathetear for Proof of Speed.",
-                "Return Proof of Speed to Konia for Maestro's Symphony Page 24 Top.",
-                "Baenar Swiftsong in South Karana sends you through Marfen in Solusek's Eye, Serra in Unrest, and Maligar in West Karana; kill Maligar's enraged doppleganger for Maligar's Head.",
-                "Turn Maligar's Head in to Baenar for Mahlin's Mystical Bongos, then give the bongos to Konia for Maestro's Symphony Page 24 Bottom.",
-                "Loot Onyx Drake Gut from Blackwing in Rathe Mountains, Red Wurm Gut from Nezekezena or Phurzikon in Burning Woods, and Chromodrac Gut from Eldrig the Old in Skyfire.",
-                "Finish the late raid drops and combines: Trakanon Gut, White Dragon Scales, Red Dragon Scales, Undead Dragongut Strings, Kedge Backbone, and related lute parts."
-            ]),
-        new("Cleric",
-            "Water/Fire chain through Lake Rathe, Timorous Deep, Sol Ro, Burning Woods, Chardok, then Ragefire for Water Sprinkler.",
-            [
-                "Kill Lord Bergurgle in Lake Rathetear for Lord Bergurgle's Crown; give it to Shmendrik Lavawalker to spawn Natasha and get Oil of Fennin Ro.",
-                "Kill Shmendrik's spawned spirit for Damaged Goblin Crown, then give it to Natasha for Ornate Sea Shell.",
-                "Give Ornate Sea Shell to Omat Vastsea in Timorous Deep for Coral Statue of Tarew.",
-                "Give Coral Statue of Tarew to a seeker in Temple of Solusek Ro; kill the Plasmatic Priest and loot Blood Soaked Plasmatic Priest Robe.",
-                "Loot Lord Gimblox's Signet Ring in Solusek's Eye; use Natasha/Omat/Naxot steps to spawn Ixiblat Fer in Burning Woods.",
-                "Loot Sceptre of Ixiblat Fer from Ixiblat Fer and Singed Scroll from Overking Bathezid in Chardok; finish through Omat/Natasha and Ragefire."
-            ]),
-        new("Druid",
-            "Nature chain shared with ranger starts at Telin, then forage/combine work, corrupted fights, Faydedar, and final cleansed spirits.",
-            [
-                "Speak with Telin Darkforest in Burning Woods for Worn Note; give it to Faelin Bloodbriar in Greater Faydark for Faelin's Ring.",
-                "Give Faelin's Ring to Giz X'Tin in Kithicor, then return the Dark Metal Coin chain to Telin and Althele in East Karana.",
-                "Use the Braided Grass Amulet on Sionae, Nuien, and Teloa in East Karana; intercept the Dark Elf Corruptor and loot Fleshbound Tome.",
-                "Give Fleshbound Tome to Althele, then Ella Foodcrafter in Misty Thicket for Shiny Tin Bowl.",
-                "Forage Chilled Tundra Root, Ripened Heartfruit, Speckled Molded Mushroom, and Sweetened Mudroot; combine them in the Shiny Tin Bowl for Hardened Mixture.",
-                "Continue the bowl/stones path through Timorous Deep, Felwithe, Chardok, the corrupted seafury/cyclops/brownie/gorilla, Faydedar, and the final druid spirits."
-            ]),
-        new("Enchanter",
-            "Stofo/Jeb notes chain, then Vessel Drozlin, Verina Tomb, Chardok prince/queen, Wraith of a Shissar, and final Staff of the Serpent turn-ins.",
-            [
-                "Hail Stofo Olan in Erudin at level 50.",
-                "Get Empty Ink Vial from Reania Jukle in Qeynos Catacombs; charm a ghoul scribe in Lower Guk and turn it in for Ink of the Dark.",
-                "Loot Shining Metallic Robes from ghoul arch magus in Lower Guk; give them to Rilgor Plegnog in Ak'Anon for Mechanical Pen.",
-                "Buy Quill and Piece of Parchment; give them to Chrislin Baker in West Karana, kill Thrackin Griften, and loot White Paper.",
-                "Give Ink of the Dark, Mechanical Pen, and White Paper to Stofo for Copy of Notes, then give Copy of Notes to Jeb Lumsed in Burning Woods for Jeb's Seal.",
-                "Loot Xolion Rod from Vessel Drozlin, Innoruuk's Word from Verina Tomb, Chalice of Kings through Chardok royals, and Wraith of a Shissar pieces before final Jeb turn-ins."
-            ]),
-        new("Magician",
-            "Token of Mastery starts the quest, then Magi`kot pages, four elemental powers, four mastery pages, four elemental staves, and Phinny.",
-            [
-                "Get Token of Mastery from Rykas in Lake Rathetear and take it to Jahsohn Aksot in West Commonlands.",
-                "Loot Torn Page of Magi`kot pg. 1 from enraged dread wolf in Kithicor, pg. 2 from tentacle terrors in Unrest, and pg. 3 from bloodthirsty ghoul in Lower Guk.",
-                "Turn the Magi`kot pages in to Jahsohn for Words of Magi`kot.",
-                "Loot Power of Wind from a gypsy dancer in Mistmoore, Power of Fire from Solusek's Eye elementals, Power of Water from Kaesora raveners, and Power of Earth from faerie guards in Lesser Faydark.",
-                "Give the four powers to Walnan in Butcherblock for Power of the Elements.",
-                "Collect Torn Page of Mastery Earth/Fire/Water/Wind, turn them in at Najena, then finish the Staff of Elemental Mastery set and Phinigel piece for Orb of Mastery."
-            ]),
-        new("Monk",
-            "Robe chain, Danl/Lheao book, Eejag/Gwan/Trunt fights, then Kaiaren and Demon Fangs for Celestial Fists.",
-            [
-                "Get Robe of the Lost Circle by killing Brother Zephyl or Brother Qwinn, or by the sash/headband subquest.",
-                "For the robe subquest: Purple Headband + Code of Zan Fi from Targin the Rock in Sol B go to Brother Qwinn for Needle of the Void.",
-                "Red Sash of Order + The Idol from Raster of Guk in Lower Guk go to Brother Zephyl for Rare Robe Pattern.",
-                "Combine Shadow Silk, Needle of the Void, Rare Robe Pattern, and Jonthan's Whistling Warsong to make Robe of the Lost Circle.",
-                "Loot the Chardok and Karnor metal pipes, then give both pipes plus Robe of the Lost Circle to Brother Balatin in Dreadlands for Robe of the Whistling Fists.",
-                "Turn Immortals in to Tomekeeper Danl in Erudin for Danl's Reference; give Danl's Reference and Robe of the Whistling Fists to Lheao in Timorous Deep for Celestial Fists book.",
-                "Spawn and kill Eejag in Lavastorm for Charred Scale; use it in Plane of Sky to spawn Gwan for Breath of Gwan; give Breath of Gwan in Nurga to spawn Trunt for Trunt's Head.",
-                "Use the Kaiaren/Deep chain in Lake of Ill Omen and Trakanon's Teeth; kill Xenevorash for Demon Fangs, then give the modified Book of Celestial Fists and Demon Fangs to sane Kaiaren."
-            ]),
-        new("Necromancer",
-            "Symbol chain through Nektulos/Lake Rathe, Najena robe, Chardok herb, Kazen/bone golem, then Fear and Plane of Sky pieces.",
-            [
-                "Start with Venenzi Oberzendi in Nektulos and Kazen Fecae in Lake Rathetear.",
-                "Kill Sir Edwin Motte for his Head; give it to Kazen for Symbol of the Apprentice, then give that to Venenzi for Twisted Symbol.",
-                "Loot Flowing Black Robe from Najena and give it to Venenzi for Rolling Stone Moss.",
-                "Give Rolling Stone Moss and Twisted Symbol to Emkel Kabae in Lake Rathetear for Symbol of the Serpent.",
-                "Give Symbol of the Serpent to Ssessthrass in Swamp of No Hope for Scaled Symbol; loot Manisi Herb from Chardok herbalists and refine it through Ssessthrass/Emkel.",
-                "Continue through Kazen, bone golem, Plane of Sky, Plane of Fear, and the final turn-ins for Scythe of the Shadowed Soul."
-            ]),
-        new("Paladin",
-            "Fiery Avenger plus three purified darksteel pieces; final Plane of Fear turn-in gives Fiery Defender.",
-            [
-                "Complete SoulFire, Ghoulbane, and Fiery Avenger first.",
-                "Loot Tainted Darksteel Breastplate from thought destroyer in Plane of Hate; purify it with Pure Crystal through Jark/Nella in North Kaladim and Reklon Gnallen in Erudin.",
-                "Loot Tainted Darksteel Sword from Keeper of the Tombs in The Hole; purify it with Bucket of Pure Water through West Freeport and Reklon Gnallen.",
-                "Loot Tainted Darksteel Shield from Kirak Vil in Nektulos Forest; purify it through Elia the Pure in Felwithe.",
-                "Turn Gleaming Crested Breastplate, Gleaming Crested Sword, and Gleaming Crested Shield in to Reklon for Mark of Atonement.",
-                "Give Mark of Atonement and Fiery Avenger to Irak Altil in Plane of Fear for Fiery Defender."
-            ]),
-        new("Ranger",
-            "Druid-style bowl chain plus ranger-only Ancient Sword, Faydedar, VS stone, and final Earthcaller/Swiftwind turn-ins.",
-            [
-                "Ask Telin Darkforest in Burning Woods for Worn Note; give it to Faelin Bloodbriar in Greater Faydark for Faelin's Ring.",
-                "Give Faelin's Ring to Giz X'Tin in Kithicor, then return to Telin and Althele in East Karana for the Braided Grass Amulet chain.",
-                "Use Sionae, Nuien, and Teloa in East Karana; kill the Dark Elf Corruptor and return Fleshbound Tome to Althele.",
-                "Get Shiny Tin Bowl from Ella Foodcrafter in Misty Thicket and forage Chilled Tundra Root, Ripened Heartfruit, Speckled Molded Mushroom, and Sweetened Mudroot for Hardened Mixture.",
-                "Do the Ancient Pattern/Runecrested Bowl path through Timorous Deep, Felwithe, Chardok, and the foraged/ground components.",
-                "Finish with Faydedar, Venril Sathir, Plane of Sky/Plane of Hate style bottlenecks, and the final hand-ins for Earthcaller and Swiftwind."
-            ]),
-        new("Rogue",
-            "Stanos pouch, pickpocket parchment, Book of Souls/Cazic quill path, then General/Vilnius/Renux for Ragebringer.",
-            [
-                "Get Stanos' Pouch from Malka Rale in Qeynos Aqueducts or with help from a level 50 rogue.",
-                "Pickpocket Stained Parchment Top from Founy Jestands in North Kaladim and Stained Parchment Bottom from Tani N'Mar in Neriak.",
-                "Use Anson McBale in Highpass to spawn Stanos; turn in both parchment halves for Combined Parchment.",
-                "Give Combined Parchment, 100pp, and two unstacked Bottles of Milk to Eldreth in Lake Rathetear for Scribbled Parchment.",
-                "Take Scribbled Parchment to Yendar Starpyre in Steamfont for Tattered Parchment and continue the Book of Souls/Cazic Quill steps.",
-                "Finish the Jagged Diamond Dagger path through General V'Ghera, Vilnius the Small, and Renux Herkanor for Ragebringer."
-            ]),
-        new("Shadow Knight",
-            "Darkforge/Kurron/Duriek start, Corrupted Ghoulbane pieces, Kyrenna/Glohnor/Lhranc chain. Indifferent con matters on hand-ins.",
-            [
-                "Give Kurron Ni in Overthere Darkforge Breastplate, Darkforge Greaves, Darkforge Helm, and 900pp; kill Kurron and loot Letter to Duriek.",
-                "Give Letter to Duriek Bloodpool in Paineel; buy Cough Elixir from Smaka in Neriak and give it to Duriek.",
-                "Loot Dusty Tome from a ratman guard in The Hole and give it to Duriek.",
-                "Loot Ghoulbane from froglok shin lord in Upper Guk, Soul Leech from Cazic-Thule or Fear golems, Blade of Abrogation from Plane of Sky, Drake Spine from Rharzar, and Decrepit Hide from ashenbone drakes in Plane of Hate.",
-                "Give Drake Spine, Decrepit Hide, and Enchanted Platinum Bar to Teydar for Decrepit Sheath.",
-                "Give Ghoulbane, Soul Leech, Blade of Abrogation, and Decrepit Sheath to Duriek for Corrupted Ghoulbane.",
-                "Use Cell Key on Caradon in The Hole, kill Kyrenna, and loot Blood of Kyrenna and Heart of Kyrenna; Blood goes to Marl Kastane for Dark Shroud.",
-                "Give Dark Shroud to Ghost of Glohnor in The Hole, kill Mummy of Glohnor for Head of Glohnor and Glohnor wrappings, then turn those in for Head of the Valiant and Will of Innoruuk.",
-                "Combine Heart of Kyrenna in Soulcase for Heart of the Innocent; give Corrupted Ghoulbane, Heart of the Innocent, Head of the Valiant, and Will of Innoruuk to Lhranc, kill him, and loot Innoruuk's Curse."
-            ]),
-        new("Shaman",
-            "True Spirit faction chain, Black Dire boots, City of Mist reports/books, High Scale Kirn/Neh`Ashiir, Fear tear, then Rak`Ashiir.",
-            [
-                "Spawn a lesser spirit by killing the RM/OoT/BBM/FoB trigger mobs; receive Tiny Gem and use Bondl Felligan in North Freeport to begin True Spirit faction.",
-                "Use the proper Greater Spirit path to get Opaque Gem, then Test of Patience in Erud's Crossing.",
-                "Kill Glaron the Wicked for Envy and Woe, and Tabien the Goodly for Marr's Promise in Rathe Mountains.",
-                "Turn Envy, Woe, and Marr's Promise in to the wandering spirit in West Karana for Shield of Falsehood and the next gem.",
-                "Kill Black Dire in Mistmoore for Black Dire Pelt; turn it in to Spirit Sentinel in Emerald Jungle for Black Fur Boots and booklet.",
-                "Collect six City of Mist reports, then Lord Ghiosk's three books, and turn them in through Spirit Sentinel.",
-                "Get Icon of the High Scale from City of Mist, give it to High Scale Kirn in The Hole, kill him, then give the ring to Neh`Ashiir in City of Mist and loot the diary.",
-                "Loot Child's Tear from the Plane of Fear broodling/golem cycle; give it to Lord Rak`Ashiir in City of Mist, kill him, and loot Iksar Scale for the final Spear of Fate turn-in."
-            ]),
-        new("Warrior",
-            "Two dragon-head hilts, ancient blades, red/green scales, then final Kargek/Wenden combines for Jagged Blade.",
-            [
-                "Hail Kargek Redblade and Wenden Blackhammer in East Freeport.",
-                "Retrieve Unjeweled Dragon Head Hilt from Lake Rathetear; combine through Wenden with Diamond, Jacinth, and Black Sapphire for Jeweled Dragon Head Hilt.",
-                "Retrieve Severely Damaged Dragon Head Hilt from Timorous Deep chessboard.",
-                "Get Giant Sized Monocle from mountain giant patriarch in Dreadlands; trade it to Mentrax Mountainbone in Frontier Mountains for Rejesiam Ore.",
-                "Loot Ball of Everliving Golem from Fright, Dread, or Terror in Plane of Fear, then turn in with Severely Damaged Dragon Head Hilt and Rejesiam Ore for Finely Crafted Dragon Head Hilt.",
-                "Buy Keg of Vox Tail Ale, get two Rebreathers, and loot Block of Permafrost from ice giants; turn in to Denken Strongpick in Ocean of Tears for Ancient Sword Blade.",
-                "Loot Ancient Blade from Queen Velazul Di`zok in Chardok, plus Red Dragon Scales and Green Dragon Scales for the final blade work."
-            ]),
-        new("Wizard",
-            "Solomen/Kandin faction path, Cazic Skin and Gabstik, then Arantir combines the three staves for Staff of the Four.",
-            [
-                "Start with Solomen in Temple of Solusek Ro; the quest is TrueSpirit/faction based.",
-                "Work the Solomen note chain to Kandin Firepot.",
-                "Give Cazic's Skin from Cazic-Thule to Kandin for Kandin's Bag.",
-                "Give Mistletoe Powder to Kandin to receive Staff of Gabstik.",
-                "Return Kandin's Bag to Kandin for the next note.",
-                "Give the note to Dargon to spawn Arantir; hand Arantir Blue Crystal Staff, Gnarled Staff, and Staff of Gabstik for the sealed bag.",
-                "Give Arantir's bag to Solomen for Staff of the Four."
-            ]),
-    ];
-
-    private static readonly Dictionary<string, string> ItemSources = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["Shadow Knight|Darkforge Breastplate"] = "Reward from Darkforge armor quests; turn in with Darkforge Greaves, Darkforge Helm, and 900pp to Kurron Ni in Overthere.",
-        ["Shadow Knight|Darkforge Greaves"] = "Reward from Darkforge armor quests; turn in with Darkforge Breastplate, Darkforge Helm, and 900pp to Kurron Ni in Overthere.",
-        ["Shadow Knight|Darkforge Helm"] = "Reward from Darkforge armor quests; turn in with Darkforge Breastplate, Darkforge Greaves, and 900pp to Kurron Ni in Overthere.",
-        ["Shadow Knight|Cough Elixir"] = "Buy from Smaka in Neriak Foreign Quarter for 1000pp; give to Duriek Bloodpool in Paineel.",
-        ["Shadow Knight|Dusty Tome"] = "Drops from a ratman guard in The Hole; give to Duriek Bloodpool in Paineel.",
-        ["Shadow Knight|Ghoulbane"] = "Drops from the froglok shin lord in Upper Guk; one of the four Corrupted Ghoulbane turn-in pieces.",
-        ["Shadow Knight|Soul Leech, Dark Sword of Blood"] = "Drops from Cazic-Thule pre-revamp, or Fear golems Fright, Dread, and Terror post-revamp.",
-        ["Shadow Knight|Blade of Abrogation"] = "Drops from Plane of Sky monsters; one of the four Corrupted Ghoulbane turn-in pieces.",
-        ["Shadow Knight|Drake Spine"] = "Drops from Rharzar in Rathe Mountains; combine path for Decrepit Sheath.",
-        ["Shadow Knight|Decrepit Hide"] = "Drops from ashenbone drakes in Plane of Hate; combine path for Decrepit Sheath.",
-        ["Shadow Knight|Enchanted Platinum Bar"] = "Craft/enchant a Platinum Bar; turn in with Drake Spine and Decrepit Hide to Teydar for Decrepit Sheath.",
-        ["Shadow Knight|Decrepit Sheath"] = "Reward from Teydar after Drake Spine, Decrepit Hide, and Enchanted Platinum Bar turn-in.",
-        ["Shadow Knight|Corrupted Ghoulbane"] = "Reward from Duriek Bloodpool after Ghoulbane, Soul Leech, Blade of Abrogation, and Decrepit Sheath turn-in.",
-        ["Shadow Knight|Cell Key"] = "Drops from a mimic/chest in The Hole city section; give it to Caradon to spawn the Kyrenna fight.",
-        ["Shadow Knight|Blood of Kyrenna"] = "Drops from Kyrenna after the Caradon Cell Key turn-in in The Hole; give to Marl Kastane for Dark Shroud.",
-        ["Shadow Knight|Heart of Kyrenna"] = "Drops from Kyrenna after the Caradon Cell Key turn-in in The Hole; combine in Soulcase for Heart of the Innocent.",
-        ["Shadow Knight|Dark Shroud"] = "Reward from Marl Kastane after turning in Blood of Kyrenna; give to Ghost of Glohnor in The Hole.",
-        ["Shadow Knight|Head of Glohnor"] = "Drops from Mummy of Glohnor after Dark Shroud turn-in to Ghost of Glohnor in The Hole; give to Gerot Kastane.",
-        ["Shadow Knight|Glohnor wrappings"] = "Drops from Mummy of Glohnor after Dark Shroud turn-in to Ghost of Glohnor in The Hole; give to Marl Kastane.",
-        ["Shadow Knight|Head of the Valiant"] = "Reward from Gerot Kastane after Head of Glohnor turn-in; final Lhranc turn-in piece.",
-        ["Shadow Knight|Will of Innoruuk"] = "Reward from Marl Kastane after Glohnor wrappings turn-in; final Lhranc turn-in piece.",
-        ["Shadow Knight|Heart of the Innocent"] = "Combine Heart of Kyrenna in Soulcase; final Lhranc turn-in piece.",
-        ["Shadow Knight|Innoruuk's Curse"] = "Final epic reward: give Lhranc Corrupted Ghoulbane, Heart of the Innocent, Head of the Valiant, and Will of Innoruuk, then kill Lhranc.",
-    };
-
-    private static string StableKey(string value)
-    {
-        var chars = value.ToLowerInvariant()
-            .Select(c => char.IsLetterOrDigit(c) ? c : '-')
-            .ToArray();
-        var compact = new string(chars);
-        while (compact.Contains("--", StringComparison.Ordinal))
-            compact = compact.Replace("--", "-", StringComparison.Ordinal);
-        return compact.Trim('-');
     }
 }

--- a/src/EQBuddy.Core/EpicQuestDefaults.cs
+++ b/src/EQBuddy.Core/EpicQuestDefaults.cs
@@ -27,6 +27,7 @@ public static class EpicQuestDefaults
                     QuestItem = row.Text,
                     Qty = 1,
                     Order = row.Order,
+                    AvailableInClassic = row.AvailableInClassic,
                 });
             }
         }

--- a/src/EQBuddy.Core/EpicQuestDefaults.cs
+++ b/src/EQBuddy.Core/EpicQuestDefaults.cs
@@ -33,6 +33,7 @@ public static class EpicQuestDefaults
                     Reward = reward,
                     QuestItem = need.Name,
                     Qty = need.Qty,
+                    Order = OrderFor(className, need.Name, i),
                     Source = SourceFor(className, need.Name, quest),
                 });
             }
@@ -47,9 +48,24 @@ public static class EpicQuestDefaults
     public static string SourceFor(string className, string itemName, QuestEntry quest)
     {
         var baseName = QuestCatalog.BaseItemName(itemName);
+        if (ItemSources.TryGetValue($"{className}|{baseName}", out var source))
+            return source;
+
         var guide = GuideFor(className);
         var step = guide?.Steps.FirstOrDefault(s => s.Contains(baseName, StringComparison.OrdinalIgnoreCase));
         return step ?? SourceLine(quest);
+    }
+
+    public static int OrderFor(string className, string itemName, int fallback)
+    {
+        var baseName = QuestCatalog.BaseItemName(itemName);
+        var guide = GuideFor(className);
+        if (guide is not null)
+            for (var i = 0; i < guide.Steps.Length; i++)
+                if (guide.Steps[i].Contains(baseName, StringComparison.OrdinalIgnoreCase))
+                    return i * 100;
+
+        return 10_000 + fallback;
     }
 
     public static QuestEntry? FindQuest(QuestCatalog catalog, string className) =>
@@ -218,6 +234,33 @@ public static class EpicQuestDefaults
                 "Give Arantir's bag to Solomen for Staff of the Four."
             ]),
     ];
+
+    private static readonly Dictionary<string, string> ItemSources = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Shadow Knight|Darkforge Breastplate"] = "Reward from Darkforge armor quests; turn in with Darkforge Greaves, Darkforge Helm, and 900pp to Kurron Ni in Overthere.",
+        ["Shadow Knight|Darkforge Greaves"] = "Reward from Darkforge armor quests; turn in with Darkforge Breastplate, Darkforge Helm, and 900pp to Kurron Ni in Overthere.",
+        ["Shadow Knight|Darkforge Helm"] = "Reward from Darkforge armor quests; turn in with Darkforge Breastplate, Darkforge Greaves, and 900pp to Kurron Ni in Overthere.",
+        ["Shadow Knight|Cough Elixir"] = "Buy from Smaka in Neriak Foreign Quarter for 1000pp; give to Duriek Bloodpool in Paineel.",
+        ["Shadow Knight|Dusty Tome"] = "Drops from a ratman guard in The Hole; give to Duriek Bloodpool in Paineel.",
+        ["Shadow Knight|Ghoulbane"] = "Drops from the froglok shin lord in Upper Guk; one of the four Corrupted Ghoulbane turn-in pieces.",
+        ["Shadow Knight|Soul Leech, Dark Sword of Blood"] = "Drops from Cazic-Thule pre-revamp, or Fear golems Fright, Dread, and Terror post-revamp.",
+        ["Shadow Knight|Blade of Abrogation"] = "Drops from Plane of Sky monsters; one of the four Corrupted Ghoulbane turn-in pieces.",
+        ["Shadow Knight|Drake Spine"] = "Drops from Rharzar in Rathe Mountains; combine path for Decrepit Sheath.",
+        ["Shadow Knight|Decrepit Hide"] = "Drops from ashenbone drakes in Plane of Hate; combine path for Decrepit Sheath.",
+        ["Shadow Knight|Enchanted Platinum Bar"] = "Craft/enchant a Platinum Bar; turn in with Drake Spine and Decrepit Hide to Teydar for Decrepit Sheath.",
+        ["Shadow Knight|Decrepit Sheath"] = "Reward from Teydar after Drake Spine, Decrepit Hide, and Enchanted Platinum Bar turn-in.",
+        ["Shadow Knight|Corrupted Ghoulbane"] = "Reward from Duriek Bloodpool after Ghoulbane, Soul Leech, Blade of Abrogation, and Decrepit Sheath turn-in.",
+        ["Shadow Knight|Cell Key"] = "Drops from a mimic/chest in The Hole city section; give it to Caradon to spawn the Kyrenna fight.",
+        ["Shadow Knight|Blood of Kyrenna"] = "Drops from Kyrenna after the Caradon Cell Key turn-in in The Hole; give to Marl Kastane for Dark Shroud.",
+        ["Shadow Knight|Heart of Kyrenna"] = "Drops from Kyrenna after the Caradon Cell Key turn-in in The Hole; combine in Soulcase for Heart of the Innocent.",
+        ["Shadow Knight|Dark Shroud"] = "Reward from Marl Kastane after turning in Blood of Kyrenna; give to Ghost of Glohnor in The Hole.",
+        ["Shadow Knight|Head of Glohnor"] = "Drops from Mummy of Glohnor after Dark Shroud turn-in to Ghost of Glohnor in The Hole; give to Gerot Kastane.",
+        ["Shadow Knight|Glohnor wrappings"] = "Drops from Mummy of Glohnor after Dark Shroud turn-in to Ghost of Glohnor in The Hole; give to Marl Kastane.",
+        ["Shadow Knight|Head of the Valiant"] = "Reward from Gerot Kastane after Head of Glohnor turn-in; final Lhranc turn-in piece.",
+        ["Shadow Knight|Will of Innoruuk"] = "Reward from Marl Kastane after Glohnor wrappings turn-in; final Lhranc turn-in piece.",
+        ["Shadow Knight|Heart of the Innocent"] = "Combine Heart of Kyrenna in Soulcase; final Lhranc turn-in piece.",
+        ["Shadow Knight|Innoruuk's Curse"] = "Final epic reward: give Lhranc Corrupted Ghoulbane, Heart of the Innocent, Head of the Valiant, and Will of Innoruuk, then kill Lhranc.",
+    };
 
     private static string StableKey(string value)
     {

--- a/src/EQBuddy.Core/EpicQuestDefaults.cs
+++ b/src/EQBuddy.Core/EpicQuestDefaults.cs
@@ -1,0 +1,66 @@
+namespace EQBuddy.Core;
+
+public static class EpicQuestDefaults
+{
+    public static List<EpicQuestChecklistItem> Items()
+    {
+        var catalog = QuestCatalog.LoadEmbedded();
+        var items = new List<EpicQuestChecklistItem>();
+
+        foreach (var className in QuestClassFilter.Classes)
+        {
+            var quest = FindQuest(catalog, className);
+            if (quest is null) continue;
+
+            var reward = string.Join(", ", quest.Rewards.Where(r => r.Length > 0).Distinct(StringComparer.OrdinalIgnoreCase));
+            var grouped = quest.Items
+                .Where(i => i.Name.Length > 0)
+                .GroupBy(i => QuestCatalog.BaseItemName(i.Name), StringComparer.OrdinalIgnoreCase)
+                .Select(g => new QuestItemNeed { Name = g.First().Name, Qty = g.Max(i => Math.Max(1, i.Qty)) })
+                .OrderBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            for (var i = 0; i < grouped.Count; i++)
+            {
+                var need = grouped[i];
+                items.Add(new EpicQuestChecklistItem
+                {
+                    Id = $"epic-{QuestClassFilter.Abbrev(className).ToLowerInvariant()}-{i:000}-{StableKey(need.Name)}",
+                    ClassName = className,
+                    QuestName = quest.Name,
+                    Reward = reward,
+                    QuestItem = need.Name,
+                    Qty = need.Qty,
+                    Source = SourceLine(quest),
+                });
+            }
+        }
+
+        return items;
+    }
+
+    public static QuestEntry? FindQuest(QuestCatalog catalog, string className) =>
+        catalog.Quests.FirstOrDefault(q =>
+            q.Name.Equals($"{className} Epic Quest", StringComparison.OrdinalIgnoreCase));
+
+    public static string SourceLine(QuestEntry quest)
+    {
+        var start = quest.StartZone.Length > 0
+            ? quest.QuestGiver.Length > 0 ? $"{quest.StartZone}: {quest.QuestGiver}" : quest.StartZone
+            : quest.QuestGiver;
+        var zones = quest.Zones.Where(z => z.Length > 0).Distinct(StringComparer.OrdinalIgnoreCase).Take(5).ToList();
+        var zoneText = zones.Count == 0 ? "" : "Zones: " + string.Join(", ", zones);
+        return start.Length > 0 && zoneText.Length > 0 ? $"{start} | {zoneText}" : start + zoneText;
+    }
+
+    private static string StableKey(string value)
+    {
+        var chars = value.ToLowerInvariant()
+            .Select(c => char.IsLetterOrDigit(c) ? c : '-')
+            .ToArray();
+        var compact = new string(chars);
+        while (compact.Contains("--", StringComparison.Ordinal))
+            compact = compact.Replace("--", "-", StringComparison.Ordinal);
+        return compact.Trim('-');
+    }
+}

--- a/src/EQBuddy.Core/EpicQuestDefaults.cs
+++ b/src/EQBuddy.Core/EpicQuestDefaults.cs
@@ -1,5 +1,7 @@
 namespace EQBuddy.Core;
 
+public sealed record EpicQuestGuide(string ClassName, string Summary, string[] Steps);
+
 public static class EpicQuestDefaults
 {
     public static List<EpicQuestChecklistItem> Items()
@@ -31,12 +33,23 @@ public static class EpicQuestDefaults
                     Reward = reward,
                     QuestItem = need.Name,
                     Qty = need.Qty,
-                    Source = SourceLine(quest),
+                    Source = SourceFor(className, need.Name, quest),
                 });
             }
         }
 
         return items;
+    }
+
+    public static EpicQuestGuide? GuideFor(string className) =>
+        Guides.FirstOrDefault(g => g.ClassName.Equals(className, StringComparison.OrdinalIgnoreCase));
+
+    public static string SourceFor(string className, string itemName, QuestEntry quest)
+    {
+        var baseName = QuestCatalog.BaseItemName(itemName);
+        var guide = GuideFor(className);
+        var step = guide?.Steps.FirstOrDefault(s => s.Contains(baseName, StringComparison.OrdinalIgnoreCase));
+        return step ?? SourceLine(quest);
     }
 
     public static QuestEntry? FindQuest(QuestCatalog catalog, string className) =>
@@ -52,6 +65,159 @@ public static class EpicQuestDefaults
         var zoneText = zones.Count == 0 ? "" : "Zones: " + string.Join(", ", zones);
         return start.Length > 0 && zoneText.Length > 0 ? $"{start} | {zoneText}" : start + zoneText;
     }
+
+    private static readonly EpicQuestGuide[] Guides =
+    [
+        new("Bard",
+            "Long travel chain with several named kills, then the Trakanon/Phinigel/VS pieces for Singing Short Sword.",
+            [
+                "Run the torch relay: Konia Swiftfoot in West Karana -> Fajio Knejo in Misty Thicket -> Andad Filla in South Ro -> Misty Tekchita in Lake Rathetear for Proof of Speed.",
+                "Return Proof of Speed to Konia for Maestro's Symphony Page 24 Top.",
+                "Baenar Swiftsong in South Karana sends you through Marfen in Solusek's Eye, Serra in Unrest, and Maligar in West Karana; kill Maligar's enraged doppleganger for Maligar's Head.",
+                "Turn Maligar's Head in to Baenar for Mahlin's Mystical Bongos, then give the bongos to Konia for Maestro's Symphony Page 24 Bottom.",
+                "Loot Onyx Drake Gut from Blackwing in Rathe Mountains, Red Wurm Gut from Nezekezena or Phurzikon in Burning Woods, and Chromodrac Gut from Eldrig the Old in Skyfire.",
+                "Finish the late raid drops and combines: Trakanon Gut, White Dragon Scales, Red Dragon Scales, Undead Dragongut Strings, Kedge Backbone, and related lute parts."
+            ]),
+        new("Cleric",
+            "Water/Fire chain through Lake Rathe, Timorous Deep, Sol Ro, Burning Woods, Chardok, then Ragefire for Water Sprinkler.",
+            [
+                "Kill Lord Bergurgle in Lake Rathetear for Lord Bergurgle's Crown; give it to Shmendrik Lavawalker to spawn Natasha and get Oil of Fennin Ro.",
+                "Kill Shmendrik's spawned spirit for Damaged Goblin Crown, then give it to Natasha for Ornate Sea Shell.",
+                "Give Ornate Sea Shell to Omat Vastsea in Timorous Deep for Coral Statue of Tarew.",
+                "Give Coral Statue of Tarew to a seeker in Temple of Solusek Ro; kill the Plasmatic Priest and loot Blood Soaked Plasmatic Priest Robe.",
+                "Loot Lord Gimblox's Signet Ring in Solusek's Eye; use Natasha/Omat/Naxot steps to spawn Ixiblat Fer in Burning Woods.",
+                "Loot Sceptre of Ixiblat Fer from Ixiblat Fer and Singed Scroll from Overking Bathezid in Chardok; finish through Omat/Natasha and Ragefire."
+            ]),
+        new("Druid",
+            "Nature chain shared with ranger starts at Telin, then forage/combine work, corrupted fights, Faydedar, and final cleansed spirits.",
+            [
+                "Speak with Telin Darkforest in Burning Woods for Worn Note; give it to Faelin Bloodbriar in Greater Faydark for Faelin's Ring.",
+                "Give Faelin's Ring to Giz X'Tin in Kithicor, then return the Dark Metal Coin chain to Telin and Althele in East Karana.",
+                "Use the Braided Grass Amulet on Sionae, Nuien, and Teloa in East Karana; intercept the Dark Elf Corruptor and loot Fleshbound Tome.",
+                "Give Fleshbound Tome to Althele, then Ella Foodcrafter in Misty Thicket for Shiny Tin Bowl.",
+                "Forage Chilled Tundra Root, Ripened Heartfruit, Speckled Molded Mushroom, and Sweetened Mudroot; combine them in the Shiny Tin Bowl for Hardened Mixture.",
+                "Continue the bowl/stones path through Timorous Deep, Felwithe, Chardok, the corrupted seafury/cyclops/brownie/gorilla, Faydedar, and the final druid spirits."
+            ]),
+        new("Enchanter",
+            "Stofo/Jeb notes chain, then Vessel Drozlin, Verina Tomb, Chardok prince/queen, Wraith of a Shissar, and final Staff of the Serpent turn-ins.",
+            [
+                "Hail Stofo Olan in Erudin at level 50.",
+                "Get Empty Ink Vial from Reania Jukle in Qeynos Catacombs; charm a ghoul scribe in Lower Guk and turn it in for Ink of the Dark.",
+                "Loot Shining Metallic Robes from ghoul arch magus in Lower Guk; give them to Rilgor Plegnog in Ak'Anon for Mechanical Pen.",
+                "Buy Quill and Piece of Parchment; give them to Chrislin Baker in West Karana, kill Thrackin Griften, and loot White Paper.",
+                "Give Ink of the Dark, Mechanical Pen, and White Paper to Stofo for Copy of Notes, then give Copy of Notes to Jeb Lumsed in Burning Woods for Jeb's Seal.",
+                "Loot Xolion Rod from Vessel Drozlin, Innoruuk's Word from Verina Tomb, Chalice of Kings through Chardok royals, and Wraith of a Shissar pieces before final Jeb turn-ins."
+            ]),
+        new("Magician",
+            "Token of Mastery starts the quest, then Magi`kot pages, four elemental powers, four mastery pages, four elemental staves, and Phinny.",
+            [
+                "Get Token of Mastery from Rykas in Lake Rathetear and take it to Jahsohn Aksot in West Commonlands.",
+                "Loot Torn Page of Magi`kot pg. 1 from enraged dread wolf in Kithicor, pg. 2 from tentacle terrors in Unrest, and pg. 3 from bloodthirsty ghoul in Lower Guk.",
+                "Turn the Magi`kot pages in to Jahsohn for Words of Magi`kot.",
+                "Loot Power of Wind from a gypsy dancer in Mistmoore, Power of Fire from Solusek's Eye elementals, Power of Water from Kaesora raveners, and Power of Earth from faerie guards in Lesser Faydark.",
+                "Give the four powers to Walnan in Butcherblock for Power of the Elements.",
+                "Collect Torn Page of Mastery Earth/Fire/Water/Wind, turn them in at Najena, then finish the Staff of Elemental Mastery set and Phinigel piece for Orb of Mastery."
+            ]),
+        new("Monk",
+            "Robe chain, Danl/Lheao book, Eejag/Gwan/Trunt fights, then Kaiaren and Demon Fangs for Celestial Fists.",
+            [
+                "Get Robe of the Lost Circle by killing Brother Zephyl or Brother Qwinn, or by the sash/headband subquest.",
+                "For the robe subquest: Purple Headband + Code of Zan Fi from Targin the Rock in Sol B go to Brother Qwinn for Needle of the Void.",
+                "Red Sash of Order + The Idol from Raster of Guk in Lower Guk go to Brother Zephyl for Rare Robe Pattern.",
+                "Combine Shadow Silk, Needle of the Void, Rare Robe Pattern, and Jonthan's Whistling Warsong to make Robe of the Lost Circle.",
+                "Loot the Chardok and Karnor metal pipes, then give both pipes plus Robe of the Lost Circle to Brother Balatin in Dreadlands for Robe of the Whistling Fists.",
+                "Turn Immortals in to Tomekeeper Danl in Erudin for Danl's Reference; give Danl's Reference and Robe of the Whistling Fists to Lheao in Timorous Deep for Celestial Fists book.",
+                "Spawn and kill Eejag in Lavastorm for Charred Scale; use it in Plane of Sky to spawn Gwan for Breath of Gwan; give Breath of Gwan in Nurga to spawn Trunt for Trunt's Head.",
+                "Use the Kaiaren/Deep chain in Lake of Ill Omen and Trakanon's Teeth; kill Xenevorash for Demon Fangs, then give the modified Book of Celestial Fists and Demon Fangs to sane Kaiaren."
+            ]),
+        new("Necromancer",
+            "Symbol chain through Nektulos/Lake Rathe, Najena robe, Chardok herb, Kazen/bone golem, then Fear and Plane of Sky pieces.",
+            [
+                "Start with Venenzi Oberzendi in Nektulos and Kazen Fecae in Lake Rathetear.",
+                "Kill Sir Edwin Motte for his Head; give it to Kazen for Symbol of the Apprentice, then give that to Venenzi for Twisted Symbol.",
+                "Loot Flowing Black Robe from Najena and give it to Venenzi for Rolling Stone Moss.",
+                "Give Rolling Stone Moss and Twisted Symbol to Emkel Kabae in Lake Rathetear for Symbol of the Serpent.",
+                "Give Symbol of the Serpent to Ssessthrass in Swamp of No Hope for Scaled Symbol; loot Manisi Herb from Chardok herbalists and refine it through Ssessthrass/Emkel.",
+                "Continue through Kazen, bone golem, Plane of Sky, Plane of Fear, and the final turn-ins for Scythe of the Shadowed Soul."
+            ]),
+        new("Paladin",
+            "Fiery Avenger plus three purified darksteel pieces; final Plane of Fear turn-in gives Fiery Defender.",
+            [
+                "Complete SoulFire, Ghoulbane, and Fiery Avenger first.",
+                "Loot Tainted Darksteel Breastplate from thought destroyer in Plane of Hate; purify it with Pure Crystal through Jark/Nella in North Kaladim and Reklon Gnallen in Erudin.",
+                "Loot Tainted Darksteel Sword from Keeper of the Tombs in The Hole; purify it with Bucket of Pure Water through West Freeport and Reklon Gnallen.",
+                "Loot Tainted Darksteel Shield from Kirak Vil in Nektulos Forest; purify it through Elia the Pure in Felwithe.",
+                "Turn Gleaming Crested Breastplate, Gleaming Crested Sword, and Gleaming Crested Shield in to Reklon for Mark of Atonement.",
+                "Give Mark of Atonement and Fiery Avenger to Irak Altil in Plane of Fear for Fiery Defender."
+            ]),
+        new("Ranger",
+            "Druid-style bowl chain plus ranger-only Ancient Sword, Faydedar, VS stone, and final Earthcaller/Swiftwind turn-ins.",
+            [
+                "Ask Telin Darkforest in Burning Woods for Worn Note; give it to Faelin Bloodbriar in Greater Faydark for Faelin's Ring.",
+                "Give Faelin's Ring to Giz X'Tin in Kithicor, then return to Telin and Althele in East Karana for the Braided Grass Amulet chain.",
+                "Use Sionae, Nuien, and Teloa in East Karana; kill the Dark Elf Corruptor and return Fleshbound Tome to Althele.",
+                "Get Shiny Tin Bowl from Ella Foodcrafter in Misty Thicket and forage Chilled Tundra Root, Ripened Heartfruit, Speckled Molded Mushroom, and Sweetened Mudroot for Hardened Mixture.",
+                "Do the Ancient Pattern/Runecrested Bowl path through Timorous Deep, Felwithe, Chardok, and the foraged/ground components.",
+                "Finish with Faydedar, Venril Sathir, Plane of Sky/Plane of Hate style bottlenecks, and the final hand-ins for Earthcaller and Swiftwind."
+            ]),
+        new("Rogue",
+            "Stanos pouch, pickpocket parchment, Book of Souls/Cazic quill path, then General/Vilnius/Renux for Ragebringer.",
+            [
+                "Get Stanos' Pouch from Malka Rale in Qeynos Aqueducts or with help from a level 50 rogue.",
+                "Pickpocket Stained Parchment Top from Founy Jestands in North Kaladim and Stained Parchment Bottom from Tani N'Mar in Neriak.",
+                "Use Anson McBale in Highpass to spawn Stanos; turn in both parchment halves for Combined Parchment.",
+                "Give Combined Parchment, 100pp, and two unstacked Bottles of Milk to Eldreth in Lake Rathetear for Scribbled Parchment.",
+                "Take Scribbled Parchment to Yendar Starpyre in Steamfont for Tattered Parchment and continue the Book of Souls/Cazic Quill steps.",
+                "Finish the Jagged Diamond Dagger path through General V'Ghera, Vilnius the Small, and Renux Herkanor for Ragebringer."
+            ]),
+        new("Shadow Knight",
+            "Darkforge/Kurron/Duriek start, Corrupted Ghoulbane pieces, Kyrenna/Glohnor/Lhranc chain. Indifferent con matters on hand-ins.",
+            [
+                "Give Kurron Ni in Overthere Darkforge Breastplate, Darkforge Greaves, Darkforge Helm, and 900pp; kill Kurron and loot Letter to Duriek.",
+                "Give Letter to Duriek Bloodpool in Paineel; buy Cough Elixir from Smaka in Neriak and give it to Duriek.",
+                "Loot Dusty Tome from a ratman guard in The Hole and give it to Duriek.",
+                "Loot Ghoulbane from froglok shin lord in Upper Guk, Soul Leech from Cazic-Thule or Fear golems, Blade of Abrogation from Plane of Sky, Drake Spine from Rharzar, and Decrepit Hide from ashenbone drakes in Plane of Hate.",
+                "Give Drake Spine, Decrepit Hide, and Enchanted Platinum Bar to Teydar for Decrepit Sheath.",
+                "Give Ghoulbane, Soul Leech, Blade of Abrogation, and Decrepit Sheath to Duriek for Corrupted Ghoulbane.",
+                "Use Cell Key on Caradon in The Hole, kill Kyrenna, and loot Blood of Kyrenna and Heart of Kyrenna; Blood goes to Marl Kastane for Dark Shroud.",
+                "Give Dark Shroud to Ghost of Glohnor in The Hole, kill Mummy of Glohnor for Head of Glohnor and Glohnor wrappings, then turn those in for Head of the Valiant and Will of Innoruuk.",
+                "Combine Heart of Kyrenna in Soulcase for Heart of the Innocent; give Corrupted Ghoulbane, Heart of the Innocent, Head of the Valiant, and Will of Innoruuk to Lhranc, kill him, and loot Innoruuk's Curse."
+            ]),
+        new("Shaman",
+            "True Spirit faction chain, Black Dire boots, City of Mist reports/books, High Scale Kirn/Neh`Ashiir, Fear tear, then Rak`Ashiir.",
+            [
+                "Spawn a lesser spirit by killing the RM/OoT/BBM/FoB trigger mobs; receive Tiny Gem and use Bondl Felligan in North Freeport to begin True Spirit faction.",
+                "Use the proper Greater Spirit path to get Opaque Gem, then Test of Patience in Erud's Crossing.",
+                "Kill Glaron the Wicked for Envy and Woe, and Tabien the Goodly for Marr's Promise in Rathe Mountains.",
+                "Turn Envy, Woe, and Marr's Promise in to the wandering spirit in West Karana for Shield of Falsehood and the next gem.",
+                "Kill Black Dire in Mistmoore for Black Dire Pelt; turn it in to Spirit Sentinel in Emerald Jungle for Black Fur Boots and booklet.",
+                "Collect six City of Mist reports, then Lord Ghiosk's three books, and turn them in through Spirit Sentinel.",
+                "Get Icon of the High Scale from City of Mist, give it to High Scale Kirn in The Hole, kill him, then give the ring to Neh`Ashiir in City of Mist and loot the diary.",
+                "Loot Child's Tear from the Plane of Fear broodling/golem cycle; give it to Lord Rak`Ashiir in City of Mist, kill him, and loot Iksar Scale for the final Spear of Fate turn-in."
+            ]),
+        new("Warrior",
+            "Two dragon-head hilts, ancient blades, red/green scales, then final Kargek/Wenden combines for Jagged Blade.",
+            [
+                "Hail Kargek Redblade and Wenden Blackhammer in East Freeport.",
+                "Retrieve Unjeweled Dragon Head Hilt from Lake Rathetear; combine through Wenden with Diamond, Jacinth, and Black Sapphire for Jeweled Dragon Head Hilt.",
+                "Retrieve Severely Damaged Dragon Head Hilt from Timorous Deep chessboard.",
+                "Get Giant Sized Monocle from mountain giant patriarch in Dreadlands; trade it to Mentrax Mountainbone in Frontier Mountains for Rejesiam Ore.",
+                "Loot Ball of Everliving Golem from Fright, Dread, or Terror in Plane of Fear, then turn in with Severely Damaged Dragon Head Hilt and Rejesiam Ore for Finely Crafted Dragon Head Hilt.",
+                "Buy Keg of Vox Tail Ale, get two Rebreathers, and loot Block of Permafrost from ice giants; turn in to Denken Strongpick in Ocean of Tears for Ancient Sword Blade.",
+                "Loot Ancient Blade from Queen Velazul Di`zok in Chardok, plus Red Dragon Scales and Green Dragon Scales for the final blade work."
+            ]),
+        new("Wizard",
+            "Solomen/Kandin faction path, Cazic Skin and Gabstik, then Arantir combines the three staves for Staff of the Four.",
+            [
+                "Start with Solomen in Temple of Solusek Ro; the quest is TrueSpirit/faction based.",
+                "Work the Solomen note chain to Kandin Firepot.",
+                "Give Cazic's Skin from Cazic-Thule to Kandin for Kandin's Bag.",
+                "Give Mistletoe Powder to Kandin to receive Staff of Gabstik.",
+                "Return Kandin's Bag to Kandin for the next note.",
+                "Give the note to Dargon to spawn Arantir; hand Arantir Blue Crystal Staff, Gnarled Staff, and Staff of Gabstik for the sealed bag.",
+                "Give Arantir's bag to Solomen for Staff of the Four."
+            ]),
+    ];
 
     private static string StableKey(string value)
     {

--- a/src/EQBuddy.UI.Shared/OptionsViewModel.cs
+++ b/src/EQBuddy.UI.Shared/OptionsViewModel.cs
@@ -115,7 +115,7 @@ public static class OverlaySections
     [
         ("combat", "Combat"), ("healing", "Healing"), ("kills", "Kills"), ("loot", "Loot"),
         ("motes", "Motes"),
-        ("sky", "Sky Quest"), ("gear", "Gear"),
+        ("sky", "Sky Quest"), ("gear", "Gear"), ("epic", "Epics"),
         // Key stays "tracked" — it's persisted in SectionOrder/HiddenSections. Only the
         // label follows the feature's rename from tracked loot to watch rules (#5).
         ("tracked", "Watch"), ("buffs", "Buffs"), ("raids", "Raids"), ("money", "Money"), ("progress", "Progress"),

--- a/src/EQBuddy/MainWindow.xaml
+++ b/src/EQBuddy/MainWindow.xaml
@@ -597,6 +597,76 @@
                 </StackPanel>
             </Expander>
 
+            <Expander x:Name="EpicSection" Style="{StaticResource Section}">
+                <Expander.Header>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="&#x2694; Epics" FontSize="13"/>
+                        <TextBlock x:Name="EpicHeader" Grid.Column="1" Style="{StaticResource StatValue}" Text="0/0"/>
+                    </Grid>
+                </Expander.Header>
+                <TabControl x:Name="EpicTabs" Margin="0,2,0,0"
+                            Background="{DynamicResource PanelBrush}"
+                            BorderBrush="{DynamicResource BorderBrush}"
+                            Foreground="{DynamicResource TextBrush}">
+                    <TabControl.Resources>
+                        <Style TargetType="TabItem">
+                            <Setter Property="Foreground" Value="{DynamicResource DimBrush}"/>
+                            <Setter Property="Background" Value="{DynamicResource PanelBrush}"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
+                            <Setter Property="Padding" Value="7,4"/>
+                            <Setter Property="FontSize" Value="10"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="TabItem">
+                                        <Border x:Name="bd" Background="{TemplateBinding Background}"
+                                                BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
+                                                CornerRadius="5" Margin="0,0,3,3" Padding="{TemplateBinding Padding}">
+                                            <ContentPresenter ContentSource="Header"
+                                                              HorizontalAlignment="Center"
+                                                              TextElement.Foreground="{TemplateBinding Foreground}"/>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="bd" Property="Background" Value="{DynamicResource PanelHoverBrush}"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
+                                            </Trigger>
+                                            <Trigger Property="IsSelected" Value="True">
+                                                <Setter TargetName="bd" Property="Background" Value="{DynamicResource PopupBrush}"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </TabControl.Resources>
+                    <TabControl.Template>
+                        <ControlTemplate TargetType="TabControl">
+                            <Grid KeyboardNavigation.TabNavigation="Local">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                                              VerticalScrollBarVisibility="Disabled">
+                                    <TabPanel IsItemsHost="True" KeyboardNavigation.TabIndex="1"/>
+                                </ScrollViewer>
+                                <Border Grid.Row="1" Background="{DynamicResource PopupBrush}"
+                                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+                                        CornerRadius="0,0,4,4" Padding="6">
+                                    <ContentPresenter x:Name="PART_SelectedContentHost"
+                                                      ContentSource="SelectedContent"/>
+                                </Border>
+                            </Grid>
+                        </ControlTemplate>
+                    </TabControl.Template>
+                </TabControl>
+            </Expander>
+
             <Expander x:Name="TrackedSection" Style="{StaticResource Section}" Visibility="Collapsed">
                 <Expander.Header>
                     <Grid>

--- a/src/EQBuddy/MainWindow.xaml
+++ b/src/EQBuddy/MainWindow.xaml
@@ -608,10 +608,18 @@
                         <TextBlock x:Name="EpicHeader" Grid.Column="1" Style="{StaticResource StatValue}" Text="0/0"/>
                     </Grid>
                 </Expander.Header>
-                <TabControl x:Name="EpicTabs" Margin="0,2,0,0"
-                            Background="{DynamicResource PanelBrush}"
-                            BorderBrush="{DynamicResource BorderBrush}"
-                            Foreground="{DynamicResource TextBrush}">
+                <StackPanel>
+                    <CheckBox x:Name="EpicClassicOnlyCheck"
+                              Margin="0,2,0,4"
+                              Checked="OnEpicClassicOnlyToggled"
+                              Unchecked="OnEpicClassicOnlyToggled"
+                              Content="Classic-doable only"
+                              FontSize="10"
+                              Foreground="{DynamicResource DimBrush}"/>
+                    <TabControl x:Name="EpicTabs" Margin="0,2,0,0"
+                                Background="{DynamicResource PanelBrush}"
+                                BorderBrush="{DynamicResource BorderBrush}"
+                                Foreground="{DynamicResource TextBrush}">
                     <TabControl.Resources>
                         <Style TargetType="TabItem">
                             <Setter Property="Foreground" Value="{DynamicResource DimBrush}"/>
@@ -664,7 +672,8 @@
                             </Grid>
                         </ControlTemplate>
                     </TabControl.Template>
-                </TabControl>
+                    </TabControl>
+                </StackPanel>
             </Expander>
 
             <Expander x:Name="TrackedSection" Style="{StaticResource Section}" Visibility="Collapsed">

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -2309,7 +2309,8 @@ public partial class MainWindow : Window
         {
             var classItems = _settings.EpicQuestChecklist
                 .Where(i => string.Equals(i.ClassName, className, StringComparison.Ordinal))
-                .OrderBy(i => i.QuestItem, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(i => i.Order)
+                .ThenBy(i => i.QuestItem, StringComparer.OrdinalIgnoreCase)
                 .ToList();
             var done = classItems.Count(i => i.Acquired);
             var total = classItems.Count;

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -37,6 +37,7 @@ public partial class MainWindow : Window
     // does elsewhere — the checklist re-renders only when a box actually changed.
     private bool _skyQuestDirty = true;
     private bool _gearChecklistDirty = true;
+    private bool _epicQuestDirty = true;
     // Perf audit #1: the version last painted into the expanded sections, and the
     // last time a full paint happened (10 s heartbeat keeps time-derived rates live).
     private long _lastRenderedVersion = -1;
@@ -186,7 +187,7 @@ public partial class MainWindow : Window
 
         if (Environment.GetEnvironmentVariable("EQBUDDY_EXPAND") == "1")
             foreach (var ex in new[] { CombatSection, HealingSection, KillsSection, LootSection,
-                         MotesSection, SkyQuestSection, GearSection, TrackedSection, MoneySection,
+                         MotesSection, SkyQuestSection, GearSection, EpicSection, TrackedSection, MoneySection,
                          ProgressSection, FactionSection, MiscSection })
                 ex.IsExpanded = true;
 
@@ -322,6 +323,7 @@ public partial class MainWindow : Window
         }
 
         SkyQuestTabs.SelectionChanged += OnSkyQuestTabChanged;
+        EpicTabs.SelectionChanged += OnEpicQuestTabChanged;
 
         _uiTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _uiTimer.Tick += (_, _) => RefreshUi();
@@ -362,7 +364,7 @@ public partial class MainWindow : Window
     {
         ["combat"] = CombatSection, ["healing"] = HealingSection, ["kills"] = KillsSection,
         ["loot"] = LootSection, ["motes"] = MotesSection, ["sky"] = SkyQuestSection,
-        ["gear"] = GearSection, ["tracked"] = TrackedSection,
+        ["gear"] = GearSection, ["epic"] = EpicSection, ["tracked"] = TrackedSection,
         ["buffs"] = BuffsSection, ["raids"] = RaidsSection,
         ["money"] = MoneySection,
         ["progress"] = ProgressSection, ["faction"] = FactionSection, ["misc"] = MiscSection,
@@ -1731,6 +1733,7 @@ public partial class MainWindow : Window
         MotesHeader.Text = motes.Total > 0 ? $"{motes.Total} · {motes.PerHour:0.#}/hr" : "0";
         UpdateSkyQuestChecklist(s);
         UpdateGearHeaderOnly();
+        UpdateEpicQuestHeaderOnly();
         MoneyHeader.Text = StatsSnapshot.FormatCoin(s.Copper);
         ProgressHeader.Text = $"{s.XpPercent:0.0}% xp"
             + (s.Levels.Count > 0 ? $", +{s.Levels.Count} lvl" : "")
@@ -1927,6 +1930,12 @@ public partial class MainWindow : Window
         {
             RenderGearChecklist();
             _gearChecklistDirty = false;
+        }
+
+        if (EpicSection.IsExpanded && _epicQuestDirty)
+        {
+            RenderEpicQuestChecklist();
+            _epicQuestDirty = false;
         }
 
         if (MoneySection.IsExpanded)
@@ -2288,6 +2297,201 @@ public partial class MainWindow : Window
         var total = _settings.GearChecklist.Count;
         var acquired = _settings.GearChecklist.Count(i => i.Acquired);
         GearHeader.Text = $"{acquired}/{total}";
+    }
+
+    private void RenderEpicQuestChecklist()
+    {
+        var selectedClass = (EpicTabs.SelectedItem as TabItem)?.Tag as string
+            ?? (_settings.EpicQuestClass.Length > 0 ? _settings.EpicQuestClass : null);
+        EpicTabs.Items.Clear();
+
+        foreach (var className in QuestClassFilter.Classes)
+        {
+            var classItems = _settings.EpicQuestChecklist
+                .Where(i => string.Equals(i.ClassName, className, StringComparison.Ordinal))
+                .OrderBy(i => i.QuestItem, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            var done = classItems.Count(i => i.Acquired);
+            var total = classItems.Count;
+            var quest = EpicQuestDefaults.FindQuest(QuestCatalog, className);
+            var panel = new StackPanel { Margin = new Thickness(0, 4, 0, 0) };
+
+            if (quest is null || total == 0)
+            {
+                panel.Children.Add(new TextBlock
+                {
+                    Text = "No Epic 1.0 quest found in the catalog for this class yet.",
+                    FontSize = 11,
+                    Foreground = (Brush)FindResource("DimBrush"),
+                    TextWrapping = TextWrapping.Wrap,
+                });
+            }
+            else
+            {
+                panel.Children.Add(new TextBlock
+                {
+                    Text = quest.Name,
+                    FontSize = 11,
+                    FontWeight = FontWeights.SemiBold,
+                    Foreground = (Brush)FindResource("AccentBrush"),
+                    TextTrimming = TextTrimming.CharacterEllipsis,
+                });
+                if (classItems[0].Reward.Length > 0)
+                    panel.Children.Add(new TextBlock
+                    {
+                        Text = "Reward: " + classItems[0].Reward,
+                        FontSize = 10,
+                        Foreground = (Brush)FindResource("DimBrush"),
+                        TextWrapping = TextWrapping.Wrap,
+                    });
+                var source = EpicQuestDefaults.SourceLine(quest);
+                if (source.Length > 0)
+                    panel.Children.Add(new TextBlock
+                    {
+                        Text = source,
+                        FontSize = 10,
+                        Foreground = (Brush)FindResource("DimBrush"),
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 1, 0, 4),
+                    });
+
+                var completed = IsEpicQuestCompleted(className);
+                var completeCheck = new CheckBox
+                {
+                    IsChecked = completed,
+                    Margin = new Thickness(0, 4, 0, 4),
+                    ToolTip = "Check when the final epic turn-in is finished.",
+                    Content = new TextBlock
+                    {
+                        Text = completed ? "Complete" : "Epic complete",
+                        FontSize = 11,
+                        FontWeight = FontWeights.SemiBold,
+                        Foreground = (Brush)FindResource("AccentBrush"),
+                    },
+                };
+                completeCheck.Checked += (_, _) => OnEpicQuestCompletedToggled(className, classItems, true);
+                completeCheck.Unchecked += (_, _) => OnEpicQuestCompletedToggled(className, classItems, false);
+                panel.Children.Add(completeCheck);
+
+                foreach (var item in classItems)
+                {
+                    var text = new StackPanel();
+                    text.Children.Add(new TextBlock
+                    {
+                        Text = item.Qty > 1 ? $"{item.QuestItem} x{item.Qty}" : item.QuestItem,
+                        FontSize = 12,
+                        Foreground = (Brush)FindResource("TextBrush"),
+                        TextTrimming = TextTrimming.CharacterEllipsis,
+                    });
+
+                    var check = new CheckBox
+                    {
+                        IsChecked = item.Acquired,
+                        Content = text,
+                        Margin = new Thickness(0, 1, 0, 1),
+                        IsEnabled = !completed,
+                        Opacity = completed ? 0.55 : 1.0,
+                        ToolTip = $"{item.QuestName}: {item.QuestItem}" +
+                                  (item.Qty > 1 ? $" x{item.Qty}" : ""),
+                    };
+                    check.Checked += (_, _) => OnEpicQuestToggled(item, true);
+                    check.Unchecked += (_, _) => OnEpicQuestToggled(item, false);
+                    panel.Children.Add(check);
+                }
+            }
+
+            var tab = new TabItem
+            {
+                Header = total > 0 ? $"{ClassAbbrev(className)} {done}/{total}" : $"{ClassAbbrev(className)} -",
+                Tag = className,
+                Content = new ScrollViewer
+                {
+                    Content = panel,
+                    MaxHeight = SkyQuestListMaxHeight(),
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                    PanningMode = PanningMode.VerticalOnly,
+                    Padding = new Thickness(0, 0, 4, 0),
+                },
+                ToolTip = className,
+            };
+            EpicTabs.Items.Add(tab);
+            if (string.Equals(selectedClass, className, StringComparison.Ordinal))
+                EpicTabs.SelectedItem = tab;
+        }
+
+        if (EpicTabs.SelectedIndex < 0 && EpicTabs.Items.Count > 0)
+            EpicTabs.SelectedIndex = 0;
+    }
+
+    private static string EpicQuestCompletedKey(string className) => className;
+
+    private bool IsEpicQuestCompleted(string className) =>
+        _settings.EpicQuestCompleted.Contains(EpicQuestCompletedKey(className), StringComparer.OrdinalIgnoreCase);
+
+    private void OnEpicQuestCompletedToggled(string className, List<EpicQuestChecklistItem> items, bool done)
+    {
+        var key = EpicQuestCompletedKey(className);
+        if (done)
+        {
+            if (!_settings.EpicQuestCompleted.Contains(key, StringComparer.OrdinalIgnoreCase))
+                _settings.EpicQuestCompleted.Add(key);
+            foreach (var item in items) item.Acquired = true;
+        }
+        else
+        {
+            _settings.EpicQuestCompleted.RemoveAll(k => string.Equals(k, key, StringComparison.OrdinalIgnoreCase));
+        }
+
+        _settings.Save();
+        UpdateEpicQuestHeaderOnly();
+        if (EpicSection.IsExpanded)
+        {
+            RenderEpicQuestChecklist();
+            _epicQuestDirty = false;
+        }
+        else
+        {
+            _epicQuestDirty = true;
+        }
+    }
+
+    private void OnEpicQuestToggled(EpicQuestChecklistItem item, bool acquired)
+    {
+        item.Acquired = acquired;
+        _settings.Save();
+        UpdateEpicQuestHeaderOnly();
+        UpdateEpicQuestTabHeader(item.ClassName);
+    }
+
+    private void OnEpicQuestTabChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if ((EpicTabs.SelectedItem as TabItem)?.Tag is string cls &&
+            !string.Equals(_settings.EpicQuestClass, cls, StringComparison.Ordinal))
+        {
+            _settings.EpicQuestClass = cls;
+            _settings.Save();
+        }
+    }
+
+    private void UpdateEpicQuestTabHeader(string className)
+    {
+        foreach (var tab in EpicTabs.Items.OfType<TabItem>())
+            if (string.Equals(tab.Tag as string, className, StringComparison.Ordinal))
+            {
+                var done = _settings.EpicQuestChecklist.Count(i =>
+                    string.Equals(i.ClassName, className, StringComparison.Ordinal) && i.Acquired);
+                var total = _settings.EpicQuestChecklist.Count(i =>
+                    string.Equals(i.ClassName, className, StringComparison.Ordinal));
+                tab.Header = total > 0 ? $"{ClassAbbrev(className)} {done}/{total}" : $"{ClassAbbrev(className)} -";
+            }
+    }
+
+    private void UpdateEpicQuestHeaderOnly()
+    {
+        var total = _settings.EpicQuestChecklist.Count;
+        var acquired = _settings.EpicQuestChecklist.Count(i => i.Acquired);
+        EpicHeader.Text = $"{acquired}/{total}";
     }
 
     private void UpdateSkyQuestChecklist(StatsSnapshot s)

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -54,6 +54,7 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        EpicClassicOnlyCheck.IsChecked = _settings.EpicQuestClassicOnly;
         // Before the watcher's startup replay, so already-logged charms classify with
         // everything learned in earlier sessions (issue #29).
         AttachSpellStore();
@@ -2307,17 +2308,18 @@ public partial class MainWindow : Window
 
         foreach (var className in QuestClassFilter.Classes)
         {
-            var classItems = _settings.EpicQuestChecklist
+            var allClassItems = _settings.EpicQuestChecklist
                 .Where(i => string.Equals(i.ClassName, className, StringComparison.Ordinal))
                 .OrderBy(i => i.Order)
                 .ThenBy(i => i.QuestItem, StringComparer.OrdinalIgnoreCase)
                 .ToList();
+            var classItems = FilterEpicQuestRows(allClassItems).ToList();
             var done = classItems.Count(i => i.Acquired);
             var total = classItems.Count;
             var quest = EpicQuestDefaults.FindQuest(QuestCatalog, className);
             var panel = new StackPanel { Margin = new Thickness(0, 4, 0, 0) };
 
-            if (quest is null || total == 0)
+            if (quest is null || allClassItems.Count == 0)
             {
                 panel.Children.Add(new TextBlock
                 {
@@ -2356,6 +2358,18 @@ public partial class MainWindow : Window
                         Margin = new Thickness(0, 1, 0, 4),
                     });
 
+                if (classItems.Count == 0)
+                {
+                    panel.Children.Add(new TextBlock
+                    {
+                        Text = "No classic-doable steps are tagged for this class yet.",
+                        FontSize = 11,
+                        Foreground = (Brush)FindResource("DimBrush"),
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 8, 0, 4),
+                    });
+                }
+
                 var completed = IsEpicQuestCompleted(className);
                 var completeCheck = new CheckBox
                 {
@@ -2370,8 +2384,8 @@ public partial class MainWindow : Window
                         Foreground = (Brush)FindResource("AccentBrush"),
                     },
                 };
-                completeCheck.Checked += (_, _) => OnEpicQuestCompletedToggled(className, classItems, true);
-                completeCheck.Unchecked += (_, _) => OnEpicQuestCompletedToggled(className, classItems, false);
+                completeCheck.Checked += (_, _) => OnEpicQuestCompletedToggled(className, allClassItems, true);
+                completeCheck.Unchecked += (_, _) => OnEpicQuestCompletedToggled(className, allClassItems, false);
                 panel.Children.Add(completeCheck);
 
                 foreach (var sectionGroup in classItems.GroupBy(i => i.Section.Length > 0 ? i.Section : "Checklist"))
@@ -2442,6 +2456,29 @@ public partial class MainWindow : Window
     private bool IsEpicQuestCompleted(string className) =>
         _settings.EpicQuestCompleted.Contains(EpicQuestCompletedKey(className), StringComparer.OrdinalIgnoreCase);
 
+    private IEnumerable<EpicQuestChecklistItem> FilterEpicQuestRows(IEnumerable<EpicQuestChecklistItem> items) =>
+        _settings.EpicQuestClassicOnly ? items.Where(i => i.AvailableInClassic) : items;
+
+    private void OnEpicClassicOnlyToggled(object sender, RoutedEventArgs e)
+    {
+        var value = EpicClassicOnlyCheck.IsChecked == true;
+        if (_settings.EpicQuestClassicOnly == value)
+            return;
+
+        _settings.EpicQuestClassicOnly = value;
+        _settings.Save();
+        UpdateEpicQuestHeaderOnly();
+        if (EpicSection.IsExpanded)
+        {
+            RenderEpicQuestChecklist();
+            _epicQuestDirty = false;
+        }
+        else
+        {
+            _epicQuestDirty = true;
+        }
+    }
+
     private void OnEpicQuestCompletedToggled(string className, List<EpicQuestChecklistItem> items, bool done)
     {
         var key = EpicQuestCompletedKey(className);
@@ -2492,18 +2529,20 @@ public partial class MainWindow : Window
         foreach (var tab in EpicTabs.Items.OfType<TabItem>())
             if (string.Equals(tab.Tag as string, className, StringComparison.Ordinal))
             {
-                var done = _settings.EpicQuestChecklist.Count(i =>
-                    string.Equals(i.ClassName, className, StringComparison.Ordinal) && i.Acquired);
-                var total = _settings.EpicQuestChecklist.Count(i =>
-                    string.Equals(i.ClassName, className, StringComparison.Ordinal));
+                var classItems = FilterEpicQuestRows(_settings.EpicQuestChecklist
+                    .Where(i => string.Equals(i.ClassName, className, StringComparison.Ordinal)))
+                    .ToList();
+                var done = classItems.Count(i => i.Acquired);
+                var total = classItems.Count;
                 tab.Header = total > 0 ? $"{ClassAbbrev(className)} {done}/{total}" : $"{ClassAbbrev(className)} -";
             }
     }
 
     private void UpdateEpicQuestHeaderOnly()
     {
-        var total = _settings.EpicQuestChecklist.Count;
-        var acquired = _settings.EpicQuestChecklist.Count(i => i.Acquired);
+        var items = FilterEpicQuestRows(_settings.EpicQuestChecklist).ToList();
+        var total = items.Count;
+        var acquired = items.Count(i => i.Acquired);
         EpicHeader.Text = $"{acquired}/{total}";
     }
 

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -2355,11 +2355,41 @@ public partial class MainWindow : Window
                         Margin = new Thickness(0, 1, 0, 4),
                     });
 
+                var guide = EpicQuestDefaults.GuideFor(className);
+                if (guide is not null)
+                {
+                    panel.Children.Add(new TextBlock
+                    {
+                        Text = guide.Summary,
+                        FontSize = 10,
+                        Foreground = (Brush)FindResource("TextBrush"),
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 2, 0, 4),
+                    });
+                    panel.Children.Add(new TextBlock
+                    {
+                        Text = "Route",
+                        FontSize = 10,
+                        FontWeight = FontWeights.SemiBold,
+                        Foreground = (Brush)FindResource("AccentBrush"),
+                        Margin = new Thickness(0, 2, 0, 2),
+                    });
+                    foreach (var step in guide.Steps)
+                        panel.Children.Add(new TextBlock
+                        {
+                            Text = "- " + step,
+                            FontSize = 10,
+                            Foreground = (Brush)FindResource("DimBrush"),
+                            TextWrapping = TextWrapping.Wrap,
+                            Margin = new Thickness(0, 0, 0, 2),
+                        });
+                }
+
                 var completed = IsEpicQuestCompleted(className);
                 var completeCheck = new CheckBox
                 {
                     IsChecked = completed,
-                    Margin = new Thickness(0, 4, 0, 4),
+                    Margin = new Thickness(0, 8, 0, 4),
                     ToolTip = "Check when the final epic turn-in is finished.",
                     Content = new TextBlock
                     {
@@ -2383,6 +2413,15 @@ public partial class MainWindow : Window
                         Foreground = (Brush)FindResource("TextBrush"),
                         TextTrimming = TextTrimming.CharacterEllipsis,
                     });
+                    if (item.Source.Length > 0)
+                        text.Children.Add(new TextBlock
+                        {
+                            Text = item.Source,
+                            FontSize = 10,
+                            Foreground = (Brush)FindResource("DimBrush"),
+                            TextWrapping = TextWrapping.Wrap,
+                            Margin = new Thickness(0, 1, 0, 0),
+                        });
 
                     var check = new CheckBox
                     {
@@ -2392,7 +2431,8 @@ public partial class MainWindow : Window
                         IsEnabled = !completed,
                         Opacity = completed ? 0.55 : 1.0,
                         ToolTip = $"{item.QuestName}: {item.QuestItem}" +
-                                  (item.Qty > 1 ? $" x{item.Qty}" : ""),
+                                  (item.Qty > 1 ? $" x{item.Qty}" : "") +
+                                  (item.Source.Length > 0 ? "\n" + item.Source : ""),
                     };
                     check.Checked += (_, _) => OnEpicQuestToggled(item, true);
                     check.Unchecked += (_, _) => OnEpicQuestToggled(item, false);

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -2356,36 +2356,6 @@ public partial class MainWindow : Window
                         Margin = new Thickness(0, 1, 0, 4),
                     });
 
-                var guide = EpicQuestDefaults.GuideFor(className);
-                if (guide is not null)
-                {
-                    panel.Children.Add(new TextBlock
-                    {
-                        Text = guide.Summary,
-                        FontSize = 10,
-                        Foreground = (Brush)FindResource("TextBrush"),
-                        TextWrapping = TextWrapping.Wrap,
-                        Margin = new Thickness(0, 2, 0, 4),
-                    });
-                    panel.Children.Add(new TextBlock
-                    {
-                        Text = "Route",
-                        FontSize = 10,
-                        FontWeight = FontWeights.SemiBold,
-                        Foreground = (Brush)FindResource("AccentBrush"),
-                        Margin = new Thickness(0, 2, 0, 2),
-                    });
-                    foreach (var step in guide.Steps)
-                        panel.Children.Add(new TextBlock
-                        {
-                            Text = "- " + step,
-                            FontSize = 10,
-                            Foreground = (Brush)FindResource("DimBrush"),
-                            TextWrapping = TextWrapping.Wrap,
-                            Margin = new Thickness(0, 0, 0, 2),
-                        });
-                }
-
                 var completed = IsEpicQuestCompleted(className);
                 var completeCheck = new CheckBox
                 {
@@ -2404,40 +2374,42 @@ public partial class MainWindow : Window
                 completeCheck.Unchecked += (_, _) => OnEpicQuestCompletedToggled(className, classItems, false);
                 panel.Children.Add(completeCheck);
 
-                foreach (var item in classItems)
+                foreach (var sectionGroup in classItems.GroupBy(i => i.Section.Length > 0 ? i.Section : "Checklist"))
                 {
-                    var text = new StackPanel();
-                    text.Children.Add(new TextBlock
-                    {
-                        Text = item.Qty > 1 ? $"{item.QuestItem} x{item.Qty}" : item.QuestItem,
-                        FontSize = 12,
-                        Foreground = (Brush)FindResource("TextBrush"),
-                        TextTrimming = TextTrimming.CharacterEllipsis,
-                    });
-                    if (item.Source.Length > 0)
-                        text.Children.Add(new TextBlock
+                    if (!sectionGroup.Key.Equals("Checklist", StringComparison.OrdinalIgnoreCase) || classItems.Select(i => i.Section).Distinct().Count() > 1)
+                        panel.Children.Add(new TextBlock
                         {
-                            Text = item.Source,
-                            FontSize = 10,
-                            Foreground = (Brush)FindResource("DimBrush"),
+                            Text = sectionGroup.Key,
+                            FontSize = 12,
+                            FontWeight = FontWeights.SemiBold,
+                            Foreground = (Brush)FindResource("AccentBrush"),
                             TextWrapping = TextWrapping.Wrap,
-                            Margin = new Thickness(0, 1, 0, 0),
+                            Margin = new Thickness(0, 8, 0, 2),
                         });
 
-                    var check = new CheckBox
+                    foreach (var item in sectionGroup)
                     {
-                        IsChecked = item.Acquired,
-                        Content = text,
-                        Margin = new Thickness(0, 1, 0, 1),
-                        IsEnabled = !completed,
-                        Opacity = completed ? 0.55 : 1.0,
-                        ToolTip = $"{item.QuestName}: {item.QuestItem}" +
-                                  (item.Qty > 1 ? $" x{item.Qty}" : "") +
-                                  (item.Source.Length > 0 ? "\n" + item.Source : ""),
-                    };
-                    check.Checked += (_, _) => OnEpicQuestToggled(item, true);
-                    check.Unchecked += (_, _) => OnEpicQuestToggled(item, false);
-                    panel.Children.Add(check);
+                        var text = new TextBlock
+                        {
+                            Text = item.QuestItem,
+                            FontSize = 11,
+                            Foreground = (Brush)FindResource("TextBrush"),
+                            TextWrapping = TextWrapping.Wrap,
+                        };
+
+                        var check = new CheckBox
+                        {
+                            IsChecked = item.Acquired,
+                            Content = text,
+                            Margin = new Thickness(0, 2, 0, 2),
+                            IsEnabled = !completed,
+                            Opacity = completed ? 0.55 : 1.0,
+                            ToolTip = $"{item.QuestName}: {item.QuestItem}",
+                        };
+                        check.Checked += (_, _) => OnEpicQuestToggled(item, true);
+                        check.Unchecked += (_, _) => OnEpicQuestToggled(item, false);
+                        panel.Children.Add(check);
+                    }
                 }
             }
 

--- a/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
+++ b/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
@@ -26,4 +26,24 @@ public sealed class EpicQuestDefaultsTests
 
         Assert.Equal(bardItems.Count, bardItems.Distinct(StringComparer.OrdinalIgnoreCase).Count());
     }
+
+    [Fact]
+    public void ProvidesGuideAndItemSourceHints()
+    {
+        var guide = Assert.IsType<EpicQuestGuide>(EpicQuestDefaults.GuideFor("Shadow Knight"));
+
+        Assert.Contains(guide.Steps, s => s.Contains("Corrupted Ghoulbane"));
+        Assert.Contains(guide.Steps, s => s.Contains("Lhranc"));
+
+        var items = EpicQuestDefaults.Items();
+        Assert.Contains(items, i => i.ClassName == "Monk" &&
+                                    i.QuestItem == "Demon Fangs" &&
+                                    i.Source.Contains("Xenevorash"));
+        Assert.Contains(items, i => i.ClassName == "Shaman" &&
+                                    i.QuestItem == "Child's Tear" &&
+                                    i.Source.Contains("Plane of Fear"));
+        Assert.Contains(items, i => i.ClassName == "Shadow Knight" &&
+                                    i.QuestItem == "Blade of Abrogation" &&
+                                    i.Source.Contains("Plane of Sky"));
+    }
 }

--- a/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
+++ b/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
@@ -45,5 +45,23 @@ public sealed class EpicQuestDefaultsTests
         Assert.Contains(items, i => i.ClassName == "Shadow Knight" &&
                                     i.QuestItem == "Blade of Abrogation" &&
                                     i.Source.Contains("Plane of Sky"));
+        Assert.Contains(items, i => i.ClassName == "Shadow Knight" &&
+                                    i.QuestItem == "Cell Key" &&
+                                    i.Source.Contains("mimic/chest") &&
+                                    i.Source.Contains("The Hole"));
+    }
+
+    [Fact]
+    public void OrdersEpicItemsByQuestRoute()
+    {
+        var items = EpicQuestDefaults.Items()
+            .Where(i => i.ClassName == "Shadow Knight")
+            .OrderBy(i => i.Order)
+            .ThenBy(i => i.QuestItem, StringComparer.OrdinalIgnoreCase)
+            .Select(i => i.QuestItem)
+            .ToList();
+
+        Assert.True(items.IndexOf("Darkforge Breastplate") < items.IndexOf("Cell Key"));
+        Assert.True(items.IndexOf("Cell Key") < items.IndexOf("Innoruuk's Curse"));
     }
 }

--- a/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
+++ b/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
@@ -5,63 +5,39 @@ namespace EQBuddy.Tests;
 public sealed class EpicQuestDefaultsTests
 {
     [Fact]
-    public void BuildsEpicChecklistFromQuestCatalog()
+    public void BuildsEpicChecklistFromWikiChecklist()
     {
         var items = EpicQuestDefaults.Items();
 
-        Assert.Contains(items, i => i.ClassName == "Monk" && i.Reward.Contains("Celestial Fists"));
-        Assert.Contains(items, i => i.ClassName == "Shadow Knight" && i.Reward.Contains("Innoruuk's Curse"));
-        Assert.Contains(items, i => i.ClassName == "Wizard" && i.QuestItem == "Staff of Gabstik");
+        Assert.Contains(items, i => i.ClassName == "Monk" && i.QuestItem.Contains("Demon Fangs"));
+        Assert.Contains(items, i => i.ClassName == "Shadow Knight" && i.QuestItem.Contains("Cell Key") && i.QuestItem.Contains("Caradon"));
+        Assert.Contains(items, i => i.ClassName == "Wizard" && i.Section == "Post-Revamp Checklist");
         Assert.DoesNotContain(items, i => i.ClassName == "Beastlord");
         Assert.DoesNotContain(items, i => i.ClassName == "Berserker");
     }
 
     [Fact]
-    public void DedupesCaseOnlyCatalogVariants()
+    public void PreservesWikiSections()
     {
-        var bardItems = EpicQuestDefaults.Items()
-            .Where(i => i.ClassName == "Bard")
-            .Select(i => i.QuestItem)
-            .ToList();
+        var bardItems = EpicQuestDefaults.Items().Where(i => i.ClassName == "Bard").ToList();
 
-        Assert.Equal(bardItems.Count, bardItems.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.Contains(bardItems, i => i.Section == "Maestro's Symphony Page 24 Top" &&
+                                        i.QuestItem.Contains("Konia Swiftfoot"));
+        Assert.Contains(bardItems, i => i.Section == "Maestro's Symphony Page 24 Bottom" &&
+                                        i.QuestItem.Contains("Baenar Swiftsong"));
     }
 
     [Fact]
-    public void ProvidesGuideAndItemSourceHints()
+    public void IncludesEveryClassicEpicClassWithChecklistRows()
     {
-        var guide = Assert.IsType<EpicQuestGuide>(EpicQuestDefaults.GuideFor("Shadow Knight"));
-
-        Assert.Contains(guide.Steps, s => s.Contains("Corrupted Ghoulbane"));
-        Assert.Contains(guide.Steps, s => s.Contains("Lhranc"));
-
         var items = EpicQuestDefaults.Items();
-        Assert.Contains(items, i => i.ClassName == "Monk" &&
-                                    i.QuestItem == "Demon Fangs" &&
-                                    i.Source.Contains("Xenevorash"));
-        Assert.Contains(items, i => i.ClassName == "Shaman" &&
-                                    i.QuestItem == "Child's Tear" &&
-                                    i.Source.Contains("Plane of Fear"));
-        Assert.Contains(items, i => i.ClassName == "Shadow Knight" &&
-                                    i.QuestItem == "Blade of Abrogation" &&
-                                    i.Source.Contains("Plane of Sky"));
-        Assert.Contains(items, i => i.ClassName == "Shadow Knight" &&
-                                    i.QuestItem == "Cell Key" &&
-                                    i.Source.Contains("mimic/chest") &&
-                                    i.Source.Contains("The Hole"));
-    }
+        var classes = new[]
+        {
+            "Bard", "Cleric", "Druid", "Enchanter", "Magician", "Monk", "Necromancer",
+            "Paladin", "Ranger", "Rogue", "Shadow Knight", "Shaman", "Warrior", "Wizard",
+        };
 
-    [Fact]
-    public void OrdersEpicItemsByQuestRoute()
-    {
-        var items = EpicQuestDefaults.Items()
-            .Where(i => i.ClassName == "Shadow Knight")
-            .OrderBy(i => i.Order)
-            .ThenBy(i => i.QuestItem, StringComparer.OrdinalIgnoreCase)
-            .Select(i => i.QuestItem)
-            .ToList();
-
-        Assert.True(items.IndexOf("Darkforge Breastplate") < items.IndexOf("Cell Key"));
-        Assert.True(items.IndexOf("Cell Key") < items.IndexOf("Innoruuk's Curse"));
+        foreach (var className in classes)
+            Assert.True(items.Count(i => i.ClassName == className) > 0, className);
     }
 }

--- a/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
+++ b/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
@@ -17,6 +17,15 @@ public sealed class EpicQuestDefaultsTests
     }
 
     [Fact]
+    public void CarriesClassicAvailabilityFromWikiMetadata()
+    {
+        var bardItems = EpicQuestDefaults.Items().Where(i => i.ClassName == "Bard").ToList();
+
+        Assert.Contains(bardItems, i => i.QuestItem.Contains("Torch of Misty") && !i.AvailableInClassic);
+        Assert.Contains(bardItems, i => i.QuestItem.Contains("Konia Swiftfoot") && i.AvailableInClassic);
+    }
+
+    [Fact]
     public void PreservesWikiSections()
     {
         var bardItems = EpicQuestDefaults.Items().Where(i => i.ClassName == "Bard").ToList();

--- a/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
+++ b/tests/EQBuddy.Tests/EpicQuestDefaultsTests.cs
@@ -1,0 +1,29 @@
+using EQBuddy.Core;
+
+namespace EQBuddy.Tests;
+
+public sealed class EpicQuestDefaultsTests
+{
+    [Fact]
+    public void BuildsEpicChecklistFromQuestCatalog()
+    {
+        var items = EpicQuestDefaults.Items();
+
+        Assert.Contains(items, i => i.ClassName == "Monk" && i.Reward.Contains("Celestial Fists"));
+        Assert.Contains(items, i => i.ClassName == "Shadow Knight" && i.Reward.Contains("Innoruuk's Curse"));
+        Assert.Contains(items, i => i.ClassName == "Wizard" && i.QuestItem == "Staff of Gabstik");
+        Assert.DoesNotContain(items, i => i.ClassName == "Beastlord");
+        Assert.DoesNotContain(items, i => i.ClassName == "Berserker");
+    }
+
+    [Fact]
+    public void DedupesCaseOnlyCatalogVariants()
+    {
+        var bardItems = EpicQuestDefaults.Items()
+            .Where(i => i.ClassName == "Bard")
+            .Select(i => i.QuestItem)
+            .ToList();
+
+        Assert.Equal(bardItems.Count, bardItems.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+}

--- a/tests/EQBuddy.Tests/OptionsViewModelTests.cs
+++ b/tests/EQBuddy.Tests/OptionsViewModelTests.cs
@@ -54,6 +54,7 @@ public sealed class OptionsViewModelTests
         Assert.DoesNotContain("bogus", s.SectionOrder);
         Assert.Contains(vm.Cards, c => c.Key == "sky" && c.Title == "Sky Quest");
         Assert.Contains(vm.Cards, c => c.Key == "gear" && c.Title == "Gear");
+        Assert.Contains(vm.Cards, c => c.Key == "epic" && c.Title == "Epics");
 
         vm.MoveCard("kills", -1);                        // top can't move up
         Assert.Equal("kills", s.SectionOrder[0]);
@@ -151,5 +152,36 @@ public sealed class OptionsViewModelTests
         Assert.Equal(["combat", "motes", "gear", "tracked"], noSky.SectionOrder);
 
         Assert.False(new AppSettings().ApplyDefaultGearSection());
+    }
+
+    [Fact]
+    public void EpicQuestSectionSlotsInAfterSky()
+    {
+        var settings = new AppSettings { SectionOrder = ["combat", "motes", "sky", "gear", "tracked"] };
+
+        Assert.True(settings.ApplyDefaultEpicQuestSection());
+        Assert.Equal(["combat", "motes", "sky", "gear", "epic", "tracked"], settings.SectionOrder);
+        Assert.False(settings.ApplyDefaultEpicQuestSection());
+
+        var noSky = new AppSettings { SectionOrder = ["combat", "motes", "tracked"] };
+        Assert.True(noSky.ApplyDefaultEpicQuestSection());
+        Assert.Equal(["combat", "motes", "epic", "tracked"], noSky.SectionOrder);
+
+        Assert.False(new AppSettings().ApplyDefaultEpicQuestSection());
+    }
+
+    [Fact]
+    public void EpicQuestDefaultsMergeOnce()
+    {
+        var settings = new AppSettings();
+
+        Assert.True(settings.ApplyDefaultEpicQuestChecklist());
+        Assert.Contains(settings.EpicQuestChecklist, i => i.ClassName == "Monk" && i.Reward.Contains("Celestial Fists"));
+        var count = settings.EpicQuestChecklist.Count;
+
+        settings.EpicQuestChecklist[0].Acquired = true;
+        Assert.False(settings.ApplyDefaultEpicQuestChecklist());
+        Assert.Equal(count, settings.EpicQuestChecklist.Count);
+        Assert.True(settings.EpicQuestChecklist[0].Acquired);
     }
 }

--- a/tests/EQBuddy.Tests/OptionsViewModelTests.cs
+++ b/tests/EQBuddy.Tests/OptionsViewModelTests.cs
@@ -198,12 +198,14 @@ public sealed class OptionsViewModelTests
             ],
         };
         settings.EpicQuestChecklist[0].Source = "old source";
+        settings.EpicQuestChecklist[0].Order = 9999;
         settings.EpicQuestChecklist[0].Acquired = true;
 
         Assert.True(settings.ApplyDefaultEpicQuestChecklist());
 
         var refreshed = settings.EpicQuestChecklist.Single(i => i.Id == item.Id);
         Assert.True(refreshed.Acquired);
+        Assert.Equal(item.Order, refreshed.Order);
         Assert.Contains("Plane of Sky", refreshed.Source);
     }
 }

--- a/tests/EQBuddy.Tests/OptionsViewModelTests.cs
+++ b/tests/EQBuddy.Tests/OptionsViewModelTests.cs
@@ -184,4 +184,26 @@ public sealed class OptionsViewModelTests
         Assert.Equal(count, settings.EpicQuestChecklist.Count);
         Assert.True(settings.EpicQuestChecklist[0].Acquired);
     }
+
+    [Fact]
+    public void EpicQuestDefaultsRefreshExistingSourceHints()
+    {
+        var item = EpicQuestDefaults.Items().Single(i =>
+            i.ClassName == "Shadow Knight" && i.QuestItem == "Blade of Abrogation");
+        var settings = new AppSettings
+        {
+            EpicQuestChecklist =
+            [
+                item.Clone()
+            ],
+        };
+        settings.EpicQuestChecklist[0].Source = "old source";
+        settings.EpicQuestChecklist[0].Acquired = true;
+
+        Assert.True(settings.ApplyDefaultEpicQuestChecklist());
+
+        var refreshed = settings.EpicQuestChecklist.Single(i => i.Id == item.Id);
+        Assert.True(refreshed.Acquired);
+        Assert.Contains("Plane of Sky", refreshed.Source);
+    }
 }

--- a/tests/EQBuddy.Tests/OptionsViewModelTests.cs
+++ b/tests/EQBuddy.Tests/OptionsViewModelTests.cs
@@ -186,10 +186,12 @@ public sealed class OptionsViewModelTests
     }
 
     [Fact]
-    public void EpicQuestDefaultsRefreshExistingSourceHints()
+    public void EpicQuestDefaultsRefreshExistingChecklistRows()
     {
         var item = EpicQuestDefaults.Items().Single(i =>
-            i.ClassName == "Shadow Knight" && i.QuestItem == "Blade of Abrogation");
+            i.ClassName == "Shadow Knight" &&
+            i.QuestItem.Contains("Cell Key") &&
+            i.QuestItem.Contains("Caradon"));
         var settings = new AppSettings
         {
             EpicQuestChecklist =
@@ -197,7 +199,8 @@ public sealed class OptionsViewModelTests
                 item.Clone()
             ],
         };
-        settings.EpicQuestChecklist[0].Source = "old source";
+        settings.EpicQuestChecklist[0].Section = "old section";
+        settings.EpicQuestChecklist[0].QuestItem = "old text";
         settings.EpicQuestChecklist[0].Order = 9999;
         settings.EpicQuestChecklist[0].Acquired = true;
 
@@ -205,7 +208,8 @@ public sealed class OptionsViewModelTests
 
         var refreshed = settings.EpicQuestChecklist.Single(i => i.Id == item.Id);
         Assert.True(refreshed.Acquired);
+        Assert.Equal(item.Section, refreshed.Section);
+        Assert.Equal(item.QuestItem, refreshed.QuestItem);
         Assert.Equal(item.Order, refreshed.Order);
-        Assert.Contains("Plane of Sky", refreshed.Source);
     }
 }

--- a/tests/EQBuddy.Tests/OptionsViewModelTests.cs
+++ b/tests/EQBuddy.Tests/OptionsViewModelTests.cs
@@ -202,6 +202,7 @@ public sealed class OptionsViewModelTests
         settings.EpicQuestChecklist[0].Section = "old section";
         settings.EpicQuestChecklist[0].QuestItem = "old text";
         settings.EpicQuestChecklist[0].Order = 9999;
+        settings.EpicQuestChecklist[0].AvailableInClassic = !item.AvailableInClassic;
         settings.EpicQuestChecklist[0].Acquired = true;
 
         Assert.True(settings.ApplyDefaultEpicQuestChecklist());
@@ -211,5 +212,6 @@ public sealed class OptionsViewModelTests
         Assert.Equal(item.Section, refreshed.Section);
         Assert.Equal(item.QuestItem, refreshed.QuestItem);
         Assert.Equal(item.Order, refreshed.Order);
+        Assert.Equal(item.AvailableInClassic, refreshed.AvailableInClassic);
     }
 }


### PR DESCRIPTION
﻿## Summary

Prototype Epic 1.0 checklist card for EQBuddy.

This is a prototype, feel free to make changes.

## What Changed

- Adds a persistent Epic checklist section/card.
- Seeds class epic checklist rows from EQLWiki-style checklist data.
- Preserves wiki section ordering/details so steps carry short guide text instead of just item names.
- Adds a class tab layout with manual checkboxes and per-class completion state.
- Adds a `Classic-doable only` toggle based on EQLWiki out-of-era metadata.

## Notes

This intentionally starts as manual checklist behavior. Auto-checking can be layered on later once log/inventory signals are trustworthy enough for epic steps.

## Validation

- `.\.dotnet\dotnet.exe build EQBuddy.slnx -c Release`
- `.\.dotnet\dotnet.exe test tests\EQBuddy.Tests\EQBuddy.Tests.csproj -c Release --no-build --logger "console;verbosity=minimal"` - 965 passed on the Epic branch
- `.\.dotnet\dotnet.exe test tests\EQBuddy.Avalonia.Tests\EQBuddy.Avalonia.Tests.csproj -c Release --no-build --logger "console;verbosity=minimal"` - 45 passed

Build warnings were existing analyzer/Avalonia warnings unrelated to this change.
