### PR TITLE
Double-click a mini-bar chip to open/close its breakout (opt-in)

### DIFF
--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -370,6 +370,14 @@ public sealed class AppSettings
     /// (Frankthetankk, discussion #45 — ✕-until-next-minimize made the window a
     /// whack-a-mole).</summary>
     public List<string> DisabledBreakouts { get; set; } = [];
+
+    /// <summary>Double-click a mini-pill chip (dps, hps, pet, loot, watch) to open or
+    /// close its breakout window on demand. Opt-in, off by default. While it's on, a
+    /// breakout closed with its ✕ stays silent — no "hidden, re-enable in Options" alert —
+    /// because a double-click brings it right back (asked for: pop the Loot or DPS window
+    /// up only when you want it, without the nag).</summary>
+    public bool DoubleClickChipsToggleBreakouts { get; set; }
+
     public double BreakoutDamageLeft { get; set; } = double.NaN;
     public double BreakoutDamageTop { get; set; } = double.NaN;
     public string BreakoutDamageScope { get; set; } = "fight";

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -24,6 +24,16 @@ public partial class MainWindow : Window
     private DateTime _lastCheckpoint = DateTime.MinValue;
     private readonly DispatcherTimer _uiTimer;
     private readonly DispatcherTimer _companionPump;
+    // Window-level double-click state for the mini-bar breakout chips (see MiniChip): the
+    // chips are rebuilt every tick, so per-element ClickCount can't be trusted. Threshold
+    // reads the user's own Windows double-click speed; add a floor for a stray zero.
+    private BreakoutKind? _lastChipClickKind;
+    private DateTime _lastChipClickAt = DateTime.MinValue;
+    private static readonly TimeSpan DoubleClickWindow =
+        TimeSpan.FromMilliseconds(Math.Max(200, GetDoubleClickTime()));
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern uint GetDoubleClickTime();
     private DateTime _lastCharScan = DateTime.MinValue;
     private DateTime _lastJanitorRun = DateTime.MinValue;
     private DateTime _lastUpdateCheck = DateTime.MinValue;
