### PR TITLE
Breakout styling on the compact strip, plus charm, focus and input fixes

### DIFF
--- a/docs/TestPlan.md
+++ b/docs/TestPlan.md
@@ -51,6 +51,7 @@ Audited at **v1.82.0 (2026-08-14)**: 1,317 unit + 45 Avalonia + 6 E2E, all green
 | **A charm cast from an ITEM still reports how long it held**: a clicky prints no casting line, so the per-spell arm window has nothing to key on — the pet's own caster-only "Master" tell starts the clock at the landing (#135, charm7.txt, the sixth distinct cause in that thread) | **Auto** — `SpellTrackingTests` |
 | **The landing line alone still claims nothing**: "has been charmed." names no caster and prints for a bystander's charm, so it is remembered and never believed until the tell names the same creature | **Auto** — `SpellTrackingTests` |
 | **An auto-sold pickup ("looted … and sold it for …") is not session loot**: dismissed at the corpse, it appears in no loot view and never touches the inventory overlay — it is vendor income, and the per-creature drop ledger (wiki packs, Target drops) still credits the mob. Watch rules still count it: a watched pattern is explicit interest | **Auto** — `SessionStatsTests`, `InventoryFileTests`, `JournalTests` |
+| **Both builds' Progress cards say the same thing**: header ("12.3% xp, +1 lvl (3 new), +2 aa") and pace summary come from one builder (`UI.Shared/ProgressText`); each ding is paced from the previous one, and the "(N new)" cue is omitted when a level unlocked nothing | **Auto** — `ProgressTextTests` |
 | **Every one of the sixteen classes can produce class evidence**, so an inference can always be argued back down (#120) | **Auto** — `ClassInferenceTests` |
 | Class evidence decays with a 10-minute half-life: a swap converges on what is being played now, and silence alone never flips a reading | **Auto** — `ClassInferenceTests` |
 | A class is named only from 3+ sightings, with two distinct spells where an item could have cast them, and a 2× lead — otherwise **no** inference | **Auto** — `ClassInferenceTests` |
@@ -149,6 +150,8 @@ Audited at **v1.82.0 (2026-08-14)**: 1,317 unit + 45 Avalonia + 6 E2E, all green
 | **Nothing on a timer may change the widget's measured size.** The title-bar CPU/memory readout formats to a fixed shape and its label reserves a fixed width, so a new sample repaints and never asks the windowing system to resize | **Auto** — `PerfReadoutTests`, `WidgetRenderTests` (#173) |
 | The readout stays off by default and costs no title-bar width until it is turned on | **Auto** — `WidgetRenderTests` (#112) |
 | That an always-on-top widget resizing does not disturb a fullscreen game underneath | **Manual** — §6 item 10; no headless test can see it |
+| **The breakout windows never take focus when the minimize pass shows them** — the star was clicked minutes ago; the show happens mid-fight, so both UIs' breakouts declare `ShowActivated` false like every other unprompted surface | **Auto** — `OverlayActivationTests` (source scan, both UIs) |
+| Clicking or dragging a WPF chip stack does not activate it either (`WS_EX_NOACTIVATE`, as the alert tile has always had) | **Manual** — the ex-style is applied in `NoActivate.cs`; only a live desktop shows focus |
 
 ## 4e. The design system
 

--- a/src/EQBuddy.Avalonia/BreakoutWindow.cs
+++ b/src/EQBuddy.Avalonia/BreakoutWindow.cs
@@ -71,6 +71,11 @@ public sealed class BreakoutWindow : Window
         Background = Brushes.Transparent;
         Topmost = true;
         ShowInTaskbar = false;
+        // Auto-shown on the minimize pass, not by a click — without this, the first
+        // Show() activates the window and yanks keyboard focus off the game mid-fight
+        // (same bug the WPF chip stacks carried; every other auto-shown overlay
+        // already declares it).
+        ShowActivated = false;
         CanResize = false;
 
         _title.FontSize = 13;

--- a/src/EQBuddy.Avalonia/LootCardView.cs
+++ b/src/EQBuddy.Avalonia/LootCardView.cs
@@ -203,7 +203,7 @@ internal sealed class LootCardView
             {
                 Text = tip,
                 TextWrapping = TextWrapping.Wrap,
-                MaxWidth = TipWidth,
+                MaxWidth = DesignTokens.TipWidth,
                 Foreground = AppTheme.BrushFor("TextBrush"),
             };
             // Multi-line tips are stat blocks — monospace keeps their columns readable.
@@ -260,7 +260,4 @@ internal sealed class LootCardView
     private static readonly double MetadataSize =
         DesignTokens.Spec(DesignTokens.TypeRole.Metadata).Size;
 
-    /// <summary>How wide a stat-block tooltip may get before it wraps — the width at which
-    /// a monospace item block stops being a column and starts being a paragraph.</summary>
-    private const double TipWidth = 340;
 }

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -1900,7 +1900,9 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
         UpdateGearChecklist(s);
         UpdateEpicQuestChecklist(s);
         _moneyHeader.Text = StatsSnapshot.FormatCoin(s.Copper);
-        _progressHeader.Text = $"{s.XpPercent:0.0}% xp" + (s.Levels.Count > 0 ? $", +{s.Levels.Count} lvl" : "") + (s.AaGained > 0 ? $", +{s.AaGained} aa" : "");
+        // The ding cue in the header, same as WPF now — this build's header predated
+        // the cue even though its card body has listed the unlocks all along.
+        _progressHeader.Text = ProgressText.Header(s, DingUnlocks(s).Count);
         _factionHeader.Text = s.Faction.Count > 0 ? $"{s.Faction.Count} factions" : "-";
         _miscHeader.Text = $"{s.Deaths.Count} death{(s.Deaths.Count == 1 ? "" : "s")}";
     }
