### PR TITLE
Wine: keep the prefix's own Segoe when it can draw the icons

### DIFF
--- a/src/EQBuddy/WineFonts.cs
+++ b/src/EQBuddy/WineFonts.cs
@@ -24,9 +24,41 @@ internal static class WineFonts
     public static void ApplyIfNeeded(ResourceDictionary appResources)
     {
         if (!IsWine()) return;
+        if (PrefixSegoeDrawsIcons()) return;
         appResources["AppFontFamily"] = new FontFamily(
             new Uri("pack://application:,,,/"),
             "./Fonts/#EQBuddy Sans, Segoe UI Variable Text, Segoe UI");
+    }
+
+    /// <summary>A prefix whose installed "Segoe UI Variable Text" can draw the
+    /// widget's icons gets the authentic look instead of the bundled stand-in —
+    /// Wine players who go to the trouble of installing a Segoe(-alike) with icon
+    /// coverage shouldn't be overruled by it. Two deliberate strictnesses: the
+    /// check names the PRIMARY family specifically, because Wine's DirectWrite
+    /// never walks past the first family in a list, so "Segoe UI" alone would
+    /// still box; and it demands a real icon glyph (💀, the canary), because a
+    /// genuine Segoe copied in without icon coverage would bring the empty boxes
+    /// back — that prefix keeps the bundled font.</summary>
+    private static bool PrefixSegoeDrawsIcons()
+    {
+        try
+        {
+            foreach (var family in Fonts.SystemFontFamilies)
+            {
+                if (!string.Equals(family.Source, "Segoe UI Variable Text",
+                        StringComparison.OrdinalIgnoreCase)) continue;
+                foreach (var typeface in family.GetTypefaces())
+                    if (typeface.TryGetGlyphTypeface(out var glyphs) &&
+                        glyphs.CharacterToGlyphMap.ContainsKey(0x1F480))
+                        return true;
+                return false;
+            }
+        }
+        catch
+        {
+            // Font cosmetics must never stop startup.
+        }
+        return false;
     }
 
     /// <summary>The canonical Wine check: ntdll exports wine_get_version under


### PR DESCRIPTION
Follow-up to #148 (thanks for the fast merge!). Field report from the CrossOver/macOS setup that motivated #148: the bundled font makes everything render, but its Noto base visibly differs from the Segoe look in the README screenshots, and a Wine prefix has no way to opt out — the swap overrules any font the player installs.

This defers to the prefix when it provides a **"Segoe UI Variable Text"** family that can actually draw the icons: check the primary family by name (Wine's DirectWrite never walks past the first family in a list, so "Segoe UI" alone wouldn't help), and require it to map U+1F480 💀 (a genuine Segoe copied in *without* icon coverage would bring the boxes back — that prefix keeps the bundled font). Wine players can then build a Segoe-metric stand-in (e.g. OFL Selawik + the icon subset from scripts/build-icon-font.py sources) and get the authentic look; everyone else is unchanged, and native Windows never takes the path at all.

Verified in a CrossOver 26 bottle: with such a font installed the app renders Segoe-metric text + icons; without it, behavior is identical to v1.86.0. 1363/1363 tests pass.