@@ -3663,20 +3673,35 @@ public partial class MainWindow : Window
         if (breakout is { } kind && _settings.DoubleClickChipsToggleBreakouts)
         {
             // Transparent (not null) so the gaps between glyph and value are hit-testable
-            // too. Handle EVERY click on the chip (not just the second): the bar's OnDrag
-            // starts a window DragMove on the FIRST click, and that modal drag captured the
-            // mouse and stole the second click, so the double-click never completed — the
-            // cursor flickering into drag mode was the tell. Eating the click here keeps
-            // OnDrag out of it entirely; the widget is still dragged from any non-chip part
-            // of the bar. When the opt-in is off the chip stays inert and a double-click
-            // expands the widget as before.
+            // too. Two things conspired against WPF's own double-click here, so we detect it
+            // ourselves at the window level:
+            //   1. The bar's OnDrag starts a modal window DragMove on the FIRST left-click
+            //      anywhere on the bar; that capture disrupted the click sequence and the
+            //      cursor flickered into drag mode (the tell). Eating the click stops it.
+            //   2. UpdateMiniChips rebuilds these panels every 1s tick, so a rebuild landing
+            //      between the two clicks left the second click on a brand-new element and
+            //      reset ClickCount to 1 — an intermittent miss.
+            // Keying the double-click on (kind, time) on the window survives both: the panel
+            // can be replaced mid-gesture and the second click still lands. The widget is
+            // still dragged from any non-chip part of the bar; when the opt-in is off the
+            // chip stays inert and a double-click expands the widget as before.
             panel.Background = System.Windows.Media.Brushes.Transparent;
             panel.Cursor = System.Windows.Input.Cursors.Hand;
             panel.ToolTip = $"Double-click to show or hide the {kind} breakout";
             panel.MouseLeftButtonDown += (_, e) =>
             {
                 e.Handled = true;
-                if (e.ClickCount == 2) ToggleBreakout(kind);
+                var now = DateTime.Now;
+                if (_lastChipClickKind == kind && now - _lastChipClickAt <= DoubleClickWindow)
+                {
+                    _lastChipClickKind = null;   // consume, so a third click starts fresh
+                    ToggleBreakout(kind);
+                }
+                else
+                {
+                    _lastChipClickKind = kind;
+                    _lastChipClickAt = now;
+                }
             };
         }
         panel.Children.Add(new TextBlock

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -3663,17 +3663,20 @@ public partial class MainWindow : Window
         if (breakout is { } kind && _settings.DoubleClickChipsToggleBreakouts)
         {
             // Transparent (not null) so the gaps between glyph and value are hit-testable
-            // too; Handled on the second click keeps it from reaching OnDrag's expand. When
-            // the opt-in is off the chip stays inert here and a double-click expands the
-            // widget as before.
+            // too. Handle EVERY click on the chip (not just the second): the bar's OnDrag
+            // starts a window DragMove on the FIRST click, and that modal drag captured the
+            // mouse and stole the second click, so the double-click never completed — the
+            // cursor flickering into drag mode was the tell. Eating the click here keeps
+            // OnDrag out of it entirely; the widget is still dragged from any non-chip part
+            // of the bar. When the opt-in is off the chip stays inert and a double-click
+            // expands the widget as before.
             panel.Background = System.Windows.Media.Brushes.Transparent;
             panel.Cursor = System.Windows.Input.Cursors.Hand;
             panel.ToolTip = $"Double-click to show or hide the {kind} breakout";
             panel.MouseLeftButtonDown += (_, e) =>
             {
-                if (e.ClickCount != 2) return;
                 e.Handled = true;
-                ToggleBreakout(kind);
+                if (e.ClickCount == 2) ToggleBreakout(kind);
             };
         }
         panel.Children.Add(new TextBlock

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -3614,11 +3614,14 @@ public partial class MainWindow : Window
                         if (!_settings.DisabledBreakouts.Contains(k.ToString()))
                             _settings.DisabledBreakouts.Add(k.ToString());
                         _settings.Save();
-                        // The ✕ is a small target floating over a game screen, and until
-                        // now the only trace of hitting it was a window that quietly never
-                        // came back — David lost his DPS breakout to exactly that
-                        // (2026-08-08) with no way to reconstruct when or how. A permanent
-                        // state change must announce itself, and leave a timestamp behind.
+                        // With double-click-toggle on, the ✕ is no longer a one-way trap —
+                        // a double-click on the chip brings the window straight back — so the
+                        // nag and its log entry would just be noise. Off, they stay: the ✕ is
+                        // a small target over a game screen, and until the alert existed the
+                        // only trace of hitting it was a window that quietly never came back
+                        // (David lost his DPS breakout to exactly that, 2026-08-08). A
+                        // permanent, hard-to-reverse state change must announce itself.
+                        if (_settings.DoubleClickChipsToggleBreakouts) return;
                         AlertTile.ShowAlert($"{k} breakout hidden — re-enable in ⚙ Options → Breakout windows");
                         CoreLog.Error($"{k} breakout hidden via its ✕ (re-enable: Options → Breakout windows)");
                     };
@@ -3634,13 +3637,45 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>Toggle a stat's breakout window from its mini chip: show it if hidden,
+    /// hide it if showing. Rides the same persistent DisabledBreakouts flag the ✕ uses,
+    /// so the choice sticks and UpdateBreakouts applies it on the spot — a
+    /// double-click is just a friendlier reach for it than the ✕ or Options
+    /// (asked for: "let me pop the DPS or Loot window up only when I want it").</summary>
+    private void ToggleBreakout(BreakoutKind kind)
+    {
+        var name = kind.ToString();
+        if (!_settings.DisabledBreakouts.Remove(name))
+            _settings.DisabledBreakouts.Add(name);
+        _settings.Save();
+        if (_latestSnapshot is { } snap) UpdateBreakouts(snap);
+    }
+
     /// <summary>One mini-dashboard stat (2026-08-11, take two — David: no ovals):
     /// glyph + semibold tabular value as clean text, separated from its neighbor by
     /// a thin hairline divider rather than any chip chrome. A counting-down watch
-    /// rule still announces itself by color alone.</summary>
-    private StackPanel MiniChip(string glyph, string value, string valueBrush, string? edgeBrush = null)
+    /// rule still announces itself by color alone. A chip whose stat has a breakout
+    /// window takes a double-click to toggle it.</summary>
+    private StackPanel MiniChip(string glyph, string value, string valueBrush, string? edgeBrush = null,
+        BreakoutKind? breakout = null)
     {
         var panel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 10, 0) };
