### PR TITLE
Alert sound: add a (Disabled) choice to silence alerts

### DIFF
--- a/src/EQBuddy.UI.Shared/OptionsViewModel.cs
+++ b/src/EQBuddy.UI.Shared/OptionsViewModel.cs
@@ -260,26 +260,42 @@ public sealed class OptionsViewModel : INotifyPropertyChanged
     }
 
     // ---- alert sound ----
+    /// <summary>First entry of the sound picker: no alert sound at all. The volume slider
+    /// floors at 10%, so this is the only way to silence alerts outright — and it's the
+    /// honest choice on a platform whose built-in sound files aren't present (Wine ships
+    /// none of the Windows Media clips, so every built-in there plays nothing anyway).
+    /// Stored as AlertSoundCatalog.OffChoice, which the sound planner already reads as
+    /// "play nothing".</summary>
+    public const string DisabledSoundChoice = "(Disabled)";
     public const string CustomSoundChoice = "Custom file…";
     public static readonly string[] SoundChoices =
-        [.. AlertSoundCatalog.Names.Select(n => n == "Ding" ? $"{n} (default)" : n), CustomSoundChoice];
+        [DisabledSoundChoice, .. AlertSoundCatalog.Names.Select(n => n == "Ding" ? $"{n} (default)" : n), CustomSoundChoice];
 
-    /// <summary>Index into SoundChoices for the current setting (the custom slot for paths).</summary>
+    // Picker layout: 0 = Disabled, 1..Names.Length = built-ins, last = Custom.
+    private static bool IsOff(string? choice) =>
+        string.Equals((choice ?? "").Trim(), AlertSoundCatalog.OffChoice, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Index into SoundChoices for the current setting (0 = Disabled, last = the
+    /// custom slot for paths).</summary>
     public int SoundIndex
     {
         get
         {
+            if (IsOff(_settings.AlertSound)) return 0;
             var i = Array.IndexOf(AlertSoundCatalog.Names, AlertSoundCatalog.Normalize(_settings.AlertSound));
-            return i >= 0 ? i : AlertSoundCatalog.Names.Length;
+            return i >= 0 ? i + 1 : AlertSoundCatalog.Names.Length + 1;
         }
     }
 
-    public bool IsCustomSoundIndex(int index) => index >= AlertSoundCatalog.Names.Length;
+    public bool IsDisabledSoundIndex(int index) => index == 0;
+    public bool IsCustomSoundIndex(int index) => index >= AlertSoundCatalog.Names.Length + 1;
 
     public void SelectNamedSound(int index)
     {
         if (IsCustomSoundIndex(index)) return;
-        _settings.AlertSound = AlertSoundCatalog.Names[index];
+        _settings.AlertSound = IsDisabledSoundIndex(index)
+            ? AlertSoundCatalog.OffChoice
+            : AlertSoundCatalog.Names[index - 1];
         PersistAnd(nameof(SoundFileNote));
     }
 

--- a/tests/EQBuddy.Tests/OptionsViewModelTests.cs
+++ b/tests/EQBuddy.Tests/OptionsViewModelTests.cs
@@ -29,17 +29,34 @@ public sealed class OptionsViewModelTests
     [Fact]
     public void SoundSelectionHandlesLegacyNamesAndCustomPaths()
     {
+        // Index 0 is now the "(Disabled)" slot, so built-ins sit one higher and the custom
+        // slot is Names.Length + 1.
         var (vm, s, _) = Create(new AppSettings { AlertSound = "Question" });
-        Assert.Equal(Array.IndexOf(AlertSoundCatalog.Names, "Notify"), vm.SoundIndex);   // legacy maps
+        Assert.Equal(Array.IndexOf(AlertSoundCatalog.Names, "Notify") + 1, vm.SoundIndex);   // legacy maps
         Assert.Equal("", vm.SoundFileNote);
 
         vm.SetCustomSound(@"C:\sounds\gong.wav");
-        Assert.Equal(AlertSoundCatalog.Names.Length, vm.SoundIndex);                     // custom slot
+        Assert.Equal(AlertSoundCatalog.Names.Length + 1, vm.SoundIndex);                     // custom slot
         Assert.Contains("gong.wav", vm.SoundFileNote);
 
-        vm.SelectNamedSound(0);
+        vm.SelectNamedSound(1);                                                              // first built-in
         Assert.Equal(AlertSoundCatalog.Names[0], s.AlertSound);
-        Assert.True(vm.IsCustomSoundIndex(AlertSoundCatalog.Names.Length));
+        Assert.True(vm.IsCustomSoundIndex(AlertSoundCatalog.Names.Length + 1));
+    }
+
+    [Fact]
+    public void DisabledSoundChoiceSilencesAlerts()
+    {
+        var (vm, s, _) = Create(new AppSettings { AlertSound = "Ding" });
+
+        vm.SelectNamedSound(0);   // the "(Disabled)" slot
+        Assert.Equal(AlertSoundCatalog.OffChoice, s.AlertSound);
+        Assert.Equal(0, vm.SoundIndex);
+        Assert.True(vm.IsDisabledSoundIndex(0));
+
+        // And a settings.json already holding "Off" lands back on the Disabled slot.
+        var (vm2, _, _) = Create(new AppSettings { AlertSound = "Off" });
+        Assert.Equal(0, vm2.SoundIndex);
     }
 
     [Fact]


### PR DESCRIPTION
## Why

The alert-sound picker had no way to turn sound off. The volume slider floors at 10%, and only per-rule sounds had an "Off" — so from the main picker, 10% was the quietest you could get.

## Change

Adds **`(Disabled)`** as the first entry of the shared sound dropdown, stored as `AlertSoundCatalog.OffChoice` (which the sound planner already renders as silence). Both the WPF and Avalonia Options windows call the same view-model methods, so the change is entirely in `OptionsViewModel`: the picker shifts by one (`0 = Disabled`, built-ins `1..N`, custom last) and `SoundIndex`/`SelectNamedSound`/`IsCustomSoundIndex` account for it. A unit test covers the new slot and that a settings file already holding `"Off"` lands back on it.

Defaults are unchanged (Ding), so this is purely additive.

## Notes
Player-visible — `WhatsNew.json`/version left to you.