@@ -2085,18 +2087,9 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
         }
         if (_sections["progress"].IsExpanded)
         {
-            _progressSummary.Text = $"{s.XpTicks} xp gains - {s.XpPerHour:0.0}%/hr - {s.XpPerActiveHour:0.0}% active - {s.SkillUpTotal} skill-ups" +
-                (s.Recent is { } rx ? $"\nLast {(int)rx.Window.TotalMinutes}m: {rx.XpPerHour:0.0}%/hr" : "") +
-                (s.AaGained > 0 ? $"\n{s.AaGained} AA point{(s.AaGained == 1 ? "" : "s")} - {s.AaPerHour:0.0} AA/hr (now {s.AaTotal} unspent)" : "") +
-                (s.HoursToLevel is { } eta ? $"\nNext level in {FormatEta(eta)} at this pace" : "") +
-                (s.Levels.Count > 0
-                    ? "\n" + string.Join(", ", s.Levels.Select((l, i) =>
-                    {
-                        var from = i == 0 ? s.SessionStart : s.Levels[i - 1].Time;
-                        var mins = from is { } f ? (int)(l.Time - f).TotalMinutes : 0;
-                        return $"{l.Text} at {l.Time:h:mm tt} ({mins}m)";
-                    }))
-                    : "");
+            // The shared builder with this build's plain-ASCII separator ("-", the
+            // file's own convention under fonts Wine/Linux may lack).
+            _progressSummary.Text = ProgressText.Summary(s, " - ");
             // Ding: the AA group in its category order (labeled, not guessed — the wiki
             // doesn't say which classes they cover); the Spells grouping follows, its
             // rows marked "… spell".
@@ -2132,9 +2125,7 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
             // AA display, rethought (Reddit, 2026-08-11: "is it supposed to just show
             // newly learned this session?" — yes, now it is): session-new AAs lead,
             // the full ledger folds behind a click, same idiom as Pet abilities.
-            var newAas = s.SessionStart is { } sess
-                ? s.AaAbilities.Where(a => a.Time >= sess).ToList()
-                : [];
+            var newAas = ProgressText.SessionNewAas(s);
             _aaNewLabel.IsVisible = newAas.Count > 0;
             _aaNewList.IsVisible = _aaNewLabel.IsVisible;
             FillList(_aaNewList, newAas.Select(a =>
@@ -3176,10 +3167,6 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
         if (_miniChips.Children.Count == 0)
             _miniChips.Children.Add(AppTheme.DimText("* star stats in full view"));
     }
-
-    // The shared one, as WPF already did. This was a verbatim copy — identical today,
-    // which is exactly when a duplicate is cheapest to remove and hardest to notice.
-    private static string FormatEta(double hours) => ProgressPresentation.FormatEta(hours);
 
     private void OnOptions(object? sender, EventArgs e)
     {

--- a/src/EQBuddy.Avalonia/SpawnsWindow.cs
+++ b/src/EQBuddy.Avalonia/SpawnsWindow.cs
@@ -283,12 +283,17 @@ public sealed class SpawnsWindow : Window
             // regress week-long raid targets.
             var duration = DarkBox(row.DurationText,
                 "Respawn time: 22 (minutes), 90s, 12h, 3d, 3d 12h, 6:40 — your edit persists and outranks the catalog");
-            duration.LostFocus += (_, _) =>
+            void CommitDuration()
             {
                 if ((duration.Text ?? "").Trim() == row.DurationText) return;
                 _vm.SetDuration(row.Zone, row.Name, duration.Text ?? "");
                 Kick();
-            };
+            }
+            duration.LostFocus += (_, _) => CommitDuration();
+            // Enter commits too, as it always has on Windows — alt-tabbing back to the
+            // game without clicking elsewhere must not silently drop the typed value
+            // (review catch, 2026-08-18).
+            duration.KeyDown += (_, e) => { if (e.Key == Key.Enter) CommitDuration(); };
             Grid.SetColumn(duration, 2);
             grid.Children.Add(duration);
 

--- a/src/EQBuddy.Core/CharmTracker.cs
+++ b/src/EQBuddy.Core/CharmTracker.cs
@@ -199,6 +199,7 @@ internal sealed class CharmTracker(SpellCatalog spells)
             // bystander's charm.
             if (category == SpellCategory.Charm && ch.Time - cast.Time <= ArmWindow(cast.Spell))
             {
+                EndTenureIfRenaming(name, ch.Time);   // a chain-charm ends the old tenure whole
                 ConfirmPet(name);
                 _hold = (name, ch.Time);   // #130
                 return true;
@@ -251,6 +252,7 @@ internal sealed class CharmTracker(SpellCatalog spells)
         // provisional — the attack-order tell confirms and merges, never loses.
         if (glazed.Time - cast.Time <= ArmWindow(cast.Spell))
         {
+            EndTenureIfRenaming(glazed.Target, glazed.Time);
             ConfirmPet(glazed.Target);
             _hold = (glazed.Target, glazed.Time);   // #130
             return true;
@@ -281,6 +283,7 @@ internal sealed class CharmTracker(SpellCatalog spells)
             // cast completed gets the provisional treatment below instead.
             if (category == SpellCategory.Charm && pb.Time - cast.Time <= ArmWindow(cast.Spell))
             {
+                EndTenureIfRenaming(blinked, pb.Time);
                 ConfirmPet(blinked);
                 _hold = (blinked, pb.Time);   // #130
                 return new BlinkOutcome(ConsumedCast: true, Ambient: true);
@@ -290,6 +293,35 @@ internal sealed class CharmTracker(SpellCatalog spells)
             // the provisional state.
             if (category == SpellCategory.Charm && pb.Weak)
                 return new BlinkOutcome(false, Ambient: true);
+            // Outside the window but our charm cast IS still recent: the strong blink
+            // degrades to the provisional "Pet?" state — the landing path's own contract,
+            // and what the comment above always promised. The assignment was missing
+            // (review catch, 2026-08-18): CharmedSince stayed null down this path, so the
+            // eventual fade had no landing time to measure a hold from. This method
+            // RENAMES the pet unconditionally below, so the clock has to move with the
+            // name — see EndTenureIfRenaming for the whole of what that means.
+            if (category == SpellCategory.Charm)
+            {
+                if (_petName is not null
+                    && string.Equals(_petName, blinked, StringComparison.OrdinalIgnoreCase))
+                {
+                    // A refresh blink for the pet we ALREADY track: with a clock running
+                    // it is a true no-op — the clock holds and a confirmed identity is
+                    // not re-doubted (the tail would demote it to "Pet?" and misfile its
+                    // damage until the next tell re-proved what was never in question).
+                    // WITHOUT a clock (a tell-only confirmation whose candidate aged
+                    // out — Codex, 2026-08-18) it supplies the missing landing time.
+                    if (CharmedSince is null) _provisional = (blinked, pb.Time);
+                    return new BlinkOutcome(false, Ambient: true);
+                }
+                // A chain-charm onto a DIFFERENT creature: the old tenure ends first —
+                // whole, echo-armed — then the new clock starts at this landing (#130).
+                EndTenureIfRenaming(blinked, pb.Time);
+                _provisional = (blinked, pb.Time);
+                _petName = blinked;
+                _petConfirmed = false;
+                return new BlinkOutcome(false, Ambient: false);
+            }
             // Unrecognised spell: hold onto it so a following "Master" tell can teach us
             // it was a charm.
             if (category == SpellCategory.Unknown)
@@ -304,9 +336,15 @@ internal sealed class CharmTracker(SpellCatalog spells)
         else
         {
             // A strong blink with no cast behind it: the item-clicky case again (#135).
-            // Remembered, not claimed — the tell decides.
+            // Remembered, not claimed — the tell decides. Tenure bookkeeping FIRST: a
+            // candidate still naming the OLD pet would block this landing's candidacy
+            // (Codex, round 2).
+            EndTenureIfRenaming(blinked, pb.Time);
             _candidate ??= (null, pb.Time, blinked);
         }
+        // These branches rename too (upstream's tail, kept): a DIFFERENT name still
+        // ends the old tenure first, or the old hold answers for the new name.
+        EndTenureIfRenaming(blinked, pb.Time);
         _petName = blinked;
         _petConfirmed = false;
         return new BlinkOutcome(false, Ambient: false);
@@ -346,6 +384,11 @@ internal sealed class CharmTracker(SpellCatalog spells)
                 // rows say "Pet?" precisely because they might be wrong.
                 _petName = null;
                 _petConfirmed = false;
+                // The whole tenure ends with the disproof — a surviving /pet hold or
+                // same-name proof from the disproved pet would suppress real break
+                // detection on whatever we charm next (Codex, round 2).
+                _petHeldSince = null;
+                _sameNameProofAt = null;
                 if (_hold is { } hold && string.Equals(
                         hold.Pet, disproved, StringComparison.OrdinalIgnoreCase))
                     _hold = null;
@@ -366,6 +409,12 @@ internal sealed class CharmTracker(SpellCatalog spells)
         // The claim must name the same creature the line did; a claim about a different
         // pet proves nothing about that cast.
         var claimed = LogParser.Normalize(pc.PetName);
+        // The tell names OUR pet with certainty. If we tracked a DIFFERENT creature,
+        // the landing path conservatively ignored the swap (a landing line is
+        // bystander-visible), so this is where the old tenure ends (Codex, 2026-08-18)
+        // — before the promotions below, which must not hand the new pet the old
+        // pet's landing time through their `_hold ??=`.
+        EndTenureIfRenaming(claimed, pc.Time);
         if (_candidate is { } cand && pc.Time - cand.Time <= BlinkToClaim
             && string.Equals(cand.Pet, claimed, StringComparison.OrdinalIgnoreCase))
         {
@@ -414,6 +463,37 @@ internal sealed class CharmTracker(SpellCatalog spells)
 
     /// <summary>Attacker AND target share the pet's name: there are two of them.</summary>
     public void NoteSameNameProof(DateTime at) => _sameNameProofAt = at;
+
+    /// <summary>A line is about to rename the pet to a DIFFERENT creature — a landing,
+    /// a chain-charm's blink, a candidate swap, a tell naming a new pet. The old pet's
+    /// tenure state ends FIRST, as one group: hold, provisional, same-name proof, the
+    /// /pet hold order, and a candidate still naming the old pet (which could never be
+    /// promoted honestly and would block the new landing's own candidacy). Two
+    /// independent reviews converged here from opposite directions (2026-08-18): five
+    /// hand-scoped partial cleanups at rename sites each missed fields that belong
+    /// together — a stale /pet hold from the old pet even suppressed real break
+    /// detection on the new one forever, since PetHeldAt compares no names.
+    ///
+    /// Deliberately NOT RecordBreak: a rename-created ledger entry armed the fade-echo
+    /// window, which is name-agnostic — it swallowed the NEW pet's own real fade for
+    /// ten seconds and labeled it with the old pet's hold (Codex, round 2). The cost of
+    /// this direction is narrower and documented: the OLD charm's delayed TARGETLESS
+    /// fade (Befriend Animal's shape, inside the skew window, mid-chain-charm) can
+    /// close the new clock early. That wrong self-corrects on the next landing; the
+    /// other wrong silently kept claiming a pet that had left.</summary>
+    private void EndTenureIfRenaming(string newName, DateTime at)
+    {
+        if (_petName is null
+            || string.Equals(_petName, newName, StringComparison.OrdinalIgnoreCase))
+            return;
+        _hold = null;
+        _provisional = null;
+        _sameNameProofAt = null;
+        _petHeldSince = null;
+        if (_candidate is { } stale
+            && string.Equals(stale.Pet, _petName, StringComparison.OrdinalIgnoreCase))
+            _candidate = null;
+    }
 
     /// <summary>Is this wear-off line the end of OUR charm? Two shapes: one naming the
     /// pet, and Befriend Animal's, which names no target at all ("Your charm spell has

--- a/src/EQBuddy.Core/MezTracker.cs
+++ b/src/EQBuddy.Core/MezTracker.cs
@@ -246,6 +246,7 @@ public sealed class MezTracker
                     _lastCastOf.Clear();
                     _awake.Clear();
                     _recentMezResists.Clear();
+                    _unpairedBreaks.Clear();
                     break;
             }
             Prune(evt.Time);
@@ -470,6 +471,13 @@ public sealed class MezTracker
                      .Where(kv => now - kv.Value > CastToLand)
                      .Select(kv => kv.Key).ToList())
             _recentMezResists.Remove(stale);
+        // A pairing token outside its 2 s window is dead by definition — without this
+        // sweep the ledger kept one entry per mob name for the PROCESS lifetime, the
+        // one dictionary in this class nothing ever emptied (review catch, 2026-08-18).
+        foreach (var stale in _unpairedBreaks
+                     .Where(kv => (now - kv.Value.At).Duration() > BreakPairWindow)
+                     .Select(kv => kv.Key).ToList())
+            _unpairedBreaks.Remove(stale);
         // Entries are RETAINED well past their visible expiry (Snapshot hides them
         // after ExpiryLinger): a rank-lengthened mez can fade long after the base
         // duration, and the natural-fade line must still find its entry to learn

--- a/src/EQBuddy.UI.Shared/ChipStyle.cs
+++ b/src/EQBuddy.UI.Shared/ChipStyle.cs
@@ -40,6 +40,42 @@ public static class ChipStyle
     /// must not compete with the content it filters.</summary>
     public const DesignTokens.TypeRole LabelRole = DesignTokens.TypeRole.Caption;
 
+    /// <summary>The dense variant for the breakout windows, and it is NOT a shrunken
+    /// pill: it is the Target|Session toggle's own vocabulary, the compact segmented
+    /// control that chrome already established (LW, 2026-08-18 — "use the style
+    /// already used by target/session"). Segments sit flush inside one hairline
+    /// group frame; unselected wears no fill at all; selected gets the toggle
+    /// highlight wash with accent text. Same bookkeeping, same tooltips, a fraction
+    /// of the card pill's weight — right for a ~270px window where the strip must
+    /// not compete with the rows it filters.</summary>
+    public static readonly (double Left, double Top, double Right, double Bottom) CompactPadding =
+        (DesignTokens.SpaceS, 1, DesignTokens.SpaceS, 1);
+
+    /// <summary>Compact chips label in Metadata — the size the scope toggle's own
+    /// segments render at, so the two controls read as one family.</summary>
+    public const DesignTokens.TypeRole CompactLabelRole = DesignTokens.TypeRole.Metadata;
+
+    /// <summary>The group frame's (and each segment highlight's) radius — the scope
+    /// toggle's own.</summary>
+    public const double CompactRadius = DesignTokens.RadiusControl;
+
+    /// <summary>"No brush at all" — a compact segment paints no fill and no edge of
+    /// its own; the group's shared hairline frame is the only chrome. Each UI maps
+    /// this to its transparent brush.</summary>
+    public const string None = "";
+
+    /// <summary>Compact ink: the scope toggle's states. Selected = the toggle
+    /// highlight wash under accent text (the one thing on the strip carrying accent,
+    /// §2.1's discipline); unselected = dim text on nothing.</summary>
+    public static Ink ForCompact(bool selected) => selected
+        ? new("ToggleHighlightBrush", None, "AccentBrush", "AccentBrush", 0.85)
+        : new(None, None, "DimBrush", "DimBrush", 1.0);
+
+    /// <summary>Hairline dividers between compact segments (LW, 2026-08-18): the split
+    /// the frame's own border implies, drawn — inset from the frame's rounded corners
+    /// by this much so a divider never touches the curve.</summary>
+    public const double CompactDividerInset = DesignTokens.SpaceXxs;
+
     /// <summary>The optional trailing count ("0 / 486").</summary>
     public const DesignTokens.TypeRole BadgeRole = DesignTokens.TypeRole.Metadata;
 

--- a/src/EQBuddy.UI.Shared/DesignTokens.cs
+++ b/src/EQBuddy.UI.Shared/DesignTokens.cs
@@ -101,6 +101,14 @@ public static class DesignTokens
     /// no — this is a rounded rect at the height of one, not a capsule.</summary>
     public const double RadiusPill = 11;
 
+    // ---- content bounds — widths that cap CONTENT, not rhythm values ----
+
+    /// <summary>How wide a stat-block tooltip may get before it wraps — the width at
+    /// which a monospace item block stops being a column and starts being a paragraph.
+    /// It was declared as a private 340 in four files at once (review catch,
+    /// 2026-08-18), and the magic-number scan can't see MaxWidth.</summary>
+    public const double TipWidth = 340;
+
     // ---- control sizes ----
 
     public const double RowHeight = 24;

--- a/src/EQBuddy.UI.Shared/ProgressText.cs
+++ b/src/EQBuddy.UI.Shared/ProgressText.cs
@@ -1,0 +1,42 @@
+using EQBuddy.Core;
+
+namespace EQBuddy.UI.Shared;
+
+/// <summary>
+/// The Progress card's header and summary text, shared so the WPF and Avalonia cards
+/// always say the same thing (the LootRows precedent: one builder,
+/// two surfaces). LevelUnlocks/LevelUnlockText cover the unlock rows; this covers
+/// the prose.
+/// </summary>
+public static class ProgressText
+{
+    /// <summary>Header value: "12.3% xp, +1 lvl (3 new), +2 aa". The ding cue
+    /// (<paramref name="dingCount"/>, AAs and spells newly available at the
+    /// session's latest level) rides here because the header is the only Progress
+    /// surface that always shows.</summary>
+    public static string Header(StatsSnapshot s, int dingCount) =>
+        $"{s.XpPercent:0.0}% xp"
+        + (s.Levels.Count > 0
+            ? $", +{s.Levels.Count} lvl" + (dingCount > 0 ? $" ({dingCount} new)" : "")
+            : "")
+        + (s.AaGained > 0 ? $", +{s.AaGained} aa" : "");
+
+    /// <summary>The card's dim summary block, as ONE string with a caller-chosen
+    /// separator. The content is <see cref="ProgressPresentation.SummaryLines"/> —
+    /// upstream's Gate 5b built the same extraction this fork had, so theirs is the
+    /// single source now and this is only the seam the Avalonia build reads through:
+    /// it passes " - ", its file-wide plain-ASCII convention under fonts Wine/Linux
+    /// may lack, and a wording fix upstream reaches it unchanged.</summary>
+    public static string Summary(StatsSnapshot s, string sep = " · ") =>
+        string.Join("\n", ProgressPresentation.SummaryLines(s)
+            .Select(line => line.Replace(" · ", sep)));
+
+    /// <summary>Which AAs count as "learned this session": announced at or after the
+    /// session's start (the ledger holds the character's whole history). One rule for
+    /// both UIs — two filters would drift (the trap-4 lesson).</summary>
+    public static List<AaAbilityInfo> SessionNewAas(StatsSnapshot s) =>
+        s.SessionStart is { } sess
+            ? s.AaAbilities.Where(a => a.Time >= sess).ToList()
+            : [];
+
+}

--- a/src/EQBuddy/BreakoutWindow.xaml
+++ b/src/EQBuddy/BreakoutWindow.xaml
@@ -44,14 +44,16 @@
                            Visibility="Collapsed" MouseLeftButtonDown="OnOpenTimeline"
                            Ink="DimBrush"
                            ToolTip="Fight timeline: the whole pull, a lane per skill — every hit, miss and resist, plus DPS over time."/>
+                <!-- Filled in code with the compact segmented strip — the same control
+                     the Loot strips use, so the highlight is rounded inside this
+                     border's own rounding (LW, 2026-08-18: the old square TextBlock
+                     wash poked outside the pill).
+                     Rebase note: LW's branch predates this file joining
+                     DesignRatchetTests.Migrated, so its literal 6 / 6,0,6,0 are the
+                     token resources here. Same geometry, held to the scale. -->
                 <Border Grid.Column="4" x:Name="ScopeBorder" CornerRadius="{DynamicResource CornerCard}" BorderThickness="1"
                         Margin="{DynamicResource FlankS}" VerticalAlignment="Center">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock x:Name="ScopeFight" Text="Fight" FontSize="{DynamicResource FontMetadata}" Padding="{DynamicResource PadScope}"
-                                   Cursor="Hand" MouseLeftButtonDown="OnScopeFight"/>
-                        <TextBlock x:Name="ScopeSession" Text="Session" FontSize="{DynamicResource FontMetadata}" Padding="{DynamicResource PadScope}"
-                                   Cursor="Hand" MouseLeftButtonDown="OnScopeSession"/>
-                    </StackPanel>
+                    <StackPanel x:Name="ScopeHost" Orientation="Horizontal"/>
                 </Border>
                 <local:EqIcon Grid.Column="5" Glyph="Close" Size="11" VerticalAlignment="Center"
                            Cursor="Hand" Margin="{DynamicResource FlankXxs}" MouseLeftButtonDown="OnDismiss"

--- a/src/EQBuddy/BreakoutWindow.xaml.cs
+++ b/src/EQBuddy/BreakoutWindow.xaml.cs
@@ -122,14 +122,37 @@ public partial class BreakoutWindow : Window
         }
         if (_kind == BreakoutKind.Loot)
         {
-            // Same toggle chrome, different axis: what the TARGET can drop vs what the
-            // SESSION has yielded (David, 2026-08-06).
-            ScopeFight.Text = "Target";
-            ScopeSession.Text = "Session";
             _lootView = new LootBreakoutView(this, settings);
             LootStrips.Content = _lootView.Strips;   // shown by the view's own render
         }
+
+        // The scope toggle, on the same compact segmented strip as the Loot filters —
+        // its hand-rolled predecessor washed the selected TextBlock square, which poked
+        // outside ScopeBorder's own rounded corners (LW, 2026-08-18). Loot rides the
+        // same chrome on a different axis: TARGET drops vs the SESSION's yield
+        // (David, 2026-08-06).
+        _scope = new EqSegmentedStrip(ScopeHost, compact: true);
+        var loot = _kind == BreakoutKind.Loot;
+        _scope.Add(loot ? "Target" : "Fight", true,
+            tip: loot ? "What the creature you're fighting — or last /considered — can drop"
+                : "The current (or last) pull's numbers",
+            onClick: () => SetScope(fight: true));
+        _scope.Add("Session", false,
+            tip: loot ? "Everything this session has yielded" : "The whole session's numbers",
+            onClick: () => SetScope(fight: false));
         ApplyScopeVisual();
+    }
+
+    private EqSegmentedStrip? _scope;
+
+    private void SetScope(bool fight)
+    {
+        _fightScope = fight;
+        SetScopeSetting(fight ? "fight" : "session");
+        ApplyScopeVisual();
+        // Repaint now, not on the next tick — the old toggle waited up to a second,
+        // which is long enough to read as a click that did nothing.
+        if (_lastSnapshot is { } s) Update(s);
     }
 
     private string ScopeSetting() => _kind switch
@@ -904,26 +927,8 @@ public partial class BreakoutWindow : Window
 
     private void ApplyScopeVisual()
     {
-        Highlight(ScopeFight, _fightScope);
-        Highlight(ScopeSession, !_fightScope);
-        _signature = "";
-
-        void Highlight(TextBlock t, bool on)
-        {
-            t.SetResourceReference(TextBlock.ForegroundProperty, on ? "AccentBrush" : "DimBrush");
-            if (on) t.SetResourceReference(TextBlock.BackgroundProperty, "ToggleHighlightBrush");
-            else t.Background = Brushes.Transparent;
-        }
-    }
-
-    private void OnScopeFight(object sender, MouseButtonEventArgs e)
-    {
-        _fightScope = true; SetScopeSetting("fight"); ApplyScopeVisual(); e.Handled = true;
-    }
-
-    private void OnScopeSession(object sender, MouseButtonEventArgs e)
-    {
-        _fightScope = false; SetScopeSetting("session"); ApplyScopeVisual(); e.Handled = true;
+        _scope?.Select(_fightScope);
+        _signature = "";   // force a repaint in the new scope on the next tick
     }
 
     private void OnDismiss(object sender, MouseButtonEventArgs e)

--- a/src/EQBuddy/DesignSystem.cs
+++ b/src/EQBuddy/DesignSystem.cs
@@ -171,6 +171,28 @@ internal static class DesignSystem
         return icon;
     }
 