+        if (breakout is { } kind && _settings.DoubleClickChipsToggleBreakouts)
+        {
+            // Transparent (not null) so the gaps between glyph and value are hit-testable
+            // too; Handled on the second click keeps it from reaching OnDrag's expand. When
+            // the opt-in is off the chip stays inert here and a double-click expands the
+            // widget as before.
+            panel.Background = System.Windows.Media.Brushes.Transparent;
+            panel.Cursor = System.Windows.Input.Cursors.Hand;
+            panel.ToolTip = $"Double-click to show or hide the {kind} breakout";
+            panel.MouseLeftButtonDown += (_, e) =>
+            {
+                if (e.ClickCount != 2) return;
+                e.Handled = true;
+                ToggleBreakout(kind);
+            };
+        }
         panel.Children.Add(new TextBlock
         {
             Text = glyph, FontSize = 11.5, Opacity = 0.9,
@@ -3693,7 +3728,15 @@ public partial class MainWindow : Window
                 "deaths" => ("☠", $"{s.Deaths.Count}"),
                 _ => ("", ""),
             };
-            MiniChips.Children.Add(MiniChip(glyph, text, "AccentBrush"));
+            BreakoutKind? breakout = key switch
+            {
+                "dps" => BreakoutKind.Damage,
+                "hps" => BreakoutKind.Healing,
+                "pet" => BreakoutKind.Pet,
+                "loot" => BreakoutKind.Loot,
+                _ => null,   // kills/procs/motes/money/xp/deaths have no breakout
+            };
+            MiniChips.Children.Add(MiniChip(glyph, text, "AccentBrush", breakout: breakout));
         }
 
         // Per-rule pins: only the rules you picked (📌 in Options), not every enabled one.
@@ -3711,8 +3754,9 @@ public partial class MainWindow : Window
             // A counting-down chip wears the warn edge too — state has a shape.
             MiniChips.Children.Add(counting
                 ? MiniChip("⏳", $"{name} {EQBuddy.UI.Shared.Countdown.Format(at - DateTime.Now)}",
-                    "WarnBrush", edgeBrush: "WarnBrush")
-                : MiniChip("🎯", $"{name} {result?.TotalQuantity ?? 0}", "AccentBrush"));
+                    "WarnBrush", edgeBrush: "WarnBrush", breakout: BreakoutKind.Watch)
+                : MiniChip("🎯", $"{name} {result?.TotalQuantity ?? 0}", "AccentBrush",
+                    breakout: BreakoutKind.Watch));
         }
 
         TrimLastMiniDivider(MiniChips);

--- a/src/EQBuddy/OptionsWindow.xaml
+++ b/src/EQBuddy/OptionsWindow.xaml
@@ -378,6 +378,14 @@
                        Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="0,0,0,2"/>
             <WrapPanel x:Name="BreakoutsPanel"/>
 