+    /// <summary>The clickable list-element contract, in one home for rows and badges:
+    /// swallow the mouse-down so it can't start a window DragMove and eat the up (#46),
+    /// and act on the up ONLY if this element saw the press — a mouse-down handler
+    /// elsewhere (a fold header, a chip) can rebuild the list mid-gesture and drop the
+    /// up on a brand-new element that was never pressed (LW's live report, 2026-08-17).
+    /// The up is Handled even when unmatched: an element's release is never any
+    /// ancestor's business.</summary>
+    public static void WireClick(FrameworkElement element, Action onClick)
+    {
+        var pressed = false;
+        element.Cursor = Cursors.Hand;
+        element.MouseLeftButtonDown += (_, e) => { pressed = true; e.Handled = true; };
+        element.MouseLeave += (_, _) => pressed = false;
+        element.MouseLeftButtonUp += (_, e) =>
+        {
+            e.Handled = true;
+            if (!pressed) return;
+            pressed = false;
+            onClick();
+        };
+    }
+
     /// <summary>An icon that behaves like a button but reads like a glyph — the close /
     /// pin / report family. A real <see cref="Button"/>, so it is keyboard-reachable and
     /// has a hit area, rather than the click-handled TextBlocks these used to be.</summary>
@@ -221,17 +243,27 @@ internal sealed class EqChip : Border
 {
     private readonly TextBlock _label;
     private readonly TextBlock? _badge;
+    private readonly bool _compact;
 
     /// <summary>What this chip selects — a mode string, a QuestTab, a class name.
     /// Compared by the strip, never interpreted here.</summary>
     public object Key { get; }
 
     public EqChip(string text, object key, string? badge = null, string? tip = null,
-        Action? onClick = null)
+        Action? onClick = null, bool compact = false)
     {
         Key = key;
-        var content = new StackPanel { Orientation = Orientation.Horizontal };
-        _label = DesignSystem.Text(ChipStyle.LabelRole, text);
+        _compact = compact;
+        // Centered both ways inside the padding box — a segment whose text sits high
+        // or leans left reads as misaligned the moment a divider gives it edges.
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        _label = DesignSystem.Text(compact ? ChipStyle.CompactLabelRole : ChipStyle.LabelRole, text);
+        _label.VerticalAlignment = VerticalAlignment.Center;
         content.Children.Add(_label);
         if (badge is { Length: > 0 })
         {
@@ -240,11 +272,15 @@ internal sealed class EqChip : Border
             content.Children.Add(_badge);
         }
         Child = content;
-        CornerRadius = new CornerRadius(ChipStyle.Radius);
-        Padding = new Thickness(ChipStyle.Padding.Left, ChipStyle.Padding.Top,
-            ChipStyle.Padding.Right, ChipStyle.Padding.Bottom);
-        Margin = new Thickness(0, 0, ChipStyle.Gap.Right, ChipStyle.Gap.Bottom);
-        BorderThickness = new Thickness(ChipStyle.BorderThickness);
+        // Compact is the scope toggle's shape: flush segments (no gap, no edge of
+        // their own) inside the strip's shared hairline frame.
+        CornerRadius = new CornerRadius(compact ? ChipStyle.CompactRadius : ChipStyle.Radius);
+        var pad = compact ? ChipStyle.CompactPadding : ChipStyle.Padding;
+        Padding = new Thickness(pad.Left, pad.Top, pad.Right, pad.Bottom);
+        Margin = compact
+            ? new Thickness(0)
+            : new Thickness(0, 0, ChipStyle.Gap.Right, ChipStyle.Gap.Bottom);
+        BorderThickness = new Thickness(compact ? 0 : ChipStyle.BorderThickness);
         Cursor = Cursors.Hand;
         if (tip is not null) ToolTip = tip;
         // Handled, or the window's own drag-to-move swallows the click.
@@ -255,20 +291,28 @@ internal sealed class EqChip : Border
 
     public void SetSelected(bool on)
     {
-        var ink = ChipStyle.For(on);
-        SetResourceReference(BackgroundProperty, ink.Background);
-        SetResourceReference(BorderBrushProperty, ink.Border);
+        var ink = _compact ? ChipStyle.ForCompact(on) : ChipStyle.For(on);
+        Paint(this, BackgroundProperty, ink.Background);
+        Paint(this, BorderBrushProperty, ink.Border);
         _label.Ink(ink.Label);
         if (_badge is null) return;
         _badge.Ink(ink.Badge);
         _badge.Opacity = ink.BadgeOpacity;
+
+        // ChipStyle.None means no brush at all — the compact segments' unfilled state;
+        // a resource reference would look the empty key up and paint nothing forever.
+        static void Paint(Border b, DependencyProperty prop, string key)
+        {
+            if (key == ChipStyle.None) b.SetValue(prop, Brushes.Transparent);
+            else b.SetResourceReference(prop, key);
+        }
     }
 }
 
 /// <summary>A row of <see cref="EqChip"/> where exactly one is selected — the segmented
 /// control. Owns the "which one is on" bookkeeping every hand-built strip wrote its own
 /// copy of, usually as a foreach over a list of tuples.</summary>
-internal sealed class EqSegmentedStrip(Panel host)
+internal sealed class EqSegmentedStrip(Panel host, bool compact = false)
 {
     private readonly List<EqChip> _chips = [];
 
@@ -283,7 +327,25 @@ internal sealed class EqSegmentedStrip(Panel host)
     public EqChip Add(string text, object key, string? badge = null, string? tip = null,
         Action? onClick = null)
     {
-        var chip = new EqChip(text, key, badge, tip, onClick);
+        var chip = new EqChip(text, key, badge, tip, onClick, compact);
+        if (compact && _chips.Count > 0)
+        {
+            // The hairline divider between segments (LW, 2026-08-18) — the split the
+            // group frame implies, drawn, inset so it never touches the frame's
+            // rounded corners. Its visibility FOLLOWS its segment's: a strip that
+            // withholds a segment (the Loot card withholds "recent") must not strand
+            // a doubled divider where it stood.
+            var divider = new Border
+            {
+                Width = ChipStyle.BorderThickness,
+                Margin = new Thickness(0, ChipStyle.CompactDividerInset,
+                    0, ChipStyle.CompactDividerInset),
+            };
+            divider.SetResourceReference(Border.BackgroundProperty, "HairlineBrush");
+            divider.SetBinding(UIElement.VisibilityProperty,
+                new System.Windows.Data.Binding(nameof(Visibility)) { Source = chip });
+            host.Children.Add(divider);
+        }
         host.Children.Add(chip);
         _chips.Add(chip);
         return chip;

--- a/src/EQBuddy/EqCardRows.cs
+++ b/src/EQBuddy/EqCardRows.cs
@@ -74,16 +74,14 @@ internal static class EqCardRows
     {
         if (context.QuestAwareTooltip(item, context.ItemHoverStats(item)) is { Length: > 0 } tip)
         {
-            var text = new TextBlock { Text = tip, TextWrapping = TextWrapping.Wrap, MaxWidth = TipWidth };
+            var text = new TextBlock { Text = tip, TextWrapping = TextWrapping.Wrap, MaxWidth = DesignTokens.TipWidth };
             // Multi-line tips are stat blocks — monospace keeps their columns readable.
             if (tip.Contains('\n')) text.FontFamily = MainWindow.MonoFamily;
             name.ToolTip = new ToolTip { Content = text };
         }
-        name.Cursor = Cursors.Hand;
-        // Swallow the down so it can't start a window DragMove and eat the Up — the
-        // discussion #46 failure mode.
-        name.MouseLeftButtonDown += (_, e) => e.Handled = true;
-        name.MouseLeftButtonUp += (_, _) => context.ShowItemInfo(item);
+        // The press-guarded contract (#46 + the mid-gesture rebuild race) — one home
+        // for every clickable list element, LootCardView's rows included.
+        DesignSystem.WireClick(name, () => context.ShowItemInfo(item));
     }
 
     /// <summary>The quest marker beside an item: click for the Quest Tracker filtered to
@@ -104,7 +102,4 @@ internal static class EqCardRows
     private static readonly double MetadataSize =
         DesignTokens.Spec(DesignTokens.TypeRole.Metadata).Size;
 
-    /// <summary>The width at which a monospace stat block stops being a column and starts
-    /// being a paragraph.</summary>
-    private const double TipWidth = 340;
 }

--- a/src/EQBuddy/LootBreakoutView.cs
+++ b/src/EQBuddy/LootBreakoutView.cs
@@ -49,7 +49,9 @@ internal sealed class LootBreakoutView
         {
             Margin = new Thickness(0, 0, DesignTokens.SpaceXxs, DesignTokens.SpaceXxs),
         };
-        _viewGroup.Margin = new Thickness(0, 0, DesignTokens.SpaceL, 0);
+        // SpaceM, not the card's SpaceL: horizontal room is this window's scarcest
+        // resource, and the group frames already separate the two strips.
+        _viewGroup.Margin = new Thickness(0, 0, DesignTokens.SpaceM, 0);
         strips.Children.Add(_viewGroup);
         strips.Children.Add(_sortGroup);
         Strips = strips;
@@ -73,15 +75,30 @@ internal sealed class LootBreakoutView
     private static EqSegmentedStrip BuildStrip(Panel group, string label,
         IReadOnlyList<LootPresentation.Option> options, Action<string> onPick)
     {
-        var caption = DesignSystem.Text(DesignTokens.TypeRole.Caption, label);
+        // Compact segments in the Target|Session toggle's own vocabulary (LW,
+        // 2026-08-18): the card-scale pill crowded this ~270px window, and the window's
+        // chrome already established what a dense toggle looks like here — flush
+        // segments inside one hairline frame, the selected one washed and accented.
+        var caption = DesignSystem.Text(ChipStyle.CompactLabelRole, label);
+        // Semibold: "show:" and "sort:" are labels, and at metadata size the weight is
+        // what separates them from the options they govern (LW, 2026-08-18).
+        caption.FontWeight = FontWeights.SemiBold;
         caption.Margin = new Thickness(0, 0, DesignTokens.SpaceXs, 0);
         caption.VerticalAlignment = VerticalAlignment.Center;
         group.Children.Add(caption);
 
         var host = new StackPanel { Orientation = Orientation.Horizontal };
-        group.Children.Add(host);
+        var frame = new Border
+        {
+            Child = host,
+            CornerRadius = new CornerRadius(ChipStyle.CompactRadius),
+            BorderThickness = new Thickness(ChipStyle.BorderThickness),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        frame.SetResourceReference(Border.BorderBrushProperty, "HairlineBrush");
+        group.Children.Add(frame);
 
-        var strip = new EqSegmentedStrip(host);
+        var strip = new EqSegmentedStrip(host, compact: true);
         foreach (var option in options)
         {
             var key = option.Key;
@@ -158,32 +175,26 @@ internal sealed class LootBreakoutView
         _w.Signature = sig;
 
         _w.Rows.Items.Clear();
-        var barBrush = BreakdownRows.BarBrush(_w);
-        foreach (var r in rows) _w.Rows.Items.Add(BuildRow(r, barBrush));
+        foreach (var r in rows) _w.Rows.Items.Add(BuildRow(r));
     }
 
     /// <summary>An item row wired the way David specced this window: hover = the eqlwiki
     /// item info, fetched on the spot when the cache is empty (the tooltip live-updates
-    /// from "Looking up…"); click = the page in the browser. The quest badge is the Loot
-    /// card's, vector and all — one item wanted by one quest must not look like two
-    /// different things in two windows.</summary>
-    private Grid BuildRow(LootRow r, Brush barBrush)
+    /// from "Looking up…"); click = the page in the browser. The row itself IS the
+    /// card's (LootCardView.ItemRow — LW, 2026-08-18): flat, badge against the value,
+    /// no underline track, so one item cannot look like two different things in two
+    /// windows. Only what hover and click DO differs.</summary>
+    private Grid BuildRow(LootRow r)
     {
         var cachedTip = _w.Main?.CachedItemStats(r.Item);
-        var badge = _w.Main is { } main ? EqCardRows.QuestBadge(main, r.Item) : null;
-
-        var row = BreakdownRows.Row(_w, r.Item, r.Value, 0, barBrush, null,
-            nameBadge: badge, nameNote: LootPresentation.Note(r.Tag));
-
         var tipText = new TextBlock
         {
             Text = cachedTip ?? "Looking up on eqlwiki…",
             TextWrapping = TextWrapping.Wrap,
-            MaxWidth = TipWidth,
+            MaxWidth = DesignTokens.TipWidth,
             FontFamily = MainWindow.MonoFamily,
         };
         var tip = new ToolTip { Content = tipText };
-        row.ToolTip = tip;
 
         var fetched = false;
         tip.Opened += async (_, _) =>
@@ -195,14 +206,12 @@ internal sealed class LootBreakoutView
             tipText.Text = text ?? (cachedTip ?? "Not on the wiki.");
         };
 
-        row.Cursor = Cursors.Hand;
-        row.MouseLeftButtonDown += (_, e) => e.Handled = true;   // don't start a window drag
-        row.MouseLeftButtonUp += (_, _) => MainWindow.OpenWikiPage(r.Item);
+        var row = LootCardView.ItemRow(_w.Main, r.Item, r.Value, LootPresentation.Note(r.Tag),
+            tip, item => MainWindow.OpenWikiPage(item));
+        // A whisper of right inset the card never needs: these rows sit against the
+        // window's own scrollbar when the list overflows.
+        row.Margin = new Thickness(0, 0, DesignTokens.SpaceXxs, 0);
         return row;
     }
 
-    /// <summary>How wide a stat-block tooltip may get before it wraps — the width at which
-    /// a monospace item block stops being a column and starts being a paragraph, not a
-    /// rhythm value.</summary>
-    private const double TipWidth = 340;
 }

--- a/src/EQBuddy/LootCardView.cs
+++ b/src/EQBuddy/LootCardView.cs
@@ -113,6 +113,9 @@ internal sealed class LootCardView
         IReadOnlyList<LootPresentation.Option> options, Action<string> onPick)
     {
         var caption = DesignSystem.Text(DesignTokens.TypeRole.Caption, label);
+        // Semibold, matching the breakout's strips: these are labels, and the weight
+        // is what separates them from the options they govern (LW, 2026-08-18).
+        caption.FontWeight = FontWeights.SemiBold;
         caption.Margin = new Thickness(0, 0, DesignTokens.SpaceXs, 0);
         caption.VerticalAlignment = VerticalAlignment.Center;
         group.Children.Add(caption);
@@ -191,6 +194,30 @@ internal sealed class LootCardView
     /// (#148, #166) — as this test just proved by refusing the comment that said so.</summary>
     private Grid BuildRow(LootRow row)
     {
+        object? tip = null;
+        if (_w.QuestAwareTooltip(row.Item, _w.ItemHoverStats(row.Item)) is { Length: > 0 } text)
+        {
+            var tipText = new TextBlock { Text = text, TextWrapping = TextWrapping.Wrap, MaxWidth = DesignTokens.TipWidth };
+            // Multi-line tips are stat blocks — monospace keeps their columns readable.
+            if (text.Contains('\n')) tipText.FontFamily = MainWindow.MonoFamily;
+            tip = new ToolTip { Content = tipText };
+        }
+        return ItemRow(_w, row.Item, row.Value, LootPresentation.Note(row.Tag),
+            tip ?? "Click for item info (eqlwiki)", _w.ShowItemInfo);
+    }
+
+    /// <summary>THE item row — one builder for the Loot card and the Loot breakout
+    /// (LW, 2026-08-18: "the more we bring the two windows together
+    /// visually and operate from the same source, the better"). Name + provenance run +
+    /// quest badge + dim value, flat: no share bar — these rows state facts, and the
+    /// underline track under every breakout row read as clutter next to the card. What
+    /// hover and click DO stays each caller's own (the card opens the in-app item info,
+    /// the breakouts open the wiki); clicks ride <see cref="DesignSystem.WireClick"/>'s
+    /// press-guard, because a breakout fold header rebuilds its list on mouse-down and
+    /// an unguarded name would catch the stray up.</summary>
+    internal static Grid ItemRow(MainWindow? w, string item, string value, string? note,
+        object? tip, Action<string>? onNameClick)
+    {
         var grid = new Grid();
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -199,42 +226,33 @@ internal sealed class LootCardView
         var name = DesignSystem.Text(DesignTokens.TypeRole.Body);
         name.TextTrimming = TextTrimming.CharacterEllipsis;
         name.Margin = new Thickness(0, 1, DesignTokens.SpaceM, 1);
-        if (LootPresentation.Note(row.Tag) is { } note)
+        if (note is { Length: > 0 })
         {
             // Provenance is a separate run, not part of the name, so a click still looks
             // the base item up (LW, 2026-08-17).
-            name.Inlines.Add(new Run(row.Item));
+            name.Inlines.Add(new Run(item));
             var tag = new Run($" {note}") { FontSize = MetadataSize };
             tag.SetResourceReference(TextElement.ForegroundProperty, "DimBrush");
             name.Inlines.Add(tag);
         }
-        else name.Text = row.Item;
-
-        if (_w.QuestAwareTooltip(row.Item, _w.ItemHoverStats(row.Item)) is { Length: > 0 } tip)
+        else name.Text = item;
+        if (tip is not null) name.ToolTip = tip;
+        if (onNameClick is not null)
         {
-            var tipText = new TextBlock { Text = tip, TextWrapping = TextWrapping.Wrap, MaxWidth = TipWidth };
-            // Multi-line tips are stat blocks — monospace keeps their columns readable.
-            if (tip.Contains('\n')) tipText.FontFamily = MainWindow.MonoFamily;
-            name.ToolTip = new ToolTip { Content = tipText };
+            var clicked = item;
+            DesignSystem.WireClick(name, () => onNameClick(clicked));
         }
-        var item = row.Item;
-        name.Cursor = Cursors.Hand;
-        name.ToolTip ??= "Click for item info (eqlwiki)";
-        // Swallow the down so it can't start a window DragMove and eat the Up (the
-        // discussion #46 failure mode, same fix as the breakout rows).
-        name.MouseLeftButtonDown += (_, e) => e.Handled = true;
-        name.MouseLeftButtonUp += (_, _) => _w.ShowItemInfo(item);
         grid.Children.Add(name);
 
-        if (EqCardRows.QuestBadge(_w, row.Item) is { } badge)
+        if (w is not null && EqCardRows.QuestBadge(w, item) is { } badge)
         {
             Grid.SetColumn(badge, 1);
             grid.Children.Add(badge);
         }
 
-        var value = DesignSystem.Text(DesignTokens.TypeRole.Body, row.Value).Ink("DimBrush");
-        Grid.SetColumn(value, 2);
-        grid.Children.Add(value);
+        var valueBlock = DesignSystem.Text(DesignTokens.TypeRole.Body, value).Ink("DimBrush");
+        Grid.SetColumn(valueBlock, 2);
+        grid.Children.Add(valueBlock);
         return grid;
     }
 
@@ -260,8 +278,4 @@ internal sealed class LootCardView
     private static readonly double MetadataSize =
         DesignTokens.Spec(DesignTokens.TypeRole.Metadata).Size;
 
-    /// <summary>How wide a stat-block tooltip may get before it wraps. Not a rhythm value
-    /// — it is the width at which a monospace item block stops being a column and starts
-    /// being a paragraph.</summary>
-    private const double TipWidth = 340;
 }

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using EQBuddy.Core;
 using LevelUnlockText = EQBuddy.UI.Shared.LevelUnlockText;