+            <CheckBox x:Name="DoubleClickChipsCheck" Margin="0,10,0,0"
+                      Checked="OnDoubleClickChipsToggled" Unchecked="OnDoubleClickChipsToggled">
+                <TextBlock Text="Double-click a mini-pill chip to open/close its breakout" FontSize="12"
+                           Foreground="{DynamicResource TextBrush}"/>
+            </CheckBox>
+            <TextBlock Text="With this on, double-click the 🎒 Loot, ⚔ dps, ✚ hps, 🐾 pet or 🎯 watch chip to pop its window up or dismiss it — and closing one with its ✕ stays quiet, since a double-click brings it right back."
+                       Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="0,0,0,2"/>
+
             <CheckBox x:Name="TargetDropsCheck" Margin="0,12,0,0"
                       Checked="OnTargetDropsToggled" Unchecked="OnTargetDropsToggled">
                 <TextBlock Text="🎯 Show target drops in the Loot card" FontSize="12"

--- a/src/EQBuddy/OptionsWindow.xaml.cs
+++ b/src/EQBuddy/OptionsWindow.xaml.cs
@@ -53,6 +53,7 @@ public partial class OptionsWindow : Window
         SpawnGrowUpCheck.IsChecked = _vm.SpawnChipsGrowUp;
         MezGrowUpCheck.IsChecked = _vm.MezChipsGrowUp;
         MezChipsCheck.IsChecked = _main.Settings.MezChipsEnabled;
+        DoubleClickChipsCheck.IsChecked = _main.Settings.DoubleClickChipsToggleBreakouts;
         SlowAlertCheck.IsChecked = _main.Settings.SlowAlertEnabled;
         SlowSpokenCheck.IsChecked = _main.Settings.SlowAlertSpoken;
         SlowRaidOnlyCheck.IsChecked = _main.Settings.SlowAlertRaidOnly;
@@ -194,6 +195,13 @@ public partial class OptionsWindow : Window
     {
         if (!_ready) return;
         _main.Settings.MezChipsEnabled = MezChipsCheck.IsChecked == true;
+        _main.Settings.Save();
+    }
+
+    private void OnDoubleClickChipsToggled(object sender, RoutedEventArgs e)
+    {
+        if (!_ready) return;
+        _main.Settings.DoubleClickChipsToggleBreakouts = DoubleClickChipsCheck.IsChecked == true;
         _main.Settings.Save();
     }
 


### PR DESCRIPTION
Double-click a mini-bar chip to open/close its breakout window (opt-in)

## Why

When the widget is minimized to the mini bar, getting an expanded view of a stat
means either keeping its breakout window always on, or going through Options. This
adds a quality-of-life shortcut: double-click a mini-bar pill to pop its breakout
open, and double-click again (or use the window's ✕) to dismiss it — a quick way to
get the expanded view straight from the small one, without leaving breakout windows
up all the time. It's opt-in for people who prefer their current behavior, and it's
intended as the foundation for more double-click pop-out views along the same lines.

## Changes

**Opt-in setting.** `AppSettings.DoubleClickChipsToggleBreakouts` (default **off**)
plus a checkbox in Options → Breakout windows. With it off, nothing changes.

**Window-level double-click detection that survives the chip rebuild.**
The mini chips are cleared and rebuilt every one-second UI tick, so a rebuild
landing between the two clicks left the second click on a brand-new element and
reset WPF's per-element `ClickCount` — an intermittent miss. Detection is now keyed
on (which chip, time) at the window level, using the user's own Windows
double-click speed (`GetDoubleClickTime`), so it survives the panel being replaced
mid-gesture.

**Drag-safe.** The mini bar is draggable, and a single left-click anywhere on it
starts a window `DragMove`; that modal drag was capturing the mouse and stealing the
second click (the cursor visibly flickered into drag mode). Breakout chips now eat
their own clicks so the drag never starts on them; the widget still drags from any
non-chip part of the bar.

**No dismiss nag when the opt-in is on.** Closing a breakout by its ✕ normally warns
that it's hidden (re-enable in Options), because that used to be a one-way trap. With
double-click-toggle on, a double-click brings it straight back, so the warning is
suppressed. With the setting off, the warning stays exactly as before.

## Notes
- Windows/WPF only in effect; inert when the setting is off (the default).
- Player-visible; I've left `WhatsNew.json` / the version bump to you to place in
  your own voice on release.