+using ProgressText = EQBuddy.UI.Shared.ProgressText;
 using SpawnChip = EQBuddy.UI.Shared.SpawnChip;
 // An alias rather than a `using EQBuddy.UI.Shared` — this file already aliases two types
 // out of that namespace one at a time, because importing the whole of it collides with
@@ -2391,15 +2392,11 @@ public partial class MainWindow : Window, ICardContext
         if (s.LastLevel is { } announced && QuestLedger is { } lg && QuestCharacterKey.Length > 0
             && lg.LevelFor(QuestCharacterKey) != announced)
             lg.SetLevel(QuestCharacterKey, announced);
-        ProgressHeader.Text = $"{s.XpPercent:0.0}% xp"
-            + (s.Levels.Count > 0
-                ? $", +{s.Levels.Count} lvl"
-                  // The ding's cue, visible while the card is closed: the header is the
-                  // only Progress surface that always shows, and clicking it opens the
-                  // card where the "New at level N" list waits (never a popup).
-                  + (DingUnlocks(s).Count > 0 ? $" ({DingUnlocks(s).Count} new)" : "")
-                : "")
-            + (s.AaGained > 0 ? $", +{s.AaGained} aa" : "");
+        // The ding's cue rides the header, visible while the card is closed: the header
+        // is the only Progress surface that always shows, and clicking it opens the
+        // card where the "New at level N" list waits (never a popup). Text built in
+        // UI.Shared so the Avalonia build's header says exactly the same thing.
+        ProgressHeader.Text = ProgressText.Header(s, DingUnlocks(s).Count);
         FactionHeader.Text = s.Faction.Count > 0 ? $"{s.Faction.Count} factions" : "—";
         MiscHeader.Text = $"{s.Deaths.Count} death{(s.Deaths.Count == 1 ? "" : "s")}";
         ApplySessionSubsections();
@@ -2555,9 +2552,7 @@ public partial class MainWindow : Window, ICardContext
             // AA display, rethought (Reddit, 2026-08-11: "is it supposed to just show
             // newly learned this session?" — yes, now it is): session-new AAs lead,
             // the full ledger folds behind a click, same idiom as Pet abilities.
-            var newAas = s.SessionStart is { } sess
-                ? s.AaAbilities.Where(a => a.Time >= sess).ToList()
-                : [];
+            var newAas = ProgressText.SessionNewAas(s);
             AaNewLabel.Visibility = newAas.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
             AaNewList.Visibility = AaNewLabel.Visibility;
             FillList(AaNewList, newAas.Select(a =>
@@ -3821,9 +3816,6 @@ public partial class MainWindow : Window, ICardContext
         }
     }
 
-
-    private static string FormatEta(double hours) =>
-        EQBuddy.UI.Shared.ProgressPresentation.FormatEta(hours);
 
     private void OnMinimize(object sender, RoutedEventArgs e) => SetMode(true);
     private void OnRestore(object sender, RoutedEventArgs e) => SetMode(false);

--- a/src/EQBuddy/MezChipsWindow.xaml.cs
+++ b/src/EQBuddy/MezChipsWindow.xaml.cs
@@ -27,6 +27,7 @@ public partial class MezChipsWindow : Window
         Action<double>? setChipScale = null)
     {
         InitializeComponent();
+        NoActivate.Attach(this);
         _settings = settings;
         _source = source;
         ChipScale.Apply(this, _settings.ChipScale);

--- a/src/EQBuddy/NoActivate.cs
+++ b/src/EQBuddy/NoActivate.cs
@@ -1,0 +1,42 @@
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace EQBuddy;
+
+/// <summary>
+/// Makes an over-the-game window incapable of taking keyboard focus, ever:
+/// WS_EX_NOACTIVATE (a click lands without activating) plus WS_EX_TOOLWINDOW
+/// (stays out of Alt-Tab). ShowActivated="False" in the XAML only covers Show()
+/// itself — without the ex-style, the first click or drag on a chip still hands
+/// the game's keyboard to EQBuddy mid-fight. Mouse interaction is unaffected:
+/// DragMove, clicks and the wheel all work on a never-activated window (the
+/// alert tile has dragged this way since 1.8.11).
+///
+/// The alert tile, grid overlay and cursor ring carry the same styles inline
+/// because each also toggles WS_EX_TRANSPARENT; this helper is for windows that
+/// only need the focus half.
+/// </summary>
+internal static class NoActivate
+{
+    private const int GwlExStyle = -20;
+    private const int WsExNoActivate = 0x08000000;
+    private const int WsExToolWindow = 0x80;
+
+    /// <summary>Call from the constructor; the styles land as soon as the HWND
+    /// exists, before the window is first shown.</summary>
+    public static void Attach(Window window)
+    {
+        window.ShowActivated = false;
+        window.SourceInitialized += (_, _) =>
+        {
+            var hwnd = new WindowInteropHelper(window).Handle;
+            if (hwnd == IntPtr.Zero) return;
+            SetWindowLong(hwnd, GwlExStyle,
+                GetWindowLong(hwnd, GwlExStyle) | WsExNoActivate | WsExToolWindow);
+        };
+    }
+
+    [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hwnd, int index);
+    [DllImport("user32.dll")] private static extern int SetWindowLong(IntPtr hwnd, int index, int value);
+}

--- a/src/EQBuddy/SpawnChipsWindow.xaml.cs
+++ b/src/EQBuddy/SpawnChipsWindow.xaml.cs
@@ -31,6 +31,7 @@ public partial class SpawnChipsWindow : Window
     public SpawnChipsWindow(MainWindow main, SpawnsViewModel vm)
     {
         InitializeComponent();
+        NoActivate.Attach(this);
         _main = main;
         _vm = vm;
         _settings = main.Settings;

--- a/tests/EQBuddy.Tests/CharmTrackerTests.cs
+++ b/tests/EQBuddy.Tests/CharmTrackerTests.cs
@@ -49,6 +49,132 @@ public class CharmTrackerTests
         Assert.Equal(["Puma"], confirmed);
     }
 
+    /// <summary>Review catch, 2026-08-18: a KNOWN charm whose strong blink arrives after
+    /// the spell's own arm window (lag, or a re-cast off a resisted first attempt) must
+    /// degrade to the provisional claim the code's own comment promised — not to
+    /// nothing. Nothing meant CharmedSince stayed null down this path, and the eventual
+    /// fade had no landing time to measure a "held M:SS" from (#135's symptom).</summary>
+    [Fact]
+    public void AStrongBlinkPastTheArmWindowIsProvisionalNotNothing()
+    {
+        var charm = New(out _);
+        // "Charm" carries a real cast time in the wiki charm catalog, so its arm window
+        // is a few seconds; 20 s later is inside CastToBlink but well past the window.
+        charm.OnBlink(new PetBlinkEvent(At(0, 20), "a puma"), ("Charm", At(0, 0)));
+        Assert.Equal(At(0, 20), charm.CharmedSince);   // provisional — the clock started
+        // The tell keeps the original landing time rather than restarting the clock.
+        charm.OnPetClaim(new PetClaimEvent(At(0, 25), "a puma"), "Douglas");
+        Assert.Equal(At(0, 20), charm.CharmedSince);
+    }
+
+    /// <summary>Round-2 review catch: OnBlink renames the pet unconditionally at its
+    /// bottom, so a chain-charm's late blink onto a DIFFERENT creature must move the
+    /// provisional clock with the name — or the label says wolf while the landing time
+    /// says puma. A repeat late blink for the SAME pet still must not restart it.</summary>
+    [Fact]
+    public void AChainCharmsLateBlinkMovesTheClockWithTheName()
+    {
+        var charm = New(out _);
+        charm.OnBlink(new PetBlinkEvent(At(0, 20), "a puma"), ("Charm", At(0, 0)));
+        // A repeat late blink for the same pet: the running clock holds.
+        charm.OnBlink(new PetBlinkEvent(At(0, 25), "a puma"), ("Charm", At(0, 6)));
+        Assert.Equal(At(0, 20), charm.CharmedSince);
+        // A different creature: the clock follows the rename.
+        charm.OnBlink(new PetBlinkEvent(At(1, 0), "a wolf"), ("Charm", At(0, 40)));
+        Assert.Equal(At(1, 0), charm.CharmedSince);
+    }
+
+    /// <summary>Round-3 review catches, both in the message-skew shapes this file
+    /// documents: a chain-charm whose predecessor's fade line never reached the parser
+    /// must not leave the CONFIRMED hold answering for the old pet (CharmedSince
+    /// prefers _hold, so the wolf's eventual break would measure from the puma's
+    /// landing); and a refresh blink for the held pet must be a true no-op — not a
+    /// demotion of a confirmed identity back to "Pet?".</summary>
+    [Fact]
+    public void AChainCharmDropsTheOldPetsHoldAndARefreshBlinkDemotesNothing()
+    {
+        var charm = Charmed(out _);              // confirmed hold on "a puma" at 0:00
+        Assert.Equal("Pet (Puma)", charm.SourceLabel);
+
+        // Refresh blink for the same pet, late and strong: identity and clock hold.
+        charm.OnBlink(new PetBlinkEvent(At(0, 30), "a puma"), ("Charm", At(0, 15)));
+        Assert.Equal("Pet (Puma)", charm.SourceLabel);
+        Assert.Equal(At(0, 0), charm.CharmedSince);
+
+        // Chain-charm onto a wolf with no puma fade line seen: the stale hold goes,
+        // and the clock is the wolf's landing, not the puma's.
+        charm.OnBlink(new PetBlinkEvent(At(1, 10), "a wolf"), ("Charm", At(0, 50)));
+        Assert.Equal(At(1, 10), charm.CharmedSince);
+    }
+
+    /// <summary>Codex review, 2026-08-18 (both rounds): a chain-charm must end the old
+    /// pet's WHOLE tenure — in particular, the old pet's /pet hold order must not
+    /// suppress real break detection on the new pet (PetHeldAt compares no names, so a
+    /// stale timestamp excuses every future attack forever).</summary>
+    [Fact]
+    public void AChainCharmEndsTheOldTenureCompletely()
+    {
+        var charm = Charmed(out _);   // confirmed hold on the puma at 0:00
+        charm.OnPetHold(new PetHoldEvent(At(0, 10), "a puma", Holding: true));
+
+        charm.OnBlink(new PetBlinkEvent(At(1, 10), "a wolf"), ("Charm", At(0, 50)));
+        Assert.Equal(At(1, 10), charm.CharmedSince);
+
+        // The wolf genuinely turning on us IS a break: the puma's hold order is gone
+        // with its tenure and cannot excuse it.
+        Assert.True(charm.OnIncomingHit(new DamageTakenEvent(At(1, 40), "a wolf", 50, Melee: true)));
+        Assert.Null(charm.CharmedSince);
+    }
+
+    /// <summary>Codex round 2: the rename must NOT arm the name-agnostic fade-echo —
+    /// doing so swallowed the NEW pet's own real fade for ten seconds and labeled it
+    /// with the old pet's hold. The accepted, narrower cost (the old charm's delayed
+    /// TARGETLESS fade closing the new clock early) is documented on
+    /// EndTenureIfRenaming.</summary>
+    [Fact]
+    public void ANewPetsRealFadeRightAfterAChainCharmStillBreaks()
+    {
+        var charm = Charmed(out _);   // confirmed hold on the puma at 0:00
+        charm.OnBlink(new PetBlinkEvent(At(1, 10), "a wolf"), ("Charm", At(0, 50)));
+        Assert.Equal(At(1, 10), charm.CharmedSince);
+
+        Assert.True(charm.OnCharmFade(new SpellWornOffEvent(At(1, 15), "Charm", "a wolf")));
+        Assert.Null(charm.CharmedSince);
+    }
+
+    /// <summary>Codex review, 2026-08-18: the tell is the one certain proof, so a tell
+    /// naming a NEW pet ends the old tenure even though the landing path conservatively
+    /// ignored the swap — CharmedSince must not keep answering with the old pet's
+    /// landing time for a pet now labeled with the new name.</summary>
+    [Fact]
+    public void ATellNamingANewPetEndsTheOldTenure()
+    {
+        var charm = Charmed(out _);   // confirmed hold on the puma at 0:00
+        charm.OnPetClaim(new PetClaimEvent(At(2, 0), "a wolf"), "Douglas");
+        Assert.Equal("Pet (Wolf)", charm.SourceLabel);
+        // Honest null, not the puma's landing: the wolf's landing was never trusted,
+        // so there is no clock to lend it.
+        Assert.Null(charm.CharmedSince);
+    }
+
+    /// <summary>Codex review, 2026-08-18: a pet confirmed by tell AFTER its no-cast
+    /// candidate aged out has no clock at all — the next known-charm refresh blink
+    /// supplies one instead of no-op'ing back to a pet that can never say "held".</summary>
+    [Fact]
+    public void ARefreshBlinkSuppliesTheClockATellOnlyConfirmationLacked()
+    {
+        var charm = New(out _);
+        charm.OnBlink(new PetBlinkEvent(At(0, 0), "a puma"), null);   // item-clicky shape
+        // The tell arrives past BlinkToClaim: pet confirmed, but no landing survives.
+        charm.OnPetClaim(new PetClaimEvent(At(1, 30), "a puma"), "Douglas");
+        Assert.Equal("Pet (Puma)", charm.SourceLabel);
+        Assert.Null(charm.CharmedSince);
+
+        charm.OnBlink(new PetBlinkEvent(At(2, 0), "a puma"), ("Charm", At(1, 40)));
+        Assert.Equal(At(2, 0), charm.CharmedSince);
+        Assert.Equal("Pet (Puma)", charm.SourceLabel);   // still confirmed — no demote
+    }
+
     // ---- a landing line is never proof on its own ----
 
     [Fact]

--- a/tests/EQBuddy.Tests/OverlayActivationTests.cs
+++ b/tests/EQBuddy.Tests/OverlayActivationTests.cs
@@ -39,6 +39,9 @@ public class OverlayActivationTests
         "EQBuddy/ClickThroughChip.cs",
         "EQBuddy/CursorRingWindow.cs",
         "EQBuddy/GridOverlayWindow.cs",
+        // The breakouts pop on the minimize pass — the star was clicked minutes ago,
+        // the show happens mid-fight.
+        "EQBuddy/BreakoutWindow.xaml",
         // Linux / macOS
         "EQBuddy.Avalonia/MezChipsWindow.cs",
         "EQBuddy.Avalonia/SpawnChipsWindow.cs",
@@ -46,6 +49,7 @@ public class OverlayActivationTests
         "EQBuddy.Avalonia/ClickThroughChip.cs",
         "EQBuddy.Avalonia/CursorRingWindow.cs",
         "EQBuddy.Avalonia/GridOverlayWindow.cs",
+        "EQBuddy.Avalonia/BreakoutWindow.cs",
     ];
 
     [Theory]

--- a/tests/EQBuddy.Tests/ProgressTextTests.cs
+++ b/tests/EQBuddy.Tests/ProgressTextTests.cs
@@ -1,0 +1,131 @@
+using EQBuddy.Core;
+using EQBuddy.UI.Shared;
+
+namespace EQBuddy.Tests;
+
+/// <summary>
+/// The Progress card's header and summary prose, shared by both UIs' cards — one
+/// builder so the two surfaces can never drift apart. These pin the
+/// words; LevelUnlocks/LevelUnlockText cover the unlock rows separately.
+/// </summary>
+public class ProgressTextTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 17, 20, 0, 0);
+
+    [Fact]
+    public void HeaderIsJustXpUntilAnythingElseHappens()
+    {
+        var s = new StatsSnapshot { XpPercent = 12.34 };
+        Assert.Equal("12.3% xp", ProgressText.Header(s, dingCount: 0));
+    }
+
+    [Fact]
+    public void HeaderCarriesLevelsTheDingCueAndAa()
+    {
+        var s = new StatsSnapshot
+        {
+            XpPercent = 3.5,
+            Levels = [new TimedDetail(T0, "You have reached level 30!")],
+            AaGained = 2,
+        };
+        Assert.Equal("3.5% xp, +1 lvl (4 new), +2 aa", ProgressText.Header(s, dingCount: 4));
+    }
+
+    [Fact]
+    public void HeaderOmitsTheDingCueWhenNothingUnlocked()
+    {
+        // "+1 lvl (0 new)" would read as a broken counter — a ding with no unlocks
+        // just says the level.
+        var s = new StatsSnapshot
+        {
+            XpPercent = 3.5,
+            Levels = [new TimedDetail(T0, "You have reached level 30!")],
+        };
+        Assert.Equal("3.5% xp, +1 lvl", ProgressText.Header(s, dingCount: 0));
+    }
+
+    [Fact]
+    public void SummaryBaseLineNamesTicksRatesAndSkillUps()
+    {
+        var s = new StatsSnapshot
+        {
+            XpTicks = 7, XpPerHour = 5.25, XpPerActiveHour = 8.5, SkillUpTotal = 3,
+        };
+        Assert.Equal("7 xp gains · 5.3%/hr · 8.5% active · 3 skill-ups",
+            ProgressText.Summary(s));
+    }
+
+    [Fact]
+    public void SummaryTakesTheAvaloniaBuildsAsciiSeparator()
+    {
+        // The Avalonia build passes " - " (its file-wide plain-ASCII convention under
+        // fonts Wine/Linux may lack) — same builder, different glyph, so a wording fix
+        // can never reach one UI and skip the other.
+        var s = new StatsSnapshot
+        {
+            XpTicks = 7, XpPerHour = 5.25, XpPerActiveHour = 8.5, SkillUpTotal = 3,
+        };
+        Assert.Equal("7 xp gains - 5.3%/hr - 8.5% active - 3 skill-ups",
+            ProgressText.Summary(s, " - "));
+    }
+
+    [Fact]
+    public void SummaryAddsRecentAaAndEtaLines()
+    {
+        var s = new StatsSnapshot
+        {
+            XpTicks = 7, XpPerHour = 5.0, XpPerActiveHour = 8.0, SkillUpTotal = 0,
+            Recent = new RecentRates(TimeSpan.FromMinutes(15), true, 1.2, 4.8, 0, 0, 0, 0),
+            AaGained = 1, AaPerHour = 0.5, AaTotal = 12,
+            HoursToLevel = 2.25,
+        };
+        var lines = ProgressText.Summary(s).Split('\n');
+        Assert.Equal("Last 15m: 4.8%/hr", lines[1]);
+        // Singular "point" — the plural is grammar, not a fixed string.
+        Assert.Equal("1 AA point · 0.5 AA/hr (now 12 unspent)", lines[2]);
+        Assert.Equal("Next level in ~2h 15m at this pace", lines[3]);
+    }
+
+    [Fact]
+    public void SummaryPacesEachDingFromThePreviousOne()
+    {
+        // First ding is measured from session start, the second from the first —
+        // "how long did that level take", not "how long since login".
+        var s = new StatsSnapshot
+        {
+            XpTicks = 1, SessionStart = T0,
+            Levels =
+            [
+                new TimedDetail(T0.AddMinutes(40), "You have reached level 30!"),
+                new TimedDetail(T0.AddMinutes(95), "You have reached level 31!"),
+            ],
+        };
+        var last = ProgressText.Summary(s).Split('\n')[^1];
+        Assert.Equal(
+            $"You have reached level 30! at {T0.AddMinutes(40):h:mm tt} (40m), " +
+            $"You have reached level 31! at {T0.AddMinutes(95):h:mm tt} (55m)", last);
+    }
+
+    [Fact]
+    public void SessionNewAasSplitsTheLedgerAtSessionStart()
+    {
+        // The ledger holds the character's whole AA history; only announcements at or
+        // after session start count as "learned this session". No session start (a
+        // log with no timestamped activity yet) honestly claims nothing.
+        var s = new StatsSnapshot
+        {
+            SessionStart = T0,
+            AaAbilities =
+            [
+                new AaAbilityInfo("Adamant Will", 1, T0.AddDays(-3)),
+                new AaAbilityInfo("Combat Fury", 2, T0),
+                new AaAbilityInfo("Planar Power", 1, T0.AddMinutes(50)),
+            ],
+        };
+        Assert.Equal(["Combat Fury", "Planar Power"],
+            ProgressText.SessionNewAas(s).Select(a => a.Name));
+        Assert.Empty(ProgressText.SessionNewAas(new StatsSnapshot
+            { AaAbilities = [new AaAbilityInfo("Adamant Will", 1, T0)] }));
+    }
+
+}


### PR DESCRIPTION
Four pieces from the fork, all running live under CrossOver since 2026-08-18. Rebased onto `main` at 54bc9b6 (v1.93.2); 1,994 unit + 227 Avalonia green.

## 1. CharmTracker: a rename ends the tenure, everywhere a rename happens

Three holes found by chaining charms live, then two adversarial review rounds (Codex + Claude, converged):

- A **late strong blink of an already-known charm entered no state at all** — "held M:SS" was lost for the rest of the tenure.
- A **chain-charm's rename left the old pet's tenure state standing** (hold, `petHeldSince`, `sameNameProofAt`, candidate) — the new pet inherited a stale clock and a proof it never earned. `EndTenureIfRenaming` is now one field-group reset called at every rename site, and the disprove branch clears the same group.
- A **refresh blink** (same name, charm still up) is a true no-op instead of a provisional restart.

`MezTracker` rides along: `_unpairedBreaks` was never emptied — it now prunes outside the 2 s pairing window and clears on zone.

**Flagged for you rather than fixed here** (the shape is your call):

- The charm **fade-echo ledger is name-agnostic**: a genuine prior break can swallow a *different* new pet's real fade within the 10 s window. Fixing it wants name-tagged ledger entries. Related accepted limitation is documented on `EndTenureIfRenaming` (a targetless delayed fade landing mid-chain-charm).
- `OnBlink`'s no-cast `_candidate ??=` keeps the **older** candidate — two different-name landings within 60 s lose the newer one's clock.
- MezTracker still cross-pairs same-named breaks under `fade, fade, awake, awake` interleaving.

## 2. Focus and input: the breakouts join the never-activate rule

Two more surfaces for #207's rule, and one keyboard hole:

- The **Avalonia breakout windows still activated on their first `Show()`** — the minimize pass pops them mid-fight. They now declare `ShowActivated = false`, and both UIs' breakouts join `OverlayActivationTests`' named list (the WPF one already declared it; the scan now holds it there).
- The **WPF chip stacks lose focus-on-click too**: `ShowActivated` covers the show, but clicking or dragging a chip stack still activated the window. `NoActivate.Attach` applies `WS_EX_NOACTIVATE`, the ex-style the alert tile has always carried.
- **Avalonia SpawnsWindow: a typed respawn override commits on Enter** — it was LostFocus-only, so typing a value and alt-tabbing back to the game silently discarded it.

## 3. Breakout styling: compact strips, the card's own rows, one press-guard

LW's read of the Gate-4 Loot breakout against its card:

- **Chips gain a compact variant** in `ChipStyle` (UI.Shared, so the Avalonia lane reads the same numbers when its breakouts arrive): flush segments inside one hairline group frame, hairline dividers inset from the corners, Metadata-size labels, selected = the toggle highlight wash under accent text. The card-scale pills crowded a ~270 px window.
- **The Fight/Session (Target/Session) scope toggle rebuilds on that strip** — its hand-rolled predecessor washed the selected TextBlock square, poking outside `ScopeBorder`'s rounded corners. A scope click also repaints from the last snapshot instead of waiting up to a second.
- **The Loot breakout's rows are the Loot card's row** (`LootCardView.ItemRow`): name + provenance run + quest badge against the value column + dim value, flat. Share bars stay with the comparison kinds, where length means something. One deliberate behavior change to know about: hover/click now live on the item *name* (matching the card's rows) rather than the whole row.
- **`DesignSystem.WireClick`** is the one home for the clickable-element contract: swallow the down so it can't start a window DragMove and eat the up (#46), act on the up only if this element saw the press — a fold header or chip can rebuild the list mid-gesture and strand the up on a fresh element. `EqCardRows`' name-click rides it too.
- **`TipWidth` (340)** was a private const in four files at once; it moves to `DesignTokens` as a content-bound token.

## 4. ProgressText: one builder for the Progress prose

The WPF and Avalonia Progress cards each built the header and pace summary by hand, and they had drifted: **the Avalonia header never carried the "(N new)" ding cue** even though its card body has listed the unlocks all along. Both now read `UI.Shared/ProgressText` (`Header`, `Summary` — a seam over your `ProgressPresentation.SummaryLines`, taking Avalonia's plain-ASCII " - " separator — and `SessionNewAas`). `ProgressTextTests` pins the words.

## Housekeeping

- No `WhatsNew.json` entry or version bump, per the #178/#198 precedent — proposed player-facing text below, renumber to whatever release ships it:
  > THE BREAKOUT WINDOWS NOW DRESS LIKE THE WIDGET'S OWN CARDS (contributed by Liminal Warmth). The Loot window's rows are the Loot card's rows — same quest marker, same provenance notes — and the filter and scope toggles are proper compact controls that stay inside their rounded frame instead of washing over it. The Linux and macOS breakout windows also stop taking your keyboard when they appear, a typed respawn time now saves when you press Enter, and a charmed pet that blinks or chain-charms no longer loses track of how long you have held it.
- `docs/TestPlan.md` rows added for the never-activate rule, the chip-stack click behavior, and the shared Progress prose.
