### PR TITLE
Unlocks tab, Shadow Knight Sky rewards, and pop-outs that can actually be resized

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,53 @@
 # EQBuddy — handoff
 
+> **2026-08-25 (later) — THE RESIZE FEATURE WAS INERT, AND WE TOLD A CONTRIBUTOR TO COPY IT.
+> MEASURED, FIXED, UNCOMMITTED. TWO OUTWARD-FACING CORRECTIONS DELIBERATELY NOT MADE.**
+>
+> `WindowStyle="None"` + `AllowsTransparency="True"` means Windows draws no non-client area,
+> so **`ResizeMode="CanResize"` creates no border to grab.** Every window that gained resize
+> on 2026-08-21 and 2026-08-25 had `CanResize`, called `WindowZoom.AllowResize`, persisted a
+> height on close — and could not be dragged by hand. Hateborne, asked directly: *"I cannot
+> resize pop-up windows."* Then, after the fix: *"I was able to resize this time."*
+>
+> → **Nothing in the suite could see it.** `ResizableWindowTests` asserts a window does not
+> say `NoResize` and that it calls `AllowResize`. Both were true throughout. That is trap 34
+> exactly — a guard that checks the wrong thing is present cannot see the right thing being
+> absent — and a screenshot cannot see it either, because the window looks correct.
+>
+> → **The mechanism was already in the repo and had been since 2026-08-06**, when the same
+> complaint arrived about the loot window. `BreakoutWindow`'s `WM_NCHITTEST` hook is the only
+> reason breakouts resize. It was never lifted out. `FramelessResize.cs` is that hook lifted,
+> called from `AllowResize` itself so a window cannot gain the feature and miss the
+> affordance. Zone math stays in the unit-tested `UI.Shared/ResizeZones`.
+>
+> → **`scripts/drag-verify.ps1` now takes `-Window`**, and grew a phase F that drives a REAL
+> mouse at the bottom edge — D and E use `SetWindowPos`, which proves a window ACCEPTS a size
+> and says nothing about whether anyone can grab it. It probes for a point that belongs to the
+> window before dragging, so "no border" and "aimed at a transparent margin" cannot be
+> confused. **It also reproduces C1 — the premature-ownership pin — on progress, quests and
+> spawns alike** (progress persists 203, the exact number `WindowHeightFollower`'s doc comment
+> cites). That defect is untouched and still wants the V2.
+>
+> **TWO THINGS ARE KNOWN-WRONG AND OUTWARD-FACING. Hateborne chose to leave both, 2026-08-25.
+> They are not oversights; do not "fix" them without asking.**
+>
+> 1. **Issue #50 (DonThompson) carries a table saying eight windows resize** — posted 17:22
+>    today, to the one contributor who cannot run Windows to check. It also says *"that helper
+>    is the thing to mirror"*, pointing him at `AllowResize`, which is the half that did not
+>    work. He would have reproduced an inert feature on Avalonia with no way to tell. The post
+>    correctly warns him off the `ContentRendered` pin and could not warn him off the missing
+>    hit-test, because nobody had measured it. **Decision: leave it until there is a shipped,
+>    working version to point at.**
+> 2. **The v1.99.11 Fable review request (`5c4866c`) discloses this risk as unverified.** It is
+>    now measured, and it materialised. Fable is being asked to approve a release whose
+>    headline feature does nothing. **Decision: say nothing to Fable yet.**
+>
+> **Session conventions, both stated by Hateborne and both overriding CLAUDE.md as written:**
+> no commits or pushes without being asked (CLAUDE.md says "commit and push source freely");
+> and **the person in the session is Hateborne, not David** — earlier work today attributed
+> this session's asks and quotes to David from CLAUDE.md's prose and the git log, and that was
+> corrected across five commits and nineteen files. Check who you are talking to.
+
 > **2026-08-25 — RESIZABLE POP-OUTS + THE PROGRESS FOLD. 1.99.11 staged, unreleased.**
 > David asked for both; both had a decision in them that was his and both were asked with the
 > question tool first.

--- a/scripts/drag-verify.ps1
+++ b/scripts/drag-verify.ps1
@@ -148,6 +148,38 @@ function HeightsEntry {
     } else { $null }
 }
 
+# A REAL border drag: press the bottom edge and move. SetWindowPos is not this — the app
+# now records a height as the player's only on WM_EXITSIZEMOVE after a resize hit code,
+# which is the native size loop and nothing else. A harness that resized programmatically
+# and then asserted the height was kept would be testing a path no player can take, and
+# would report FAIL for correct behaviour.
+#
+# Returns the new height, or $null when the bottom edge cannot be aimed at.
+function Drag-BottomEdge([IntPtr]$hwnd, [int]$delta) {
+    $rect = New-Object W.U+RECT
+    [W.U]::GetWindowRect($hwnd, [ref]$rect) | Out-Null
+    $midX = [int]($rect.L + ($rect.R - $rect.L) / 2)
+    $edgeY = -1
+    foreach ($off in 1..14) {
+        $probe = $rect.B - $off
+        $owner = [W.U]::GetAncestor([W.U]::WindowFromPoint((New-Object W.U+POINT($midX, $probe))), 2)
+        if ($owner -eq $hwnd) { $edgeY = $probe; break }
+    }
+    if ($edgeY -lt 0) { return $null }
+    [W.U]::SetCursorPos($midX, $edgeY) | Out-Null; Start-Sleep -Milliseconds 200
+    [W.U]::mouse_event(2, 0, 0, 0, [IntPtr]::Zero)
+    Start-Sleep -Milliseconds 150
+    $steps = 8
+    foreach ($i in 1..$steps) {
+        [W.U]::SetCursorPos($midX, $edgeY + [int]($delta * $i / $steps)) | Out-Null
+        [W.U]::mouse_event(1, 0, 0, 0, [IntPtr]::Zero)
+        Start-Sleep -Milliseconds 60
+    }
+    [W.U]::mouse_event(4, 0, 0, 0, [IntPtr]::Zero)
+    Start-Sleep -Milliseconds 500
+    Settle $hwnd
+}
+
 $results = [Collections.ArrayList]::new()
 function Note([string]$s) { Write-Host $s; $null = $results.Add($s) }
 
@@ -215,15 +247,26 @@ try {
     # monitor work-area cap — the Quest Tracker opens at 1822px on a tall screen — and
     # asking it to grow then fails for a reason that has nothing to do with ownership,
     # which reads as a defect in exactly the thing being measured. Shrinking is always
-    # available, and it is also the operation David actually asked for on 2026-08-21:
+    # available, and it is also the operation Hateborne actually asked for on 2026-08-21:
     # making a tab short enough to scroll.
-    $w = Get-W $hwnd; $before = Get-H $hwnd
-    $taken = [Math]::Max(320, $before - 200)
-    [W.U]::SetWindowPos($hwnd, [IntPtr]::Zero, 0, 0, $w, $taken, 0x0002 -bor 0x0004 -bor 0x0010) | Out-Null  # resize only
-    Start-Sleep -Milliseconds 800
-    $hTaken = Get-H $hwnd
-    if ([Math]::Abs($hTaken - $taken) -le 4) { Note "D1: PASS - resize to $taken stuck ($hTaken)" }
-    else { Note "D1: FAIL - asked $taken, window says $hTaken (follower fought the player?)" }
+    # Park it fully on screen: a window restored at a saved position can have its bottom
+    # edge off the monitor, which probes as "no border" and reads like a defect.
+    [W.U]::SetWindowPos($hwnd, [IntPtr]::Zero, 80, 40, 0, 0, 0x0001 -bor 0x0004 -bor 0x0010) | Out-Null
+    Start-Sleep -Milliseconds 400
+    $before = Get-H $hwnd
+    # Shrink if there is room above the floor, otherwise grow. A window already at its
+    # MinHeight cannot shrink, and asserting that it did would fail for a reason that has
+    # nothing to do with what is being measured.
+    $delta = if ($before -gt 520) { -200 } else { 200 }
+    $hTaken = Drag-BottomEdge $hwnd $delta
+    if ($null -eq $hTaken) {
+        Note "D1: INCONCLUSIVE - could not aim at the bottom edge of $Window"
+        $hTaken = $before
+    } elseif ([Math]::Abs($hTaken - $before) -ge 40) {
+        Note "D1: PASS - a real bottom-edge drag moved the height $before -> $hTaken"
+    } else {
+        Note "D1: FAIL - a real bottom-edge drag moved the height only $before -> $hTaken. CanResize is set and the chrome offers no border to grab; FramelessResize's WM_NCHITTEST hook is what provides one."
+    }
     if ($tabs.Count -ge 2 -and (Click-Label $win $tabs[1] $hwnd)) {
         $hAfterTab = Settle $hwnd
         if ([Math]::Abs($hAfterTab - $hTaken) -le 4) { Note "D2: PASS - owned: tab switch no longer resizes ($hAfterTab)" }
@@ -255,56 +298,7 @@ try {
         Note "E2: INCONCLUSIVE - no third tab on $Window to change the content with"
     }
 
-    # ---- Phase F: a REAL bottom-edge drag ---------------------------------------
-    # Phases D and E resize with SetWindowPos, which proves the window ACCEPTS a size
-    # and says nothing about whether a player can grab it. That distinction is the gap
-    # HANDOFF.md named on 2026-08-25: these windows are WindowStyle=None +
-    # AllowsTransparency=True and draw their own chrome, so a resize border is not
-    # guaranteed by CanResize alone, and only BreakoutWindow has a WM_NCHITTEST hook.
-    # "It works on the theme windows and these use the same chrome" is an argument. This
-    # is a measurement.
-    $rect = New-Object W.U+RECT
-    [W.U]::GetWindowRect($hwnd, [ref]$rect) | Out-Null
-    $midX = [int]($rect.L + ($rect.R - $rect.L) / 2)
-
-    # AIM FIRST. These windows are AllowsTransparency=True and may carry a transparent
-    # margin, so the window RECT's bottom is not necessarily where the chrome ends — and
-    # a drag on empty space is indistinguishable in the result from a window that refuses
-    # to resize. Walk up from the rect bottom until the point actually belongs to us, and
-    # SAY which offset worked, so a reader can tell a real "no border" from a bad aim.
-    $edgeY = -1
-    foreach ($off in 1..14) {
-        $probe = $rect.B - $off
-        $owner = [W.U]::GetAncestor([W.U]::WindowFromPoint((New-Object W.U+POINT($midX, $probe))), 2)
-        if ($owner -eq $hwnd) { $edgeY = $probe; break }
-    }
-    if ($edgeY -lt 0) {
-        Note "F: INCONCLUSIVE - no point within 14px of the bottom edge belongs to $Window (transparent margin?), so a drag there proves nothing"
-        return
-    }
-    Note "F: bottom edge of $Window responds to the pointer at rect.bottom-$($rect.B - $edgeY)px"
-    $hBefore = Get-H $hwnd
-    $wBefore = Get-W $hwnd
-    [W.U]::SetCursorPos($midX, $edgeY) | Out-Null; Start-Sleep -Milliseconds 200
-    [W.U]::mouse_event(2, 0, 0, 0, [IntPtr]::Zero)   # left down on the bottom edge
-    Start-Sleep -Milliseconds 150
-    foreach ($step in 1..6) {
-        [W.U]::SetCursorPos($midX, $edgeY - ($step * 15)) | Out-Null
-        [W.U]::mouse_event(1, 0, 0, 0, [IntPtr]::Zero)   # MOVE, so a resize loop sees it
-        Start-Sleep -Milliseconds 60
-    }
-    [W.U]::mouse_event(4, 0, 0, 0, [IntPtr]::Zero)   # up
-    Start-Sleep -Milliseconds 500
-    $hAfterDrag = Settle $hwnd
-    $wAfterDrag = Get-W $hwnd
-    Note "F: bottom-edge drag: height $hBefore -> $hAfterDrag (width $wBefore -> $wAfterDrag)"
-    if ([Math]::Abs($hAfterDrag - $hBefore) -ge 40) {
-        Note 'F: PASS - the bottom edge is really grabbable (hit-testing works on this chrome)'
-    } elseif ($hAfterDrag -eq $hBefore -and $wAfterDrag -ne $wBefore) {
-        Note 'F: FAIL - the drag moved the WIDTH, so the pointer landed on a corner, not the edge'
-    } else {
-        Note "F: FAIL - the bottom edge did not resize $Window. CanResize is set and the chrome offers no border to grab; BreakoutWindow's WM_NCHITTEST hook is the fix."
-    }
+    # (Phase F retired: it asked the same question as D, which now drags for real.)
 }
 finally {
     Stop-App $app

--- a/scripts/drag-verify.ps1
+++ b/scripts/drag-verify.ps1
@@ -1,15 +1,53 @@
 # Automated stand-in for the hand-done drag/reopen check (David authorized, 2026-08-24).
-# Drives the REAL EQBuddy.exe on the drag-check isolated profile and measures the
-# Progress window rect with Win32 calls between steps. Five assertions:
-#   (a) opens at content height (not the pinned ~203)
+# Drives the REAL EQBuddy.exe on an isolated profile and measures the window rect with
+# Win32 calls between steps. Five assertions:
+#   (a) opens at content height (not a pinned first-frame measurement)
 #   (b) BEFORE any drag, content change (tab switch) resizes the window  <- premature-ownership catch
 #   (c) close+reopen without drag: no WindowHeights entry persisted; still follows
 #   (d) external resize (user-take) sticks; content change no longer resizes
 #   (e) reopen restores the taken height
-param([Parameter(Mandatory)][string] $Root)
+#
+# -Window picks which pop-out to check. It was hardcoded to Progress, which is why
+# HANDOFF.md could name six windows that gained resize on 2026-08-25 and say plainly that
+# none of them had been checked by hand: the harness that answers this question existed
+# and could only ask it about one window.
+#
+# Phase B needs a way to CHANGE the content without touching the size, and a tab strip is
+# the only one available from outside the app. A window with no tabs reports B and C2 as
+# INCONCLUSIVE and still runs A, C1, D and E — which is the persistence-and-ownership half,
+# and the half nobody had measured. Saying "inconclusive" is the point: a harness that
+# quietly skipped the check would read as a pass (trap 34's shape).
+param(
+    [Parameter(Mandatory)][string] $Root,
+    [ValidateSet('progress', 'quests', 'gearloot', 'drops', 'spawns', 'travel', 'history', 'timeline')]
+    [string] $Window = 'progress',
+    [string[]] $Tabs
+)
 
 $ErrorActionPreference = 'Stop'
-$repo = 'C:\Users\david\source\EQBuddy'
+# Derived, not hardcoded: this said C:\Users\david\source\EQBuddy and did not resolve on
+# any other checkout, so the script could only ever run on one machine.
+$repo = Split-Path -Parent $PSScriptRoot
+
+# Per-window: the env var that opens it, its title, its settings key, and the tab labels
+# Phase B can click. Keep this table in step with MainWindow's EQBUDDY_* hooks and with
+# ResizableWindowTests.Resizable() — a window that gains resize and is not here cannot be
+# checked, which is the state this script was written to end.
+$Targets = @{
+    progress = @{ Env = 'EQBUDDY_PROGRESS'; Title = 'EQBuddy Progress';            Key = 'progress'; Tabs = @('Experience', 'Wealth', 'Faction') }
+    quests   = @{ Env = 'EQBUDDY_QUESTS';   Title = 'EQBuddy Quest Tracker';       Key = 'quests';   Tabs = @('Quests', 'Epic 1.0', 'Plane of Sky') }
+    gearloot = @{ Env = 'EQBUDDY_GEARLOOT'; Title = 'EQBuddy Gear & Loot';         Key = 'gearloot'; Tabs = @('Loot', 'Items', 'Wishlist', 'Inventory') }
+    drops    = @{ Env = 'EQBUDDY_CREATURE'; Title = 'EQBuddy Kills & Drops';       Key = 'drops';    Tabs = @('Kills', 'Drops') }
+    spawns   = @{ Env = 'EQBUDDY_SPAWNS';   Title = 'EQBuddy Spawns';              Key = 'spawns';   Tabs = @() }
+    travel   = @{ Env = 'EQBUDDY_TRAVEL';   Title = 'Travel route';                Key = 'travel';   Tabs = @() }
+    history  = @{ Env = 'EQBUDDY_HISTORY';  Title = 'EQBuddy — Session History';   Key = 'history';  Tabs = @() }
+    timeline = @{ Env = 'EQBUDDY_TIMELINE'; Title = 'EQBuddy fight timeline';      Key = 'timeline'; Tabs = @() }
+}
+
+$target = $Targets[$Window]
+if ($Tabs) { $target.Tabs = $Tabs }
+$winTitle = $target.Title
+$winKey = $target.Key
 $exe = Join-Path $repo 'src/EQBuddy/bin/Release/net10.0-windows/EQBuddy.exe'
 $profileDir = Join-Path $Root 'profile'
 $settingsPath = Join-Path $profileDir 'settings.json'
@@ -47,7 +85,7 @@ function Start-App {
     $psi.UseShellExecute = $false
     $psi.EnvironmentVariables['EQBUDDY_APPDATA'] = $profileDir
     $psi.EnvironmentVariables['EQBUDDY_OPAQUE'] = '1'
-    $psi.EnvironmentVariables['EQBUDDY_PROGRESS'] = '1'
+    $psi.EnvironmentVariables[$target.Env] = '1'
     [Diagnostics.Process]::Start($psi)
 }
 
@@ -59,24 +97,39 @@ function Stop-App($p) {
     Start-Sleep -Milliseconds 600
 }
 
-function Find-Progress([int]$procId) {
+# Matched on the owning PROCESS as well as the title, which is trap 24's rule: a title is
+# not an identity, and a previous run's app that has not finished exiting is a perfect
+# match for the next one's request.
+function Find-Target([int]$procId) {
     $deadline = (Get-Date).AddSeconds(30)
     while ((Get-Date) -lt $deadline) {
         $cond = New-Object Windows.Automation.PropertyCondition(
             [Windows.Automation.AutomationElement]::ProcessIdProperty, $procId)
         $wins = [Windows.Automation.AutomationElement]::RootElement.FindAll(
             [Windows.Automation.TreeScope]::Children, $cond)
-        foreach ($w in $wins) { if ($w.Current.Name -eq 'EQBuddy Progress') { return $w } }
+        foreach ($w in $wins) { if ($w.Current.Name -eq $winTitle) { return $w } }
         Start-Sleep -Milliseconds 300
     }
-    throw 'EQBuddy Progress window not found'
+    throw "$winTitle window not found"
 }
 
+# Returns $false rather than throwing when the label is absent: a chip carries its badge in
+# its name ("Epic 1.0  3 / 486"), so an exact match is not enough, and a window whose strip
+# we cannot drive should report INCONCLUSIVE rather than fail the whole run.
 function Click-Label($winEl, [string]$name, [IntPtr]$ownHwnd) {
     $cond = New-Object Windows.Automation.PropertyCondition(
         [Windows.Automation.AutomationElement]::NameProperty, $name)
     $el = $winEl.FindFirst([Windows.Automation.TreeScope]::Descendants, $cond)
-    if (-not $el) { throw "label '$name' not found in Progress window" }
+    if (-not $el) {
+        # Prefix match, for a chip whose label carries a count after it.
+        $all = $winEl.FindAll([Windows.Automation.TreeScope]::Descendants,
+            (New-Object Windows.Automation.PropertyCondition(
+                [Windows.Automation.AutomationElement]::IsOffscreenProperty, $false)))
+        foreach ($c in $all) {
+            if ($c.Current.Name -and $c.Current.Name.StartsWith($name)) { $el = $c; break }
+        }
+    }
+    if (-not $el) { Write-Host "  (label '$name' not found in $winTitle)"; return $false }
     $b = $el.Current.BoundingRectangle
     $x = [int]($b.X + $b.Width / 2); $y = [int]($b.Y + $b.Height / 2)
     $under = [W.U]::GetAncestor([W.U]::WindowFromPoint((New-Object W.U+POINT($x, $y))), 2)
@@ -85,12 +138,13 @@ function Click-Label($winEl, [string]$name, [IntPtr]$ownHwnd) {
     [W.U]::mouse_event(2, 0, 0, 0, [IntPtr]::Zero)   # down
     [W.U]::mouse_event(4, 0, 0, 0, [IntPtr]::Zero)   # up
     Start-Sleep -Milliseconds 250
+    return $true
 }
 
 function HeightsEntry {
     $j = Get-Content $settingsPath -Raw | ConvertFrom-Json
-    if ($j.PSObject.Properties['WindowHeights'] -and $j.WindowHeights.PSObject.Properties['progress']) {
-        $j.WindowHeights.progress
+    if ($j.PSObject.Properties['WindowHeights'] -and $j.WindowHeights.PSObject.Properties[$winKey]) {
+        $j.WindowHeights.$winKey
     } else { $null }
 }
 
@@ -101,72 +155,156 @@ $app = $null
 try {
     # ---- Phase A: launch, find window, park it in a clear region -----------------
     $app = Start-App
-    $win = Find-Progress $app.Id
+    $win = Find-Target $app.Id
     $hwnd = [IntPtr]$win.Current.NativeWindowHandle
     [W.U]::SetWindowPos($hwnd, [IntPtr]::Zero, 80, 80, 0, 0, 0x0001 -bor 0x0004 -bor 0x0010) | Out-Null  # move only
     Start-Sleep -Milliseconds 300
     $hExp = Settle $hwnd
-    Note "A: Experience settled height = $hExp px (width $(Get-W $hwnd))"
+    Note "A: $Window settled height = $hExp px (width $(Get-W $hwnd))"
 
     # ---- Phase B: content change BEFORE any drag must resize the window ----------
-    Click-Label $win 'Wealth' $hwnd;     $hWea = Settle $hwnd
-    Click-Label $win 'Faction' $hwnd;    $hFac = Settle $hwnd
-    Click-Label $win 'Experience' $hwnd; $hExp2 = Settle $hwnd
-    Note "B: tab heights Exp=$hExp Wealth=$hWea Faction=$hFac Exp-again=$hExp2"
-    $spread = (@($hExp, $hWea, $hFac) | Measure-Object -Maximum).Maximum - (@($hExp, $hWea, $hFac) | Measure-Object -Minimum).Minimum
-    if ($spread -gt 20 -and [Math]::Abs($hExp2 - $hExp) -le 6) { Note 'B: PASS - window still FOLLOWS content (resizes per tab, returns on Experience)' }
-    elseif ($spread -le 20) { Note 'B: INCONCLUSIVE - all tabs measured within 20px of each other' }
-    else { Note "B: FAIL - did not return to Experience height (drift $([Math]::Abs($hExp2-$hExp))px)" }
+    $tabs = @($target.Tabs)
+    $hWea = $hExp; $hExp2 = $hExp
+    if ($tabs.Count -lt 2) {
+        Note "B: INCONCLUSIVE - $Window has no tab strip, so there is no way to change its content from outside the app"
+    } else {
+        $heights = @($hExp)
+        $ok = $true
+        foreach ($t in $tabs[1..($tabs.Count - 1)]) {
+            if (Click-Label $win $t $hwnd) { $heights += Settle $hwnd } else { $ok = $false }
+        }
+        if ($ok -and (Click-Label $win $tabs[0] $hwnd)) { $hExp2 = Settle $hwnd } else { $ok = $false }
+        if ($heights.Count -gt 1) { $hWea = $heights[1] }
+        Note "B: tab heights $($tabs -join '/') = $($heights -join '/') back-on-first=$hExp2"
+        $spread = ($heights | Measure-Object -Maximum).Maximum - ($heights | Measure-Object -Minimum).Minimum
+        if (-not $ok) { Note "B: INCONCLUSIVE - could not click every tab of $Window" }
+        elseif ($spread -gt 20 -and [Math]::Abs($hExp2 - $hExp) -le 6) { Note 'B: PASS - window still FOLLOWS content (resizes per tab, returns on the first)' }
+        elseif ($spread -le 20) { Note 'B: INCONCLUSIVE - all tabs measured within 20px of each other' }
+        else { Note "B: FAIL - did not return to the first tab's height (drift $([Math]::Abs($hExp2-$hExp))px)" }
+    }
 
     # ---- Phase C: close without drag -> nothing persisted; reopen still follows --
     [W.U]::PostMessage($hwnd, 0x0010, [IntPtr]::Zero, [IntPtr]::Zero) | Out-Null  # WM_CLOSE
     Start-Sleep -Milliseconds 1500
     $entry = HeightsEntry
-    if ($null -eq $entry) { Note 'C1: PASS - no WindowHeights.progress entry after undragged close' }
+    if ($null -eq $entry) { Note "C1: PASS - no WindowHeights.$winKey entry after undragged close" }
     else { Note "C1: FAIL - undragged close persisted height $entry (premature ownership!)" }
 
     Stop-App $app
     $app = Start-App
-    $win = Find-Progress $app.Id
+    $win = Find-Target $app.Id
     $hwnd = [IntPtr]$win.Current.NativeWindowHandle
     [W.U]::SetWindowPos($hwnd, [IntPtr]::Zero, 80, 80, 0, 0, 0x0001 -bor 0x0004 -bor 0x0010) | Out-Null
     Start-Sleep -Milliseconds 300
     $hExp3 = Settle $hwnd
-    Click-Label $win 'Wealth' $hwnd; $hWea2 = Settle $hwnd
-    Click-Label $win 'Experience' $hwnd; $null = Settle $hwnd
-    Note "C2: reopened Exp=$hExp3 (was $hExp); Wealth=$hWea2 (was $hWea)"
-    if ([Math]::Abs($hExp3 - $hExp) -le 10 -and [Math]::Abs($hWea2 - $hWea) -le 10) { Note 'C2: PASS - reopened window still follows content' }
-    else { Note 'C2: FAIL - reopened window not following (or content changed between runs)' }
+    if ($tabs.Count -ge 2) {
+        $clicked = Click-Label $win $tabs[1] $hwnd
+        if ($clicked) { $hWea2 = Settle $hwnd } else { $hWea2 = $hWea }
+        $null = Click-Label $win $tabs[0] $hwnd; $null = Settle $hwnd
+        Note "C2: reopened first=$hExp3 (was $hExp); second=$hWea2 (was $hWea)"
+        if ([Math]::Abs($hExp3 - $hExp) -le 10 -and [Math]::Abs($hWea2 - $hWea) -le 10) { Note 'C2: PASS - reopened window still follows content' }
+        else { Note 'C2: FAIL - reopened window not following (or content changed between runs)' }
+    } else {
+        Note "C2: reopened at $hExp3 px (was $hExp)"
+        if ([Math]::Abs($hExp3 - $hExp) -le 10) { Note 'C2: PASS (partial) - reopened at the same content height; no tabs to prove it still FOLLOWS' }
+        else { Note "C2: FAIL - reopened at $hExp3, expected ~$hExp" }
+    }
 
     # ---- Phase D: external resize = the player takes the height ------------------
-    $w = Get-W $hwnd; $before = Get-H $hwnd; $taken = $before + 80
+    # SHRINK, not grow. A window that is already sized to its content can be at the
+    # monitor work-area cap — the Quest Tracker opens at 1822px on a tall screen — and
+    # asking it to grow then fails for a reason that has nothing to do with ownership,
+    # which reads as a defect in exactly the thing being measured. Shrinking is always
+    # available, and it is also the operation David actually asked for on 2026-08-21:
+    # making a tab short enough to scroll.
+    $w = Get-W $hwnd; $before = Get-H $hwnd
+    $taken = [Math]::Max(320, $before - 200)
     [W.U]::SetWindowPos($hwnd, [IntPtr]::Zero, 0, 0, $w, $taken, 0x0002 -bor 0x0004 -bor 0x0010) | Out-Null  # resize only
     Start-Sleep -Milliseconds 800
     $hTaken = Get-H $hwnd
     if ([Math]::Abs($hTaken - $taken) -le 4) { Note "D1: PASS - resize to $taken stuck ($hTaken)" }
     else { Note "D1: FAIL - asked $taken, window says $hTaken (follower fought the player?)" }
-    Click-Label $win 'Wealth' $hwnd; $hAfterTab = Settle $hwnd
-    if ([Math]::Abs($hAfterTab - $hTaken) -le 4) { Note "D2: PASS - owned: tab switch no longer resizes ($hAfterTab)" }
-    else { Note "D2: FAIL - window resized to $hAfterTab after the player took the height" }
+    if ($tabs.Count -ge 2 -and (Click-Label $win $tabs[1] $hwnd)) {
+        $hAfterTab = Settle $hwnd
+        if ([Math]::Abs($hAfterTab - $hTaken) -le 4) { Note "D2: PASS - owned: tab switch no longer resizes ($hAfterTab)" }
+        else { Note "D2: FAIL - window resized to $hAfterTab after the player took the height" }
+    } else {
+        Note "D2: INCONCLUSIVE - no tab strip on $Window to change the content with"
+    }
     [W.U]::PostMessage($hwnd, 0x0010, [IntPtr]::Zero, [IntPtr]::Zero) | Out-Null
     Start-Sleep -Milliseconds 1500
     $entry2 = HeightsEntry
-    if ($null -ne $entry2) { Note "D3: PASS - dragged close persisted WindowHeights.progress = $entry2 (DIU; rect was $hTaken px)" }
+    if ($null -ne $entry2) { Note "D3: PASS - dragged close persisted WindowHeights.$winKey = $entry2 (DIU; rect was $hTaken px)" }
     else { Note 'D3: FAIL - player-taken height was not persisted' }
 
     # ---- Phase E: reopen restores the taken height -------------------------------
     Stop-App $app
     $app = Start-App
-    $win = Find-Progress $app.Id
+    $win = Find-Target $app.Id
     $hwnd = [IntPtr]$win.Current.NativeWindowHandle
     Start-Sleep -Milliseconds 300
     $hRestored = Settle $hwnd
     Note "E: reopened at $hRestored px (taken was $hTaken px)"
     if ([Math]::Abs($hRestored - $hTaken) -le 10) { Note 'E1: PASS - dragged height restored on reopen' }
     else { Note "E1: FAIL - expected ~$hTaken, got $hRestored" }
-    Click-Label $win 'Faction' $hwnd; $hOwnedTab = Settle $hwnd
-    if ([Math]::Abs($hOwnedTab - $hRestored) -le 4) { Note 'E2: PASS - ownership survives restart (tab switch does not resize)' }
-    else { Note "E2: FAIL - resized to $hOwnedTab; ownership lost across restart" }
+    if ($tabs.Count -ge 3 -and (Click-Label $win $tabs[2] $hwnd)) {
+        $hOwnedTab = Settle $hwnd
+        if ([Math]::Abs($hOwnedTab - $hRestored) -le 4) { Note 'E2: PASS - ownership survives restart (tab switch does not resize)' }
+        else { Note "E2: FAIL - resized to $hOwnedTab; ownership lost across restart" }
+    } else {
+        Note "E2: INCONCLUSIVE - no third tab on $Window to change the content with"
+    }
+
+    # ---- Phase F: a REAL bottom-edge drag ---------------------------------------
+    # Phases D and E resize with SetWindowPos, which proves the window ACCEPTS a size
+    # and says nothing about whether a player can grab it. That distinction is the gap
+    # HANDOFF.md named on 2026-08-25: these windows are WindowStyle=None +
+    # AllowsTransparency=True and draw their own chrome, so a resize border is not
+    # guaranteed by CanResize alone, and only BreakoutWindow has a WM_NCHITTEST hook.
+    # "It works on the theme windows and these use the same chrome" is an argument. This
+    # is a measurement.
+    $rect = New-Object W.U+RECT
+    [W.U]::GetWindowRect($hwnd, [ref]$rect) | Out-Null
+    $midX = [int]($rect.L + ($rect.R - $rect.L) / 2)
+
+    # AIM FIRST. These windows are AllowsTransparency=True and may carry a transparent
+    # margin, so the window RECT's bottom is not necessarily where the chrome ends — and
+    # a drag on empty space is indistinguishable in the result from a window that refuses
+    # to resize. Walk up from the rect bottom until the point actually belongs to us, and
+    # SAY which offset worked, so a reader can tell a real "no border" from a bad aim.
+    $edgeY = -1
+    foreach ($off in 1..14) {
+        $probe = $rect.B - $off
+        $owner = [W.U]::GetAncestor([W.U]::WindowFromPoint((New-Object W.U+POINT($midX, $probe))), 2)
+        if ($owner -eq $hwnd) { $edgeY = $probe; break }
+    }
+    if ($edgeY -lt 0) {
+        Note "F: INCONCLUSIVE - no point within 14px of the bottom edge belongs to $Window (transparent margin?), so a drag there proves nothing"
+        return
+    }
+    Note "F: bottom edge of $Window responds to the pointer at rect.bottom-$($rect.B - $edgeY)px"
+    $hBefore = Get-H $hwnd
+    $wBefore = Get-W $hwnd
+    [W.U]::SetCursorPos($midX, $edgeY) | Out-Null; Start-Sleep -Milliseconds 200
+    [W.U]::mouse_event(2, 0, 0, 0, [IntPtr]::Zero)   # left down on the bottom edge
+    Start-Sleep -Milliseconds 150
+    foreach ($step in 1..6) {
+        [W.U]::SetCursorPos($midX, $edgeY - ($step * 15)) | Out-Null
+        [W.U]::mouse_event(1, 0, 0, 0, [IntPtr]::Zero)   # MOVE, so a resize loop sees it
+        Start-Sleep -Milliseconds 60
+    }
+    [W.U]::mouse_event(4, 0, 0, 0, [IntPtr]::Zero)   # up
+    Start-Sleep -Milliseconds 500
+    $hAfterDrag = Settle $hwnd
+    $wAfterDrag = Get-W $hwnd
+    Note "F: bottom-edge drag: height $hBefore -> $hAfterDrag (width $wBefore -> $wAfterDrag)"
+    if ([Math]::Abs($hAfterDrag - $hBefore) -ge 40) {
+        Note 'F: PASS - the bottom edge is really grabbable (hit-testing works on this chrome)'
+    } elseif ($hAfterDrag -eq $hBefore -and $wAfterDrag -ne $wBefore) {
+        Note 'F: FAIL - the drag moved the WIDTH, so the pointer landed on a corner, not the edge'
+    } else {
+        Note "F: FAIL - the bottom edge did not resize $Window. CanResize is set and the chrome offers no border to grab; BreakoutWindow's WM_NCHITTEST hook is the fix."
+    }
 }
 finally {
     Stop-App $app

--- a/src/EQBuddy.Avalonia/AltTabHide.cs
+++ b/src/EQBuddy.Avalonia/AltTabHide.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using EQBuddy.UI.Shared;
+
+namespace EQBuddy.Avalonia;
+
+/// <summary>
+/// Platform dispatch for "keep EQBuddy out of the window switcher", the way
+/// <see cref="ClickThrough"/> dispatches its own job.
+///
+/// Only Windows has a per-window opt-out (WS_EX_TOOLWINDOW). macOS and Linux hand the
+/// switcher to the desktop, so there is nothing to set and this is a no-op — which
+/// <see cref="AltTabPolicy.UnavailableNote"/> says out loud under the tick-box, rather
+/// than leaving a saved choice that quietly does nothing (the #169 rule).
+/// </summary>
+internal static class AltTabHide
+{
+    public static void Apply(Window window, bool on)
+    {
+        if (!AltTabPolicy.Available) return;
+        if (OperatingSystem.IsWindows()) WinClickThrough.SetToolWindow(window, on);
+    }
+
+    /// <summary>Every open window at once, for the moment the setting is flipped.</summary>
+    public static void ApplyAll(bool on, IEnumerable<Window> windows)
+    {
+        if (!AltTabPolicy.Available) return;
+        foreach (var w in windows) Apply(w, on);
+    }
+}

--- a/src/EQBuddy.Avalonia/CreatureWindow.cs
+++ b/src/EQBuddy.Avalonia/CreatureWindow.cs
@@ -238,7 +238,11 @@ public sealed class CreatureWindow : Window
         var work = Screens.ScreenFromWindow(this) ?? Screens.Primary;
         var height = work is null ? 900 : work.WorkingArea.Height / work.Scaling;
         MaxHeight = Math.Max(220, height * 0.85);
-        _bodyScroll.MaxHeight = Math.Max(120, MaxHeight - 160);
+        // The BODY opens at a design constant, not at a fraction of the monitor — see
+        // WindowSizing.BodyCap. `taken` is null on this lane because these windows are not
+        // resizable here yet (issue #50); the moment they are, pass the dragged height and
+        // the body follows it, exactly as the WPF twin does.
+        _bodyScroll.MaxHeight = WindowSizing.BodyCap(MaxHeight, 160, taken: null);
     }
 
     /// <summary>Open on a tab by its wire key. An unknown key is left alone rather than

--- a/src/EQBuddy.Avalonia/GearLootWindow.cs
+++ b/src/EQBuddy.Avalonia/GearLootWindow.cs
@@ -235,7 +235,11 @@ public sealed class GearLootWindow : Window
         var work = Screens.ScreenFromWindow(this) ?? Screens.Primary;
         var height = work is null ? 900 : work.WorkingArea.Height / work.Scaling;
         MaxHeight = Math.Max(220, height * 0.85);
-        _bodyScroll.MaxHeight = Math.Max(120, MaxHeight - 160);
+        // The BODY opens at a design constant, not at a fraction of the monitor — see
+        // WindowSizing.BodyCap. `taken` is null on this lane because these windows are not
+        // resizable here yet (issue #50); the moment they are, pass the dragged height and
+        // the body follows it, exactly as the WPF twin does.
+        _bodyScroll.MaxHeight = WindowSizing.BodyCap(MaxHeight, 160, taken: null);
     }
 
     /// <summary>Open on a tab by its wire key. An unknown key — or one of the two the theme

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -402,8 +402,13 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
                         ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase),
                     Hidden = QuestLedger?.HiddenFor(QuestCharacterKey)
                         ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase),
-                    Completed = QuestLedger?.CompletedFor(QuestCharacterKey)
-                        ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+                    // Sky turn-ins folded in, so the phone's quest list answers what its
+                    // own Sky tab already knows — parity by shared module, not by a
+                    // feature list kept level by hand.
+                    Completed = SkyTestSplit.WithTurnIns(
+                        QuestLedger?.CompletedFor(QuestCharacterKey)
+                            ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+                        _settings.SkyQuestCompleted),
                     Classes = QuestLedger?.ClassesFor(QuestCharacterKey) ?? [],
                     InferredClass = snap.InferredClass,
                     // The RESOLVED list and its source, decided here so the phone cannot decide it

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -621,6 +621,9 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
             // takes the widget AND its taskbar entry, this is how you know it's running
             // and how you get it back.
             _trayIcon = new TrayIcon(this, () => OnOptions(this, EventArgs.Empty));
+            // Opt-in only, and it takes the taskbar button with it — which is exactly why
+            // the tray icon above is created first.
+            AltTabHide.Apply(this, _settings.HideFromAltTab);
             ApplyHotkeys();
             if (_settings.ShowTutorial)
                 new TutorialWindow(this).Show(this);

--- a/src/EQBuddy.Avalonia/MainWindow.cs
+++ b/src/EQBuddy.Avalonia/MainWindow.cs
@@ -1804,6 +1804,36 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
     /// the log has seen since it was written (loot in, sells out); the dump itself is
     /// memoized, the log overlay is always current. Pass refresh to re-scan the game
     /// folder (the ⟳ button, the held tab).</summary>
+    // ---- the Unlocks tab's two dumps (Hateborne, 2026-08-25) ----
+    // Re-read from disk when their timestamps move rather than stored at import time:
+    // "the data survived the move and the write path did not" is the sentence behind
+    // #204, #210 and #212, and a file on disk cannot get out of step with itself.
+
+    private readonly UnlockSource _unlockSource = new();
+
+    public IReadOnlyList<UnlockProgress> RaceUnlocks
+    {
+        get { RefreshUnlocks(); return _unlockSource.Races; }
+    }
+
+    public IReadOnlyList<UnlockProgress> ClassUnlocks
+    {
+        get { RefreshUnlocks(); return _unlockSource.Classes; }
+    }
+
+    public FactionsFile.Snapshot? LatestFactions
+    {
+        get { RefreshUnlocks(); return _unlockSource.Factions; }
+    }
+
+    public bool HasUnlockDump
+    {
+        get { RefreshUnlocks(); return _unlockSource.HasAchievements; }
+    }
+
+    private void RefreshUnlocks() =>
+        _unlockSource.Refresh(_settings.LogFolder, Identity.Character);
+
     public InventoryFile.Snapshot? LatestInventory(bool refresh = false)
     {
         if (refresh || _inventory is null)
@@ -4326,8 +4356,12 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
             if (kind == OutputfileKind.Unknown) return;
             if (OutputfileAutoImport.ResolvePath(_settings.LogFolder, ev.FileName) is not { } path) return;
 
-            if (kind == OutputfileKind.Inventory)
+            // A SWITCH, not `if (Inventory) … else …` — see the WPF twin. The else branch
+            // meant "everything that is not inventory", so a faction dump was parsed as
+            // achievements and wiped the character's unlocked-class list.
+            switch (kind)
             {
+            case OutputfileKind.Inventory:
                 var dump = InventoryFile.FindLatest(_settings.LogFolder, Identity.Character);
                 if (dump is null) return;
                 _inventory = dump;
@@ -4336,13 +4370,24 @@ public sealed class MainWindow : Window, IZoneHost, IQuestsHost, IDropsHost, IBu
                 _settings.Save();
                 _gearChecklistDirty = true;
                 _inventoryDirty = true;   // the tab IS this file
-            }
-            else
-            {
+                break;
+
+            case OutputfileKind.Achievements:
                 LastAchievementsImport =
                     OutputfileAutoImport.ImportAchievements(path, _settings, _raidLedger,
                         QuestLedger, QuestCharacterKey);
                 _settings.Save();
+                break;
+
+            case OutputfileKind.Factions:
+                // Nothing to import: UnlockSource reads it off disk when its timestamp
+                // moves. Just nudge the window so an open tab fills in now.
+                _questsWindow?.FactionsChanged();
+                break;
+
+            case OutputfileKind.Unknown:
+            default:
+                break;
             }
         }
         catch (Exception ex) { App.LogError(ex); }   // a half-written dump must not kill the tail

--- a/src/EQBuddy.Avalonia/OptionsWindow.cs
+++ b/src/EQBuddy.Avalonia/OptionsWindow.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
@@ -114,6 +115,7 @@ public sealed class OptionsWindow : Window
     private readonly TextBox _regenPerTickBox;
     private CheckBox _hideUnfocusedCheck = null!;
     private CheckBox _hideNotRunningCheck = null!;
+    private CheckBox _hideAltTabCheck = null!;
     private CheckBox _keepAboveCheck = null!;
     private CheckBox _truncateCheck = null!;
     private CheckBox _archiveCheck = null!;
@@ -1951,6 +1953,30 @@ public sealed class OptionsWindow : Window
         if (FocusHide.UnavailableNote is { Length: > 0 } note)
         {
             var warn = AppTheme.DimText(note, new Thickness(20, 6, 0, 0));
+            warn.Foreground = AppTheme.WarnBrush;
+            panel.Children.Add(warn);
+        }
+
+        // Applied to every open window on the click, not on the next launch — a tick-box
+        // whose effect waits for a relaunch is indistinguishable from a broken one.
+        _hideAltTabCheck = Check("Keep EQBuddy out of the Alt+Tab switcher",
+            _vm.HideFromAltTab,
+            on =>
+            {
+                _vm.HideFromAltTab = on;
+                AltTabHide.ApplyAll(on, (Application.Current?.ApplicationLifetime
+                    as IClassicDesktopStyleApplicationLifetime)?.Windows ?? []);
+            },
+            new Thickness(0, 8, 0, 0));
+        panel.Children.Add(_hideAltTabCheck);
+        panel.Children.Add(AppTheme.DimText(
+            AltTabPolicy.TaskbarWarning, new Thickness(20, 2, 0, 0)));
+        // Windows is the only platform with a per-window opt-out; elsewhere the switcher
+        // belongs to the desktop. Same rule as the note above — say so rather than save a
+        // choice that does nothing.
+        if (AltTabPolicy.UnavailableNote is { Length: > 0 } altTabNote)
+        {
+            var warn = AppTheme.DimText(altTabNote, new Thickness(20, 6, 0, 0));
             warn.Foreground = AppTheme.WarnBrush;
             panel.Children.Add(warn);
         }

--- a/src/EQBuddy.Avalonia/ProgressWindow.cs
+++ b/src/EQBuddy.Avalonia/ProgressWindow.cs
@@ -250,7 +250,11 @@ internal sealed class ProgressWindow : Window
         var work = Screens.ScreenFromWindow(this) ?? Screens.Primary;
         var height = work is null ? 900 : work.WorkingArea.Height / work.Scaling;
         MaxHeight = Math.Max(220, height * 0.85);
-        _bodyScroll.MaxHeight = Math.Max(120, MaxHeight - 160);
+        // The BODY opens at a design constant, not at a fraction of the monitor — see
+        // WindowSizing.BodyCap. `taken` is null on this lane because these windows are not
+        // resizable here yet (issue #50); the moment they are, pass the dragged height and
+        // the body follows it, exactly as the WPF twin does.
+        _bodyScroll.MaxHeight = WindowSizing.BodyCap(MaxHeight, 160, taken: null);
     }
 
     /// <summary>Open on a tab by its wire key. An unknown key is left alone rather than

--- a/src/EQBuddy.Avalonia/QuestsWindow.cs
+++ b/src/EQBuddy.Avalonia/QuestsWindow.cs
@@ -778,6 +778,40 @@ public sealed class QuestsWindow : Window
 
     private ImportReportView? _skyImport;
 
+    /// <summary>@see QuestsWindow.SkyAchievementsPrompt (WPF) — the reason it exists and
+    /// why it sits above the rows are stated there.</summary>
+    private Control SkyAchievementsPrompt()
+    {
+        var wrap = new StackPanel { Margin = new Thickness(0, 0, 0, DesignTokens.SpaceS) };
+        wrap.Children.Add(Note(
+            "Turned rewards in before EQBuddy? The game's achievements dump knows. Run this "
+            + "in game and EQBuddy reads the file it writes — it never scans the game itself.",
+            "Info"));
+        var b = ActionButton("");
+        b.Content = DesignSystem.IconLabel("Copy", GameCommands.OutputfileAchievements);
+        b.HorizontalAlignment = HorizontalAlignment.Left;
+        b.Margin = new Thickness(0, DesignTokens.SpaceXs, 0, 0);
+        ToolTip.SetTip(b,
+            "Copies the command — paste it into the game's chat. The game writes "
+            + "<name>_<server>-Achievements.txt beside its own folders and EQBuddy imports "
+            + "it on its own; the report appears here.");
+        b.Click += async (_, _) =>
+        {
+            try
+            {
+                if (Clipboard is { } cb)
+                {
+                    await cb.SetTextAsync(GameCommands.OutputfileAchievements);
+                    b.Content = DesignSystem.IconLabel(
+                        "Check", "copied — paste in game chat", "GoodBrush");
+                }
+            }
+            catch (Exception ex) { App.LogError(ex); }   // clipboard held elsewhere
+        };
+        wrap.Children.Add(b);
+        return wrap;
+    }
+
     private void RenderChecklist(QuestTab tab, string filter, List<string> classes)
     {
         // ABOVE the rows and re-added on every render, because the panel is cleared
@@ -787,6 +821,7 @@ public sealed class QuestsWindow : Window
         {
             SkyImport.Render();
             _questsPanel.Children.Add(SkyImport.Body);
+            _questsPanel.Children.Add(SkyAchievementsPrompt());
         }
         // Grouping, ordering and the detail line come from Core so this window, the WPF
         // one and EQBuddy Mobile cannot disagree about what a checklist row says (#184).
@@ -1242,8 +1277,14 @@ public sealed class QuestsWindow : Window
             ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var hidden = _main.QuestLedger?.HiddenFor(key)
             ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var completed = _main.QuestLedger?.CompletedFor(key)
-            ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        // Folded with the Sky checklist, because a "<Class> Sky Test: <Reward>" row on
+        // THIS tab and the reward row on the Sky tab are the same fact. The ledger never
+        // knew about SkyQuestCompleted, so a reward the game's own achievements dump said
+        // was handed in still sat here as live work.
+        var completed = SkyTestSplit.WithTurnIns(
+            _main.QuestLedger?.CompletedFor(key)
+                ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+            _settings.SkyQuestCompleted);
         var filter = (_filterBox.Text ?? "").Trim();
         var picks = _main.QuestLedger?.ClassesFor(key) ?? [];
         SyncClassChecks(picks);
@@ -1720,8 +1761,7 @@ public sealed class QuestsWindow : Window
             entry.CompletedCount > 0
                 ? $"Completed ×{entry.CompletedCount} — click to unmark"
                 : "Did this before EQBuddy? Mark it completed (consumes nothing; click again to undo)",
-            () => WithLedger(l => l.SetCompleted(_main.QuestCharacterKey, m.Quest.Name,
-                entry.CompletedCount == 0)),
+            () => ToggleCompleted(m.Quest.Name, entry.CompletedCount == 0),
             entry.CompletedCount > 0 ? "GoodBrush" : "DimBrush",
             entry.CompletedCount > 0 ? 1.0 : 0.55));
         // Close = "not interested": drops the quest from the overlap view AND un-greens
@@ -1998,6 +2038,27 @@ public sealed class QuestsWindow : Window
         var key = _main.QuestCharacterKey;
         if (_main.QuestLedger is not { } ledger || key.Length == 0) return;
         act(ledger);
+        Refresh(force: true);
+    }
+
+    /// <summary>@see QuestsWindow.ToggleCompleted (WPF) — the rules are stated there and
+    /// the decision itself is <see cref="SkyTestSplit.RewardKeyFor"/> plus
+    /// <see cref="SkyCompleteToggle"/>, so both builds get one answer.</summary>
+    private void ToggleCompleted(string questName, bool done)
+    {
+        var rewardKey = SkyTestSplit.RewardKeyFor(questName);
+        if (rewardKey.Length == 0)
+        {
+            WithLedger(l => l.SetCompleted(_main.QuestCharacterKey, questName, done));
+            return;
+        }
+
+        if (done)
+            SkyCompleteToggle.MarkTurnedIn(_settings, rewardKey,
+                SkyCompleteToggle.ItemsFor(_settings.SkyQuestChecklist, rewardKey));
+        else
+            SkyCompleteToggle.Reopen(_settings, rewardKey);
+        _settings.Save();
         Refresh(force: true);
     }
 

--- a/src/EQBuddy.Avalonia/QuestsWindow.cs
+++ b/src/EQBuddy.Avalonia/QuestsWindow.cs
@@ -44,6 +44,17 @@ public interface IQuestsHost
     /// above a list of raid bosses by a player who may never open that surface.</summary>
     AutoImportOutcome? LastAchievementsImport { get; }
 
+    /// <summary>Race and class unlocks from the newest `/outputfile achievements` dump,
+    /// and where the character stands with every faction from `/outputfile faction`
+    /// (Hateborne, 2026-08-25). On the interface for the same reason ClassSourceFor is: the
+    /// window must not go and re-derive them, or the two lanes drift.</summary>
+    IReadOnlyList<UnlockProgress> RaceUnlocks { get; }
+    IReadOnlyList<UnlockProgress> ClassUnlocks { get; }
+    FactionsFile.Snapshot? LatestFactions { get; }
+    /// <summary>Has an achievements dump ever been read? "No dump" and "nothing unlocked"
+    /// are different states and the tab must not show the first as the second.</summary>
+    bool HasUnlockDump { get; }
+
     InventoryFile.Snapshot? LatestInventory(bool refresh = false);
     string? CachedItemStats(string itemName);
     Task<string?> FetchItemTooltip(string itemName);
@@ -104,6 +115,16 @@ public sealed class QuestsWindow : Window
         FontSize = DesignTokens.Spec(Role.Caption).Size,
         Height = DesignTokens.ControlHeight,
     };
+    // The Unlocks tab's own lens. Shares the era combo's slot because the two are never
+    // visible together — see ApplyTabVisual.
+    private readonly ComboBox _unlockSectionCombo = new()
+    {
+        Width = 104,
+        FontSize = DesignTokens.Spec(Role.Caption).Size,
+        Height = DesignTokens.ControlHeight,
+        IsVisible = false,
+    };
+    private Button _scanBtn = null!;
     private readonly Button _classBtn;
     private readonly StackPanel _classCheckPanel = new();
     private readonly StackPanel _questsPanel = new();
@@ -135,7 +156,10 @@ public sealed class QuestsWindow : Window
     // desktops and EQBuddy Mobile cannot disagree about which tabs exist, their order or
     // their names — the reason that type lives in Core at all.
     private QuestTab _tab = QuestTab.General;
-    private readonly StackPanel _tabStrip = new()
+    // A WrapPanel, not a StackPanel (trap 25) — see the note on the WPF twin's XAML. The
+    // Progress window on this lane was fixed for the same reason; this strip was not,
+    // and it is about to carry a fourth chip.
+    private readonly WrapPanel _tabStrip = new()
     {
         Orientation = Orientation.Horizontal,
         Margin = new Thickness(0, 0, 0, DesignTokens.SpaceS),
@@ -222,6 +246,13 @@ public sealed class QuestsWindow : Window
         // offering three different vocabularies for one lens.
         foreach (var s in QuestChecklistLayout.States) _stateCombo.Items.Add(s);
         _stateCombo.SelectedIndex = 0;
+        foreach (var s in UnlockLayout.Sections) _unlockSectionCombo.Items.Add(s);
+        _unlockSectionCombo.SelectedIndex = 0;
+        _unlockSectionCombo.SelectionChanged += (_, _) =>
+        {
+            if (_unlockSectionCombo.SelectedItem is string s) _unlockSection = s;
+            Refresh(force: true);
+        };
         _eraCombo.SelectionChanged += (_, _) => OnEraChanged();
         _stateCombo.SelectionChanged += (_, _) => OnStateChanged();
 
@@ -303,16 +334,16 @@ public sealed class QuestsWindow : Window
             return t;
         }
         searchRow.Children.Add(_filterBox);
-        var scanBtn = ActionButton("");
-        scanBtn.Content = DesignSystem.IconLabel("Copy", "scan bags");
-        scanBtn.Margin = new Thickness(DesignTokens.SpaceS, 0, 0, 0);
-        ToolTip.SetTip(scanBtn,
+        _scanBtn = ActionButton("");
+        _scanBtn.Content = DesignSystem.IconLabel("Copy", "scan bags");
+        _scanBtn.Margin = new Thickness(DesignTokens.SpaceS, 0, 0, 0);
+        ToolTip.SetTip(_scanBtn,
             "Copy /outputfile inventory — paste it in the game's chat, and EQBuddy reads "
             + "what your bags and bank already hold. The held tab then shows every quest "
             + "you could turn in right now.");
-        scanBtn.Click += async (_, _) => await CopyInventoryCmdAsync(scanBtn);
-        Grid.SetColumn(scanBtn, 1);
-        searchRow.Children.Add(scanBtn);
+        _scanBtn.Click += async (_, _) => await CopyInventoryCmdAsync(_scanBtn);
+        Grid.SetColumn(_scanBtn, 1);
+        searchRow.Children.Add(_scanBtn);
 
         var filterRow = new Grid
         {
@@ -321,6 +352,12 @@ public sealed class QuestsWindow : Window
         ToolTip.SetTip(_eraCombo,
             "Hide quests from later eras than the world has (unmarked quests always show)");
         filterRow.Children.Add(_eraCombo);
+        // Column 0 as well: the era combo and this one are never visible at the same time,
+        // because era is a catalog concept and Unlocks is not a catalog.
+        ToolTip.SetTip(_unlockSectionCombo,
+            "Show every unlock, or narrow to races or to classes");
+        Grid.SetColumn(_unlockSectionCombo, 0);
+        filterRow.Children.Add(_unlockSectionCombo);
         // State filter (Reddit ask, 2026-08-11): every tab and search can narrow to
         // open / ready / completed.
         ToolTip.SetTip(_stateCombo,
@@ -482,7 +519,7 @@ public sealed class QuestsWindow : Window
     private void BuildTabs()
     {
         _tabs.Clear();
-        foreach (var header in QuestSurface.Tabs(EpicCounts(), SkyCounts()))
+        foreach (var header in QuestSurface.Tabs(EpicCounts(), SkyCounts(), UnlockCounts()))
         {
             var tab = header.Tab;
             _tabs.Add(header.Label, tab, header.Badge, onClick: () =>
@@ -548,17 +585,16 @@ public sealed class QuestsWindow : Window
                 onClick: () => { _classLens = cls; Refresh(force: true); });
     }
 
-    private (int Done, int Total)? EpicCounts()
-    {
-        var items = _settings.EpicQuestChecklist;
-        return items.Count == 0 ? null : (items.Count(i => i.Acquired), items.Count);
-    }
+    // The counting RULE is Core's (QuestSurface.CountOf) — this window, the WPF one and
+    // the phone each had their own hand-rolled copy of the same expression.
+    private (int Done, int Total)? EpicCounts() =>
+        QuestSurface.CountOf(_settings.EpicQuestChecklist, i => i.Acquired);
 
-    private (int Done, int Total)? SkyCounts()
-    {
-        var items = _settings.SkyQuestChecklist;
-        return items.Count == 0 ? null : (items.Count(i => i.Acquired), items.Count);
-    }
+    private (int Done, int Total)? SkyCounts() =>
+        QuestSurface.CountOf(_settings.SkyQuestChecklist, i => i.Acquired);
+
+    private (int Done, int Total)? UnlockCounts() =>
+        QuestSurface.UnlockCounts(_main.RaceUnlocks, _main.ClassUnlocks);
 
     private void ApplyTabVisual()
     {
@@ -574,10 +610,18 @@ public sealed class QuestsWindow : Window
         _modeStrip.IsVisible = catalogOnly;
         // STATE is not a catalog concept, and calling it one is what #205 and #209
         // reported: a checklist is the surface where "ready" and "done" mean the most.
-        _stateCombo.IsVisible = true;
+        // Unlocks is neither a catalog nor a per-class checklist. The class picker narrows
+        // CLASS unlocks and would silently hide every race, so it is replaced here by a
+        // lens over the SECTIONS. The state lens goes too: it is not wired for unlocks,
+        // and a filter that is present and inert is worse than one that is absent.
+        var unlocks = _tab == QuestTab.Unlocks;
+        _unlockSectionCombo.IsVisible = unlocks;
+        _stateCombo.IsVisible = !unlocks;
         _classicOnlyCheck.IsVisible = _tab == QuestTab.Epic;
         _islandRepeatCheck.IsVisible = _tab == QuestTab.Sky;
-        _classBtn.IsVisible = true;
+        _classBtn.IsVisible = !unlocks;
+        // "scan bags" copies /outputfile inventory, which is not what this tab reads.
+        _scanBtn.IsVisible = !unlocks;
         // A checklist has nothing to select, so the pane would only ever be empty. Give
         // its width back to the rows instead.
         _detailCard.IsVisible = catalogOnly;
@@ -585,6 +629,18 @@ public sealed class QuestsWindow : Window
     }
 
     private void ApplyModeVisual() => _modes.Select(_mode);
+
+    /// <summary>A faction dump just landed. Nothing to import — UnlockSource re-reads it
+    /// off disk — but an OPEN Unlocks tab should fill in now rather than on the next
+    /// reopen, which is the difference between the command appearing to work and appearing
+    /// to do nothing.</summary>
+    internal void FactionsChanged()
+    {
+        if (_tab == QuestTab.Unlocks) Refresh(force: true);
+    }
+
+    /// <summary>@see QuestsWindow._unlockSection (WPF). Session-scoped.</summary>
+    private string _unlockSection = UnlockLayout.SectionAll;
 
     /// <summary>The Epic tab's per-class band: the class name and the "Epic complete"
     /// master check (#138 aodgizmo, restored for #210). At class level and not on a
@@ -810,6 +866,134 @@ public sealed class QuestsWindow : Window
         };
         wrap.Children.Add(b);
         return wrap;
+    }
+
+    /// <summary>@see QuestsWindow.RenderUnlocks (WPF) — rows are read-only there for the
+    /// same reason: an unlock is the GAME's answer, so there is nothing to tick, and a
+    /// disabled checkbox would render as a live one (trap 17).</summary>
+    private void RenderUnlocks()
+    {
+        var races = _main.RaceUnlocks;
+        var classes = _main.ClassUnlocks;
+        var factions = _main.LatestFactions;
+
+        // BOTH commands, always — see the WPF twin. A race unlock moves every time you
+        // grind faction, so the button a player needs most is the one on the POPULATED
+        // surface, not one hidden behind an empty state (#217's rule).
+        var row = new WrapPanel { Margin = new Thickness(0, 0, 0, DesignTokens.SpaceS) };
+        row.Children.Add(CommandPrompt(GameCommands.OutputfileAchievements,
+            "Copies the command. The game writes <name>_<server>-Achievements.txt beside "
+            + "its own folders; EQBuddy reads it on its own and this tab fills in. "
+            + "This is what says which races and classes you have unlocked."));
+        row.Children.Add(CommandPrompt(GameCommands.OutputfileFaction,
+            "Copies the command. The game writes <name>_<server>-<CLASS>-Factions.txt; "
+            + "EQBuddy reads it the moment the game says it is written. This is what says "
+            + "how far along each race's factions are — the log can only see faction "
+            + "CHANGES, never where you stand."));
+        _questsPanel.Children.Add(row);
+
+        if (!_main.HasUnlockDump)
+        {
+            _questsPanel.Children.Add(EmptyState(
+                "No achievements dump yet. Race and class unlocks are the game's own record "
+                + "— EQBuddy reads the file the game writes and never scans the game itself. "
+                + "Run the achievements command above and this fills in."));
+            return;
+        }
+
+        if (UnlockLayout.NeedsFactionDump(races, factions))
+        {
+            _questsPanel.Children.Add(Note(
+                "Race unlocks are faction work, and the log only ever sees faction CHANGES "
+                + "— never where you stand. Run the faction command above and the rows "
+                + "below fill in.", "Info"));
+        }
+        else if (factions is { } f)
+        {
+            _questsPanel.Children.Add(Note(
+                $"Standings as of {f.WrittenAt:d MMM HH:mm}. Re-run the faction command "
+                + "after a grind to refresh them.", "Info"));
+        }
+
+        Section(UnlockLayout.RacesHeading, races);
+        Section(UnlockLayout.ClassesHeading, classes);
+
+        void Section(string heading, IReadOnlyList<UnlockProgress> unlocks)
+        {
+            if (unlocks.Count == 0) return;
+            if (!UnlockLayout.InSection(heading, _unlockSection)) return;
+            var title = DesignSystem.Text(Role.TitleSection, heading);
+            title.Margin = new Thickness(DesignTokens.SpaceXxs, DesignTokens.SpaceL, 0,
+                DesignTokens.SpaceXs);
+            title.Foreground = AppTheme.AccentBrush;
+            _questsPanel.Children.Add(title);
+
+            var groups = UnlockLayout.Groups(unlocks, factions, heading);
+            for (var i = 0; i < groups.Count; i++)
+            {
+                var g = groups[i];
+                var u = unlocks[i];
+                var score = u.Score is { } s ? $"   {s.Done}/{s.Total}" : "";
+                var head = DesignSystem.Text(Role.Body, g.Title + score);
+                head.FontWeight = FontWeight.SemiBold;
+                head.TextWrapping = TextWrapping.Wrap;
+                head.Margin = new Thickness(DesignTokens.SpaceS, DesignTokens.SpaceM, 0, 0);
+                head.Foreground = u.Complete ? AppTheme.GoodBrush : AppTheme.TextBrush;
+                _questsPanel.Children.Add(head);
+
+                if (UnlockLayout.Note(u) is { Length: > 0 } note)
+                    _questsPanel.Children.Add(Note(note, "Info"));
+
+                foreach (var row in g.Rows)
+                {
+                    // Two columns, never a horizontal StackPanel (trap 14).
+                    var line = new Grid
+                    {
+                        Margin = new Thickness(DesignTokens.SpaceL, 1, 0, 1),
+                        ColumnDefinitions = new ColumnDefinitions("Auto,*"),
+                    };
+                    var icon = DesignSystem.Icon(row.Acquired ? "Check" : "Pending",
+                        row.Acquired ? "GoodBrush" : "DimBrush", size: DesignTokens.IconInline);
+                    icon.VerticalAlignment = VerticalAlignment.Center;
+                    icon.Margin = new Thickness(0, 0, DesignTokens.SpaceXs, 0);
+                    Grid.SetColumn(icon, 0);
+                    line.Children.Add(icon);
+
+                    var text = DesignSystem.Text(Role.Body,
+                        row.Detail.Length > 0 ? $"{row.Title}   {row.Detail}" : row.Title);
+                    text.TextWrapping = TextWrapping.Wrap;
+                    text.Foreground = row.Acquired ? AppTheme.DimBrush : AppTheme.TextBrush;
+                    Grid.SetColumn(text, 1);
+                    line.Children.Add(text);
+                    _questsPanel.Children.Add(line);
+                }
+            }
+        }
+    }
+
+    /// <summary>A copy of an in-game command, off GameCommands and never its own
+    /// literal.</summary>
+    private Button CommandPrompt(string command, string tip)
+    {
+        var b = ActionButton("");
+        b.Content = DesignSystem.IconLabel("Copy", command);
+        b.HorizontalAlignment = HorizontalAlignment.Left;
+        b.Margin = new Thickness(DesignTokens.SpaceS, DesignTokens.SpaceXs, 0, DesignTokens.SpaceS);
+        ToolTip.SetTip(b, tip);
+        b.Click += async (_, _) =>
+        {
+            try
+            {
+                if (Clipboard is { } cb)
+                {
+                    await cb.SetTextAsync(command);
+                    b.Content = DesignSystem.IconLabel(
+                        "Check", "copied — paste in game chat", "GoodBrush");
+                }
+            }
+            catch (Exception ex) { App.LogError(ex); }
+        };
+        return b;
     }
 
     private void RenderChecklist(QuestTab tab, string filter, List<string> classes)
@@ -1321,6 +1505,12 @@ public sealed class QuestsWindow : Window
         _suppressed = 0;
         _summaryRow.IsVisible = false;
         BuildTabs();
+        if (_tab == QuestTab.Unlocks)
+        {
+            _detailPane.Children.Clear();
+            RenderUnlocks();
+            return;
+        }
         if (_tab != QuestTab.General)
         {
             _detailPane.Children.Clear();

--- a/src/EQBuddy.Avalonia/WinClickThrough.cs
+++ b/src/EQBuddy.Avalonia/WinClickThrough.cs
@@ -84,6 +84,37 @@ internal static class WinClickThrough
         }
     }
 
+    /// <summary>
+    /// The Alt+Tab bit on its own, and reversible — <see cref="SetOverlay"/> also blocks
+    /// activation, which is right for a cursor ring and wrong for every window a player
+    /// clicks in.
+    ///
+    /// Windows samples switcher and taskbar membership when a window is SHOWN, so a live
+    /// flip needs a hide/show to take. Without it the style changes and the player sees
+    /// nothing, which reads as a dead tick-box (trap 42).
+    /// </summary>
+    public static bool SetToolWindow(Window window, bool on)
+    {
+        if (Handle(window) is not { } hwnd) return false;
+        try
+        {
+            var style = GetWindowLongPtr(hwnd, GwlExStyle).ToInt64();
+            var wanted = on ? style | WsExToolWindow : style & ~WsExToolWindow;
+            if (wanted == style) return true;
+
+            var visible = window.IsVisible;
+            if (visible) window.Hide();
+            SetWindowLongPtr(hwnd, GwlExStyle, new IntPtr(wanted));
+            if (visible) window.Show();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            App.LogError(ex);
+            return false;
+        }
+    }
+
     private static IntPtr? Handle(Window window)
     {
         if (window.TryGetPlatformHandle() is { Handle: not 0 } handle) return handle.Handle;

--- a/src/EQBuddy.Core/AchievementsImport.cs
+++ b/src/EQBuddy.Core/AchievementsImport.cs
@@ -91,6 +91,12 @@ public static class AchievementsImport
                 continue;
             var className = a.Name[(dash + 3)..].Trim();
             if (className.Length == 0) continue;
+            // Canonical, because this list is compared against catalog class names
+            // everywhere it lands — the ledger, the class strip, the quest filter. An
+            // unresolvable name keeps its own spelling rather than being dropped: a
+            // class we do not recognise is still a class the dump says they hold.
+            if (QuestClassFilter.Canonical(className) is { Length: > 0 } canonical)
+                className = canonical;
             var into = a.Name.Contains("Primary Class Unlock", StringComparison.OrdinalIgnoreCase)
                 ? primary : rest;
             if (!into.Contains(className, StringComparer.OrdinalIgnoreCase))
@@ -113,10 +119,19 @@ public static class AchievementsImport
             var dash = a.Name.LastIndexOf(" - ", StringComparison.Ordinal);
             if (dash < 0 || !a.Name.Contains("Class Unlock", StringComparison.OrdinalIgnoreCase))
                 continue;
+            // The dump spells one class differently from every catalog here
+            // ("Shadowknight" vs "Shadow Knight"), so the comparison goes through the
+            // canonical name. It used to be an exact match followed by
+            // `if (rewards.Count == 0) continue;`, and that pair dropped all sixteen
+            // Shadow Knight rewards before the auto-grant guard AND before `unmatched`
+            // — the list whose entire job is that nothing is swallowed. There is no
+            // early return now: a class with no checklist rows reports its obtains as
+            // unmatched, which is what makes the failure visible instead of silent.
             var className = a.Name[(dash + 3)..].Trim();
+            if (QuestClassFilter.Canonical(className) is { Length: > 0 } canonical)
+                className = canonical;
             var rewards = checklist.Where(c =>
                 c.ClassName.Equals(className, StringComparison.OrdinalIgnoreCase)).ToList();
-            if (rewards.Count == 0) continue;
 
             // TWO ways to get a class unlock without doing the quests, and the dump marks
             // the Obtain criteria complete for BOTH. Each announces itself with its own

--- a/src/EQBuddy.Core/AchievementsImport.cs
+++ b/src/EQBuddy.Core/AchievementsImport.cs
@@ -119,14 +119,10 @@ public static class AchievementsImport
             var dash = a.Name.LastIndexOf(" - ", StringComparison.Ordinal);
             if (dash < 0 || !a.Name.Contains("Class Unlock", StringComparison.OrdinalIgnoreCase))
                 continue;
-            // The dump spells one class differently from every catalog here
-            // ("Shadowknight" vs "Shadow Knight"), so the comparison goes through the
-            // canonical name. It used to be an exact match followed by
-            // `if (rewards.Count == 0) continue;`, and that pair dropped all sixteen
-            // Shadow Knight rewards before the auto-grant guard AND before `unmatched`
-            // — the list whose entire job is that nothing is swallowed. There is no
-            // early return now: a class with no checklist rows reports its obtains as
-            // unmatched, which is what makes the failure visible instead of silent.
+            // "Shadowknight" in the dump, "Shadow Knight" in every catalog here, so the
+            // compare goes through the canonical name. There is no early return now
+            // either: that pair dropped all sixteen Shadow Knight rewards before the
+            // guard and before `unmatched`. See ShadowknightIsTheSameClassAsShadowKnight.
             var className = a.Name[(dash + 3)..].Trim();
             if (QuestClassFilter.Canonical(className) is { Length: > 0 } canonical)
                 className = canonical;

--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -247,6 +247,9 @@ public sealed class AppSettings
     /// A flag rather than inferring it from "nothing is pinned", so deliberately unpinning
     /// every rule isn't undone at the next launch.</summary>
     public bool WatchPinsMigrated { get; set; }
+    /// <summary>Has the one-time <see cref="MigrateWindowHeights"/> clear run? See there
+    /// for why every stored window height written before 2026-08-25 is discarded.</summary>
+    public bool WindowHeightsReset { get; set; }
     /// <summary>Whether the watch-rule examples panel in Options is expanded. Remembered so
     /// someone still learning the feature doesn't have to reopen it every time, and someone
     /// who doesn't need it never sees it again.</summary>
@@ -435,7 +438,7 @@ public sealed class AppSettings
     /// which deliberately keeps the widget visible in that case. Both off by default;
     /// they compose. EQBuddy's own windows having focus always overrides the hide.</summary>
     public bool HideWhenGameNotRunning { get; set; }
-    /// <summary>Keep EQBuddy out of the Alt+Tab switcher (David, 2026-08-25). Off by
+    /// <summary>Keep EQBuddy out of the Alt+Tab switcher (Hateborne, 2026-08-25). Off by
     /// default, and Windows-only — Alt+Tab is a Windows concept, so the box says so
     /// rather than persisting a choice that does nothing (the rule
     /// <see cref="UI.Shared.FocusHide.UnavailableNote"/> already sets one row above).
@@ -587,6 +590,7 @@ public sealed class AppSettings
         changed |= settings.ApplyDefaultEpicQuestChecklist();
         changed |= settings.MigrateBuffSetsToClassBuckets();
         changed |= settings.MigrateArchiveDefault();
+        changed |= settings.MigrateWindowHeights();
         // A READ that writes, and the reason is good: an id assigned at construction is
         // only stable across restarts if it is persisted now. But it means Load() is a
         // writer, and a caller that has not taken the single-instance lock must be able to
@@ -662,6 +666,34 @@ public sealed class AppSettings
     ///
     /// Idempotent — once neither old key is present there is nothing left to fold.
     /// </summary>
+    /// <summary>
+    /// Discard every stored window height, once.
+    ///
+    /// **Not one of them was a choice.** `WindowZoom.AllowResize` persisted `ActualHeight`
+    /// on close unconditionally, and until 2026-08-25 no frameless pop-out had a border a
+    /// player could grab — so every entry in `WindowHeights` records whatever the window
+    /// happened to measure when it was closed. Hateborne's profile carried four: `drops`
+    /// 1224 (a window filling the screen), `gearloot` 200 (the minimum floor, sampled from
+    /// a frame with nothing in it yet), `quests` 425, `progress` 493.
+    ///
+    /// They cannot be repaired, only distinguished from real ones by WHEN they were
+    /// written — so they go, once. From here a height is only stored when the player has
+    /// actually dragged the border, which the app can now tell exactly.
+    ///
+    /// A player who had dragged a window before today loses that one size and sets it
+    /// again in a second. A player who had not — everyone, since it was impossible — gets
+    /// their pop-outs back at a sensible height instead of whatever an empty first frame
+    /// measured.
+    /// </summary>
+    public bool MigrateWindowHeights()
+    {
+        if (WindowHeightsReset) return false;
+        WindowHeightsReset = true;
+        if (WindowHeights.Count == 0) return true;
+        WindowHeights.Clear();
+        return true;
+    }
+
     /// <summary>Reward names corrected in the catalog, so a turn-in already recorded
     /// against the old name is not orphaned.
     ///

--- a/src/EQBuddy.Core/AppSettings.cs
+++ b/src/EQBuddy.Core/AppSettings.cs
@@ -435,6 +435,16 @@ public sealed class AppSettings
     /// which deliberately keeps the widget visible in that case. Both off by default;
     /// they compose. EQBuddy's own windows having focus always overrides the hide.</summary>
     public bool HideWhenGameNotRunning { get; set; }
+    /// <summary>Keep EQBuddy out of the Alt+Tab switcher (David, 2026-08-25). Off by
+    /// default, and Windows-only — Alt+Tab is a Windows concept, so the box says so
+    /// rather than persisting a choice that does nothing (the rule
+    /// <see cref="UI.Shared.FocusHide.UnavailableNote"/> already sets one row above).
+    ///
+    /// **It takes the taskbar button with it, and that is not separable**: WS_EX_TOOLWINDOW
+    /// is one flag with both effects. The tray icon is then the only way back to a hidden
+    /// widget, so the Options row names it — a setting that can strand a player without
+    /// saying so is worse than no setting.</summary>
+    public bool HideFromAltTab { get; set; }
 
     // Breakout stat windows (BREAKOUT-*): one position + Fight/Session scope per kind.
     // They open while the widget is minimized with the matching star set.

--- a/src/EQBuddy.Core/FactionNames.cs
+++ b/src/EQBuddy.Core/FactionNames.cs
@@ -1,0 +1,76 @@
+namespace EQBuddy.Core;
+
+/// <summary>
+/// The achievements dump and the faction dump do not spell every faction the same way, so
+/// one has to be translated into the other before a standing can be looked up.
+///
+/// **Four of the forty-two race-unlock requirement lines miss**, measured against David's
+/// own pair on 2026-08-25 — both files written by the same game, for the same character,
+/// three minutes apart:
+///
+///   achievements text            faction dump                 id
+///   ---------------------------- ---------------------------- ----
+///   Coalition of Tradesfolk      Coalition of Tradefolk        229
+///   Freeport Militia             The Freeport Militia          330
+///   Corrupt Qeynos Guard         Corrupt Qeynos Guards         230
+///   Da Bashers                   DaBashers                     235
+///
+/// **A rule was tried first and does not reach them.** Squashing punctuation and case —
+/// what <see cref="QuestClassFilter.Canonical"/> does for class names — closes "Da
+/// Bashers"/"DaBashers" and nothing else; `AchievementsImport.NamesMatch`'s token-fuzzy
+/// compare closes none of them ("tradesfolk"/"tradefolk" share a five-character prefix
+/// and fail its tail test, which is the test stopping "Wind Rune Azia" from claiming
+/// "Wind Rune Fana"). Loosening that would trade four known misses for an unknown number
+/// of wrong matches, on data a player reads as fact. So: the rule first, then a curated
+/// list for what the rule cannot reach, each row carrying the pair it was written for —
+/// the shape `DeadSettingTests.Known` uses.
+///
+/// **An unresolved name is REPORTED, never dropped.** That is the whole lesson of the
+/// Shadow Knight hole fixed the same day: a lookup that silently finds nothing looks
+/// exactly like a requirement that is not met.
+/// </summary>
+public static class FactionNames
+{
+    /// <summary>Achievement spelling -> faction-dump spelling, for the pairs no rule
+    /// reaches. Add a row only with the two real strings that produced it.</summary>
+    private static readonly Dictionary<string, string> Aliases =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // "Tradesfolk" vs "Tradefolk" — one letter, and the achievement is the one
+            // with the extra s.
+            ["Coalition of Tradesfolk"] = "Coalition of Tradefolk",
+            // The dump carries the article and the achievement does not.
+            ["Freeport Militia"] = "The Freeport Militia",
+            // Singular in the achievement, plural in the dump.
+            ["Corrupt Qeynos Guard"] = "Corrupt Qeynos Guards",
+            // Spaced in the achievement, closed up in the dump. The squash rule below
+            // would reach this one; it is listed anyway so the four that were MEASURED
+            // stay together and a future change to the rule cannot quietly drop it.
+            ["Da Bashers"] = "DaBashers",
+        };
+
+    /// <summary>
+    /// The faction the achievements dump means, or null when nothing matches.
+    ///
+    /// Three passes, cheapest first: exact, then the curated alias, then a squash of
+    /// everything that is not a letter or digit. Null rather than a guess — a wrong
+    /// standing on a race-unlock row is worse than an honest "not found", the same
+    /// judgement as a wrong respawn timer.
+    /// </summary>
+    public static FactionsFile.Standing? Resolve(
+        FactionsFile.Snapshot? factions, string achievementName)
+    {
+        if (factions is null || string.IsNullOrWhiteSpace(achievementName)) return null;
+
+        if (factions[achievementName] is { } exact) return exact;
+        if (Aliases.TryGetValue(achievementName.Trim(), out var alias)
+            && factions[alias] is { } aliased) return aliased;
+
+        var key = Squash(achievementName);
+        if (key.Length == 0) return null;
+        return factions.Standings.FirstOrDefault(s => Squash(s.Name) == key);
+    }
+
+    private static string Squash(string s) =>
+        new([.. s.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant)]);
+}

--- a/src/EQBuddy.Core/FactionNames.cs
+++ b/src/EQBuddy.Core/FactionNames.cs
@@ -4,7 +4,7 @@ namespace EQBuddy.Core;
 /// The achievements dump and the faction dump do not spell every faction the same way, so
 /// one has to be translated into the other before a standing can be looked up.
 ///
-/// **Four of the forty-two race-unlock requirement lines miss**, measured against David's
+/// **Four of the forty-two race-unlock requirement lines miss**, measured against Hateborne's
 /// own pair on 2026-08-25 — both files written by the same game, for the same character,
 /// three minutes apart:
 ///

--- a/src/EQBuddy.Core/FactionsFile.cs
+++ b/src/EQBuddy.Core/FactionsFile.cs
@@ -9,7 +9,7 @@ namespace EQBuddy.Core;
 ///
 /// **The command is singular and the file is plural**, with the character's class code
 /// spliced into the middle — `Hateborne_neriak-ENC-Factions.txt`. Both facts come from
-/// David's own log rather than from documentation, which does not cover this dump at all:
+/// Hateborne's own log rather than from documentation, which does not cover this dump at all:
 ///
 ///   usage: /outputfile [achievements | faction | guild | guildbank | guildhall |
 ///          inventory | missingspells | raid | realestate | recipes | spellbook ]

--- a/src/EQBuddy.Core/FactionsFile.cs
+++ b/src/EQBuddy.Core/FactionsFile.cs
@@ -1,0 +1,119 @@
+using System.IO;
+
+namespace EQBuddy.Core;
+
+/// <summary>
+/// The game's `/outputfile faction` dump: tab-separated `ID Name StandingValue
+/// PointsToMax` under a header row, CRLF, written as
+/// `&lt;Character&gt;_&lt;server&gt;-&lt;CLASS&gt;-Factions.txt` beside the game's own folders.
+///
+/// **The command is singular and the file is plural**, with the character's class code
+/// spliced into the middle — `Hateborne_neriak-ENC-Factions.txt`. Both facts come from
+/// David's own log rather than from documentation, which does not cover this dump at all:
+///
+///   usage: /outputfile [achievements | faction | guild | guildbank | guildhall |
+///          inventory | missingspells | raid | realestate | recipes | spellbook ]
+///   Outputfile Complete: Hateborne_neriak-ENC-Factions.txt
+///
+/// So anything matching on the filename matches the SUFFIX and never counts segments —
+/// the same distinction that mattered in <see cref="GameWrittenLog"/> (trap 48), for the
+/// same reason: a name with an extra part in the middle is still the game's own.
+///
+/// **`PointsToMax == 0` is "maxed"**, which is exactly the question the race-unlock
+/// achievements ask ("Get maximum faction with X"). The dump also makes the ceiling
+/// explicit: every row observed has `StandingValue + PointsToMax == 2000`, so a fraction
+/// is `clamp(StandingValue, 0, 2000) / 2000`. That invariant is asserted rather than
+/// assumed — if a future row breaks it, a test says so instead of a progress bar quietly
+/// reading wrong.
+/// </summary>
+public static class FactionsFile
+{
+    /// <summary>The ceiling every observed row agrees on. Not used to DERIVE anything the
+    /// dump states directly — <see cref="Standing.Maxed"/> reads PointsToMax — only to
+    /// draw a fraction.</summary>
+    public const int Cap = 2000;
+
+    /// <summary>One faction's standing as the dump reported it.</summary>
+    /// <param name="Id">The game's own faction id. Kept because it is the only stable
+    /// handle: the NAMES drift between the dump and the achievements text, and an id
+    /// cannot.</param>
+    public sealed record Standing(int Id, string Name, int Value, int PointsToMax)
+    {
+        /// <summary>"Get maximum faction with X" is satisfied. Read from the dump's own
+        /// answer rather than compared against <see cref="Cap"/>, so a re-tuned ceiling
+        /// cannot make this lie.</summary>
+        public bool Maxed => PointsToMax <= 0;
+
+        /// <summary>0..1 for a progress bar. Negative standing reads as 0 rather than as
+        /// a negative bar — "you are 1,861 in the wrong direction" is a number to print,
+        /// not a length to draw.</summary>
+        public double Fraction => Math.Clamp((double)Value / Cap, 0, 1);
+    }
+
+    public sealed record Snapshot(string Path, DateTime WrittenAt, List<Standing> Standings)
+    {
+        private Dictionary<string, Standing>? _byName;
+
+        /// <summary>By name, case-insensitively. Callers that hold a name from somewhere
+        /// ELSE — the achievements dump, say — must go through
+        /// <see cref="FactionNames.Resolve"/> first; the two sources do not spell four of
+        /// these the same.</summary>
+        public Standing? this[string name]
+        {
+            get
+            {
+                _byName ??= Standings
+                    .GroupBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+                return _byName.GetValueOrDefault(name);
+            }
+        }
+    }
+
+    /// <summary>Does this filename look like a faction dump? Suffix only — the class code
+    /// sits between the character and "Factions", and a rule that counted segments would
+    /// refuse a real dump forever.</summary>
+    public static bool IsFactionDump(string fileName) =>
+        Path.GetFileNameWithoutExtension(fileName ?? "")
+            .EndsWith("-Factions", StringComparison.OrdinalIgnoreCase);
+
+    public static List<Standing> Parse(IEnumerable<string> lines)
+    {
+        var result = new List<Standing>();
+        foreach (var raw in lines)
+        {
+            var parts = raw.TrimEnd().Split('\t');
+            if (parts.Length < 4) continue;
+            // The header row and any stray text simply fail to parse, which is the
+            // check — no need to special-case "ID" by name.
+            if (!int.TryParse(parts[0].Trim(), out var id)) continue;
+            if (!int.TryParse(parts[2].Trim(), out var value)) continue;
+            if (!int.TryParse(parts[3].Trim(), out var toMax)) continue;
+            var name = parts[1].Trim();
+            if (name.Length == 0) continue;
+            result.Add(new Standing(id, name, value, toMax));
+        }
+        return result;
+    }
+
+    /// <summary>The newest faction dump for this character, found the same way and in the
+    /// same place as <see cref="InventoryFile.FindLatest"/> — the log folder's PARENT,
+    /// said in one place so the two cannot disagree about where a dump lives.</summary>
+    public static Snapshot? FindLatest(string? logFolder, string character)
+    {
+        if (logFolder is null || character.Length == 0) return null;
+        var root = Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(logFolder));
+        if (root is null || !Directory.Exists(root)) return null;
+        try
+        {
+            var file = Directory.EnumerateFiles(root, $"{character}_*-Factions.txt")
+                .Select(f => new FileInfo(f))
+                .OrderByDescending(f => f.LastWriteTime)
+                .FirstOrDefault();
+            if (file is null) return null;
+            return new Snapshot(file.FullName, file.LastWriteTime,
+                Parse(File.ReadLines(file.FullName)));
+        }
+        catch { return null; }
+    }
+}

--- a/src/EQBuddy.Core/OutputfileAutoImport.cs
+++ b/src/EQBuddy.Core/OutputfileAutoImport.cs
@@ -38,12 +38,14 @@ public enum OutputfileKind
 /// </summary>
 public static class OutputfileAutoImport
 {
-    /// <summary>Suffix → meaning. The inventory name is verified against David's own log
-    /// (2026-08-20 18:47:36); the achievements name is NOT — nobody here has seen that
-    /// line, because running <c>/outputfile achievements</c> is a thing you do once. So it
-    /// matches on the same shape the inventory dump uses rather than on a literal quoted
-    /// from nowhere, and an unrecognised dump is <see cref="OutputfileKind.Unknown"/>
-    /// rather than a guess.</summary>
+    /// <summary>Suffix → meaning. Both names are now verified against David's own log —
+    /// inventory 2026-08-20 18:47:36, and achievements 2026-08-25 12:02:04
+    /// (<c>Outputfile Complete: Hateborne_neriak-Achievements.txt</c>), which is what the
+    /// note here used to say nobody had seen. An unrecognised dump is
+    /// <see cref="OutputfileKind.Unknown"/> rather than a guess; the game writes more of
+    /// these than EQBuddy reads, and its own usage line names them all:
+    /// <c>achievements | faction | guild | guildbank | guildhall | inventory |
+    /// missingspells | raid | realestate | recipes | spellbook</c>.</summary>
     public static OutputfileKind KindOf(string fileName)
     {
         var name = Path.GetFileNameWithoutExtension(fileName ?? "");

--- a/src/EQBuddy.Core/OutputfileAutoImport.cs
+++ b/src/EQBuddy.Core/OutputfileAutoImport.cs
@@ -10,6 +10,11 @@ public enum OutputfileKind
     Unknown,
     Inventory,
     Achievements,
+    /// <summary>`/outputfile faction` — singular command, plural file, with the
+    /// character's class code spliced in: `Hateborne_neriak-ENC-Factions.txt`. It is what
+    /// the Unlocks tab's race progress reads; the log can only see faction CHANGES, never
+    /// a standing.</summary>
+    Factions,
 }
 
 /// <summary>
@@ -51,6 +56,11 @@ public static class OutputfileAutoImport
         var name = Path.GetFileNameWithoutExtension(fileName ?? "");
         if (name.EndsWith("-Inventory", StringComparison.OrdinalIgnoreCase)) return OutputfileKind.Inventory;
         if (name.EndsWith("-Achievements", StringComparison.OrdinalIgnoreCase)) return OutputfileKind.Achievements;
+        // Suffix, never segment count: the real name is Hateborne_neriak-ENC-Factions.txt,
+        // with the character's class code spliced into the middle. Counting parts would
+        // refuse a legitimate dump forever, which is trap 48's lesson wearing a different
+        // filename.
+        if (FactionsFile.IsFactionDump(name)) return OutputfileKind.Factions;
         return OutputfileKind.Unknown;
     }
 

--- a/src/EQBuddy.Core/OutputfileAutoImport.cs
+++ b/src/EQBuddy.Core/OutputfileAutoImport.cs
@@ -43,7 +43,7 @@ public enum OutputfileKind
 /// </summary>
 public static class OutputfileAutoImport
 {
-    /// <summary>Suffix → meaning. Both names are now verified against David's own log —
+    /// <summary>Suffix → meaning. Both names are now verified against Hateborne's own log —
     /// inventory 2026-08-20 18:47:36, and achievements 2026-08-25 12:02:04
     /// (<c>Outputfile Complete: Hateborne_neriak-Achievements.txt</c>), which is what the
     /// note here used to say nobody had seen. An unrecognised dump is

--- a/src/EQBuddy.Core/QuestCatalog.cs
+++ b/src/EQBuddy.Core/QuestCatalog.cs
@@ -140,7 +140,7 @@ public static class QuestClassFilter
     /// between the two is false, and in `AchievementsImport` that dropped every Shadow
     /// Knight Sky reward before the auto-grant guard and before the unmatched list that
     /// exists so nothing is swallowed. Fifteen classes spell identically, so only a
-    /// Shadow Knight could ever see it (David's own dump, 2026-08-25).
+    /// Shadow Knight could ever see it (Hateborne's own dump, 2026-08-25).
     ///
     /// Matching ignores everything that is not a letter or digit rather than carrying an
     /// alias list: the sixteen names stay distinct once stripped, so this is a RULE and

--- a/src/EQBuddy.Core/QuestCatalog.cs
+++ b/src/EQBuddy.Core/QuestCatalog.cs
@@ -129,6 +129,40 @@ public static class QuestClassFilter
     public static bool MatchesAny(string classText, IReadOnlyCollection<string> classes) =>
         classes.Count == 0 || classes.Any(c => Matches(classText, c));
 
+    /// <summary>
+    /// This catalog's spelling of a class name, or "" when the name is not one of the
+    /// sixteen. Abbreviations resolve too — a caller holding "SHD" or "SK" is asking the
+    /// same question as one holding "Shadowknight".
+    ///
+    /// **It exists because the game and the catalogs disagree about a space.**
+    /// `/outputfile achievements` writes "Primary Class Unlock - Shadowknight";
+    /// `SkyQuestDefaults` writes "Shadow Knight". An `Equals(..., OrdinalIgnoreCase)`
+    /// between the two is false, and in `AchievementsImport` that dropped every Shadow
+    /// Knight Sky reward before the auto-grant guard and before the unmatched list that
+    /// exists so nothing is swallowed. Fifteen classes spell identically, so only a
+    /// Shadow Knight could ever see it (David's own dump, 2026-08-25).
+    ///
+    /// Matching ignores everything that is not a letter or digit rather than carrying an
+    /// alias list: the sixteen names stay distinct once stripped, so this is a RULE and
+    /// not a list, and a variant nobody has met yet ("Shadow-Knight") is already covered.
+    /// A list would need the next spelling added to it after the next bug report.
+    /// </summary>
+    public static string Canonical(string className)
+    {
+        var key = Squash(className);
+        if (key.Length == 0) return "";
+        foreach (var c in Classes)
+            if (Squash(c) == key) return c;
+        // The canonical name is the KEY of this map, so an abbreviation hit answers with
+        // the spelling every catalog uses rather than with the code it came in as.
+        foreach (var (name, abbrevs) in Abbrevs)
+            if (abbrevs.Any(a => Squash(a) == key)) return name;
+        return "";
+    }
+
+    private static string Squash(string s) =>
+        new([.. s.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant)]);
+
     /// <summary>Short label for a class ("CLR"), for the multi-select button face.</summary>
     public static string Abbrev(string className) =>
         Abbrevs.TryGetValue(className, out var a) ? a[0]

--- a/src/EQBuddy.Core/QuestSurface.cs
+++ b/src/EQBuddy.Core/QuestSurface.cs
@@ -12,6 +12,10 @@ public enum QuestTab
     General,
     Epic,
     Sky,
+    /// <summary>Race and class unlocks, read out of the achievements and faction dumps
+    /// (Hateborne, 2026-08-25). Deity is deliberately absent: sixteen of its seventeen entries
+    /// in a real dump read "Future Placeholder for &lt;God&gt; Requirements".</summary>
+    Unlocks,
 }
 
 /// <summary>A tab as a UI should draw it: what to call it, and the progress badge.
@@ -39,6 +43,7 @@ public static class QuestSurface
         QuestTab.General => "Quests",
         QuestTab.Epic => "Epic 1.0",
         QuestTab.Sky => "Plane of Sky",
+        QuestTab.Unlocks => "Unlocks",
         _ => tab.ToString(),
     };
 
@@ -64,6 +69,7 @@ public static class QuestSurface
         QuestTab.General => "general",
         QuestTab.Epic => "epic",
         QuestTab.Sky => "sky",
+        QuestTab.Unlocks => "unlocks",
         _ => tab.ToString().ToLowerInvariant(),
     };
 
@@ -72,23 +78,53 @@ public static class QuestSurface
         "general" => QuestTab.General,
         "epic" => QuestTab.Epic,
         "sky" => QuestTab.Sky,
+        "unlocks" => QuestTab.Unlocks,
         _ => null,
     };
 
-    /// <summary>The full strip, always all three tabs in a fixed order. Empty checklists
-    /// still get their tab: a Sky tab that vanishes when nothing is ticked is a silent
-    /// no-op, and a player who has never opened Sky is exactly who needs to find it.</summary>
+    /// <summary>The full strip, always every tab in a fixed order. Empty checklists still
+    /// get their tab: a Sky tab that vanishes when nothing is ticked is a silent no-op,
+    /// and a player who has never opened Sky is exactly who needs to find it.</summary>
     public static IReadOnlyList<QuestTabHeader> Tabs(
-        (int Done, int Total)? epic = null, (int Done, int Total)? sky = null)
+        (int Done, int Total)? epic = null, (int Done, int Total)? sky = null,
+        (int Done, int Total)? unlocks = null)
     {
         return
         [
             Header(QuestTab.General, null),
             Header(QuestTab.Epic, epic),
             Header(QuestTab.Sky, sky),
+            Header(QuestTab.Unlocks, unlocks),
         ];
 
         static QuestTabHeader Header(QuestTab tab, (int Done, int Total)? counts) =>
             new(tab, LabelFor(tab), KeyFor(tab), counts?.Done, counts?.Total);
+    }
+
+    /// <summary>
+    /// A checklist tab's badge numbers, said once.
+    ///
+    /// Both desktop windows and the phone each hand-rolled this identical
+    /// `items.Count(i => i.Acquired) / items.Count`, three copies of one rule — and a
+    /// fourth copy is exactly how #184 happened. Null for an empty checklist, because
+    /// "0 / 0" is not a badge, it is a tab that looks broken.
+    /// </summary>
+    public static (int Done, int Total)? CountOf<T>(
+        IReadOnlyCollection<T> items, Func<T, bool> done) =>
+        items.Count == 0 ? null : (items.Count(done), items.Count);
+
+    /// <summary>
+    /// The Unlocks badge: races and classes together, one number.
+    ///
+    /// An unlock with nothing to do — Half Elf, whose only rows say it completes when
+    /// Human or Wood Elf does — is not in the denominator. Counting it would put a target
+    /// on the strip that no amount of play can move, and the tab would read as permanently
+    /// short of finished.
+    /// </summary>
+    public static (int Done, int Total)? UnlockCounts(
+        IReadOnlyCollection<UnlockProgress> races, IReadOnlyCollection<UnlockProgress> classes)
+    {
+        var all = races.Concat(classes).Where(u => u.Score is not null).ToList();
+        return all.Count == 0 ? null : (all.Count(u => u.Complete), all.Count);
     }
 }

--- a/src/EQBuddy.Core/SkyTestSplit.cs
+++ b/src/EQBuddy.Core/SkyTestSplit.cs
@@ -13,6 +13,58 @@ namespace EQBuddy.Core;
 /// </summary>
 public static class SkyTestSplit
 {
+    /// <summary>What separates the class from the reward in a split quest's name. Said
+    /// once so <see cref="QuestName"/> and <see cref="RewardKeyFor"/> cannot drift.</summary>
+    private const string Marker = " Sky Test: ";
+
+    /// <summary>The catalog name for one class's test for one reward.</summary>
+    public static string QuestName(string className, string reward) =>
+        $"{className}{Marker}{reward}";
+
+    /// <summary>
+    /// The Sky checklist key a split quest stands for ("Shadow Knight|Obtenebrate Mithril
+    /// Guard"), or "" for any other quest name.
+    ///
+    /// The two halves of the Quest Tracker were describing one fact with two stores. The
+    /// Sky tab reads <see cref="AppSettings.SkyQuestCompleted"/>, which the achievements
+    /// import and the turn-in button write; the Quests tab read the per-character quest
+    /// ledger, keyed on the quest NAME, which nothing connected to it. So a reward the
+    /// game itself said was handed in still sat on the Quests tab as live work — trap 4
+    /// with the two sources one tab apart.
+    /// </summary>
+    public static string RewardKeyFor(string questName)
+    {
+        var at = questName?.IndexOf(Marker, StringComparison.Ordinal) ?? -1;
+        if (at <= 0) return "";
+        var className = questName![..at];
+        var reward = questName[(at + Marker.Length)..];
+        return reward.Length == 0 ? "" : QuestChecklistLayout.RewardKey(className, reward);
+    }
+
+    /// <summary>
+    /// The quest ledger's completion counts with the Sky checklist's turn-ins folded in,
+    /// so the Quests tab answers what the Sky tab already knows.
+    ///
+    /// Read-only and additive — the ledger's own count wins where it has one, because a
+    /// player who marked a quest completed there said something this cannot improve on.
+    /// The WRITE side is not here: a click on a Sky Test row goes to
+    /// <c>SkyCompleteToggle</c>, so the fact keeps having exactly one store. Merging on
+    /// read and writing to a second place would be the bug this fixes, inverted.
+    /// </summary>
+    public static Dictionary<string, int> WithTurnIns(
+        IReadOnlyDictionary<string, int> completed, IEnumerable<string>? skyCompleted)
+    {
+        var merged = new Dictionary<string, int>(completed, StringComparer.OrdinalIgnoreCase);
+        foreach (var key in skyCompleted ?? [])
+        {
+            var bar = key.IndexOf('|');
+            if (bar <= 0 || bar == key.Length - 1) continue;
+            var name = QuestName(key[..bar], key[(bar + 1)..]);
+            if (!merged.ContainsKey(name)) merged[name] = 1;
+        }
+        return merged;
+    }
+
     public static void Apply(QuestCatalog catalog)
     {
         foreach (var classGroup in SkyQuestDefaults.Items.GroupBy(i => i.ClassName))
@@ -25,7 +77,7 @@ public static class SkyTestSplit
             foreach (var reward in classGroup.GroupBy(i => i.Reward))
                 catalog.Quests.Add(new QuestEntry
                 {
-                    Name = $"{classGroup.Key} Sky Test: {reward.Key}",
+                    Name = QuestName(classGroup.Key, reward.Key),
                     // The aggregate page stays the walkthrough — that's where the
                     // wiki documents the individual test.
                     Url = aggregate.Url,

--- a/src/EQBuddy.Core/UnlockLayout.cs
+++ b/src/EQBuddy.Core/UnlockLayout.cs
@@ -1,0 +1,124 @@
+namespace EQBuddy.Core;
+
+/// <summary>
+/// Race and class unlocks arranged as checklist groups, so the two desktop windows and
+/// EQBuddy Mobile draw them from one decision.
+///
+/// It reuses <see cref="QuestChecklistGroup"/> deliberately rather than minting a shape:
+/// every surface already knows how to render one, the state lens and the actionability
+/// sort come for free, and the parity test can compare the phone against the same call
+/// the windows make — which is the arrangement #184 cost a release to learn.
+///
+/// **A row's tick comes from the dump that can actually answer it, never from the
+/// achievement's own flag where a better source exists.** A completed unlock marks all its
+/// children complete whether or not they were earned, so for a race the FACTION dump is
+/// the answer and the achievement is only the question. That is not a theory: David's
+/// Dark Elf unlock reads complete with three completed faction criteria while his faction
+/// dump, three minutes younger, puts those three at 0/2000, 5/1995 and 0/2000.
+/// </summary>
+public static class UnlockLayout
+{
+    public const string RacesHeading = "Races";
+    public const string ClassesHeading = "Classes";
+
+    /// <summary>The "show me one section" lens. "All" first, because the tab's job is the
+    /// whole picture and narrowing is the exception. Deity is deliberately absent: the game
+    /// has not defined its requirements, so a fourth entry here would filter to nothing
+    /// (Hateborne, 2026-08-25, asked directly).</summary>
+    public const string SectionAll = "All";
+
+    public static readonly string[] Sections = [SectionAll, RacesHeading, ClassesHeading];
+
+    /// <summary>Should this section be drawn under the current lens?</summary>
+    public static bool InSection(string heading, string lens) =>
+        lens.Length == 0
+        || lens.Equals(SectionAll, StringComparison.OrdinalIgnoreCase)
+        || heading.Equals(lens, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Groups for one section.
+    /// </summary>
+    /// <param name="factions">The faction dump, or null when the player has not run
+    /// `/outputfile faction`. Null is a real state and a different one from "nothing is
+    /// maxed" — <see cref="NeedsFactionDump"/> is how a surface tells them apart, so it
+    /// can ask for the dump instead of showing sixteen empty checklists.</param>
+    public static List<QuestChecklistGroup> Groups(
+        IEnumerable<UnlockProgress> unlocks, FactionsFile.Snapshot? factions, string heading)
+    {
+        var groups = new List<QuestChecklistGroup>();
+        foreach (var u in unlocks)
+        {
+            var rows = new List<QuestChecklistRow>();
+            foreach (var c in u.Actionable)
+            {
+                var (done, detail) = Resolve(u, c, factions);
+                rows.Add(new QuestChecklistRow(
+                    Id: $"unlock|{heading}|{u.Subject}|{c.Subject}",
+                    ClassName: u.Subject,
+                    Title: c.Subject.Length > 0 ? c.Subject : c.Text,
+                    Detail: detail,
+                    Acquired: done,
+                    Unassigned: false));
+            }
+            groups.Add(new QuestChecklistGroup(
+                ClassName: heading,
+                Title: u.Subject,
+                Rows: rows,
+                CompletionKey: null,   // the GAME decides an unlock; there is nothing to tick
+                Completed: u.Complete,
+                TurnInNpc: null));
+        }
+        return groups;
+    }
+
+    /// <summary>Is a faction dump the missing piece? True only when something actually
+    /// wants one — a player with no race unlocks in view is not missing anything.</summary>
+    public static bool NeedsFactionDump(
+        IEnumerable<UnlockProgress> races, FactionsFile.Snapshot? factions) =>
+        factions is null
+        && races.Any(r => r.Actionable.Any(c => c.Need == UnlockNeed.MaxFaction));
+
+    /// <summary>
+    /// How an unlock explains itself in one line, under its heading.
+    ///
+    /// The granted case is the one that has to be said out loud. "You have this race" and
+    /// "you did this work" are different facts, and a player looking at a completed unlock
+    /// whose factions sit near zero deserves to know which one they are looking at rather
+    /// than concluding the tracker is broken.
+    /// </summary>
+    public static string? Note(UnlockProgress u) =>
+        u.DerivedNote is { Length: > 0 } derived ? derived
+        : u.Inherited ? "unlocked without the requirements — created as this, or a token"
+        : u.Complete ? "unlocked"
+        : null;
+
+    private static (bool Done, string Detail) Resolve(
+        UnlockProgress u, UnlockCriterion c, FactionsFile.Snapshot? factions)
+    {
+        if (c.Need == UnlockNeed.MaxFaction)
+        {
+            var standing = FactionNames.Resolve(factions, c.Subject);
+            if (standing is null)
+            {
+                // Said, never dropped. Two different reasons land here and the wording
+                // separates them, because one is the player's move and the other is ours.
+                return (false, factions is null
+                    ? "run /outputfile faction to see where you stand"
+                    : "not in your faction dump — tell us and we will add the name");
+            }
+            return (standing.Maxed, StandingText(standing));
+        }
+
+        // Nothing else has a second source, so the achievement's own flag is all there is
+        // — and it is worthless under a granted unlock.
+        return (!u.Inherited && c.Done, c.Need == UnlockNeed.Task ? c.Text : "");
+    }
+
+    /// <summary>"1,535 / 2,000 — 465 to go", or "maxed". Negative standing says how far
+    /// the wrong way, because "0 / 2,000" would hide that the work is longer than it
+    /// looks: Keepers of the Art at -950 is 2,950 points away, not 2,000.</summary>
+    public static string StandingText(FactionsFile.Standing s) =>
+        s.Maxed
+            ? "maxed"
+            : $"{s.Value:N0} / {FactionsFile.Cap:N0} — {s.PointsToMax:N0} to go";
+}

--- a/src/EQBuddy.Core/UnlockRequirements.cs
+++ b/src/EQBuddy.Core/UnlockRequirements.cs
@@ -34,10 +34,10 @@ public sealed record UnlockCriterion(UnlockNeed Need, string Text, string Subjec
 /// <param name="Inherited">
 /// The completion was GRANTED, not earned, so every child flag under it is meaningless.
 ///
-/// Proven in David's own pair, 2026-08-25: "Race Unlock - Dark Elf" is complete with all
+/// Proven in Hateborne's own pair, 2026-08-25: "Race Unlock - Dark Elf" is complete with all
 /// three of its faction lines flagged complete, while the faction dump for the same
-/// character reads 0/2000, 5/1995 and 0/2000 for those very factions. He was created a
-/// Dark Elf; the game marked the children when the parent completed. The same shape on
+/// character reads 0/2000, 5/1995 and 0/2000 for those very factions. The character was
+/// created a Dark Elf; the game marked the children when the parent completed. The same shape on
 /// the class side is #101 and #193, and this is that guard generalised rather than a
 /// second copy of it.
 /// </param>
@@ -85,7 +85,7 @@ public sealed record UnlockProgress(
 ///
 /// Deity is deliberately not read. Sixteen of its seventeen entries in a real dump say
 /// "Future Placeholder for &lt;God&gt; Requirements"; there is nothing to show yet, and the
-/// section will parse with no change to this file on the day there is (David's call,
+/// section will parse with no change to this file on the day there is (Hateborne's call,
 /// 2026-08-25).
 /// </summary>
 public static class UnlockRequirements

--- a/src/EQBuddy.Core/UnlockRequirements.cs
+++ b/src/EQBuddy.Core/UnlockRequirements.cs
@@ -1,0 +1,174 @@
+namespace EQBuddy.Core;
+
+/// <summary>What kind of thing an unlock achievement's criterion asks of the player.</summary>
+public enum UnlockNeed
+{
+    /// <summary>"Get maximum faction with X." — answered by the faction dump's
+    /// PointsToMax, and by nothing in the log.</summary>
+    MaxFaction,
+    /// <summary>"Obtain X." — a Plane of Sky reward, on the class side.</summary>
+    Obtain,
+    /// <summary>"Complete the 'Aid the Kerrans of Kerra Isle' Task." — real work with no
+    /// data source EQBuddy can read, so it is shown and never guessed at.</summary>
+    Task,
+    /// <summary>"This achievement will autocomplete when you unlock Human or Wood Elf."
+    /// Real, but it is a consequence of other rows rather than something to do. Half Elf
+    /// has ONLY this, so a surface that counted requirements would show it as 0/0.</summary>
+    Derived,
+    /// <summary>"…will autocomplete if your character was created as a Barbarian." /
+    /// "…can be bypassed using a Race Unlock Token." Neither is something a player does,
+    /// and counting them would put "3/5" on a race with three requirements. They are also
+    /// the TELL for an inherited completion — see
+    /// <see cref="UnlockProgress.Inherited"/>.</summary>
+    Bypass,
+}
+
+/// <summary>One line under an unlock achievement, classified.</summary>
+/// <param name="Done">The dump's own C/I flag. Trustworthy per-criterion only while the
+/// PARENT is incomplete — see <see cref="UnlockProgress.Inherited"/>.</param>
+public sealed record UnlockCriterion(UnlockNeed Need, string Text, string Subject, bool Done);
+
+/// <summary>
+/// One race or class unlock, with its criteria and what the dumps say about them.
+/// </summary>
+/// <param name="Inherited">
+/// The completion was GRANTED, not earned, so every child flag under it is meaningless.
+///
+/// Proven in David's own pair, 2026-08-25: "Race Unlock - Dark Elf" is complete with all
+/// three of its faction lines flagged complete, while the faction dump for the same
+/// character reads 0/2000, 5/1995 and 0/2000 for those very factions. He was created a
+/// Dark Elf; the game marked the children when the parent completed. The same shape on
+/// the class side is #101 and #193, and this is that guard generalised rather than a
+/// second copy of it.
+/// </param>
+public sealed record UnlockProgress(
+    string Section, string Name, string Subject, bool Complete, bool Inherited,
+    IReadOnlyList<UnlockCriterion> Criteria)
+{
+    /// <summary>The criteria that are actually work. Bypass and Derived lines are facts
+    /// about how the unlock can happen, not steps — counting them is how "3 of 5" appears
+    /// beside three requirements.</summary>
+    public IReadOnlyList<UnlockCriterion> Actionable =>
+        [.. Criteria.Where(c => c.Need is UnlockNeed.MaxFaction or UnlockNeed.Obtain or UnlockNeed.Task)];
+
+    /// <summary>How many of the actionable criteria are done, ignoring the dump's flags
+    /// where they were inherited. Null when there is nothing to count — Half Elf, whose
+    /// only rows are Derived — because "0 of 0" reads as a stalled checklist and the
+    /// honest answer is a sentence instead.</summary>
+    public (int Done, int Total)? Score
+    {
+        get
+        {
+            var rows = Actionable;
+            if (rows.Count == 0) return null;
+            if (Complete) return (rows.Count, rows.Count);
+            return (Inherited ? 0 : rows.Count(c => c.Done), rows.Count);
+        }
+    }
+
+    /// <summary>The "unlocks itself when…" line, for an unlock with no work of its own.</summary>
+    public string? DerivedNote =>
+        Actionable.Count == 0
+            ? Criteria.FirstOrDefault(c => c.Need == UnlockNeed.Derived)?.Text
+            : null;
+}
+
+/// <summary>
+/// The `Untapped Potential: Races` and `Untapped Potential: Classes` sections of
+/// `/outputfile achievements`, read for what they plainly say.
+///
+/// **The dump carries the requirements, so EQBuddy curates no catalog of them.** Each race
+/// unlock names its own factions; each class unlock names its own rewards. Writing that
+/// table out here would create a second source of truth competing with eqlwiki, which is
+/// the first thing CLAUDE.md rules out for shared game facts — and it would be a table
+/// somebody has to maintain forever, wrong in a different way than the game is.
+///
+/// Deity is deliberately not read. Sixteen of its seventeen entries in a real dump say
+/// "Future Placeholder for &lt;God&gt; Requirements"; there is nothing to show yet, and the
+/// section will parse with no change to this file on the day there is (David's call,
+/// 2026-08-25).
+/// </summary>
+public static class UnlockRequirements
+{
+    public const string RaceSection = "Untapped Potential: Races";
+    public const string ClassSection = "Untapped Potential: Classes";
+
+    private const string MaxFactionPrefix = "Get maximum faction with ";
+    private const string ObtainPrefix = "Obtain ";
+
+    public static List<UnlockProgress> Races(IEnumerable<AchievementEntry> achievements) =>
+        Read(achievements, RaceSection, "Race Unlock");
+
+    public static List<UnlockProgress> Classes(IEnumerable<AchievementEntry> achievements) =>
+        Read(achievements, ClassSection, "Class Unlock");
+
+    private static List<UnlockProgress> Read(
+        IEnumerable<AchievementEntry> achievements, string section, string marker)
+    {
+        var result = new List<UnlockProgress>();
+        foreach (var a in achievements)
+        {
+            if (!a.Section.Equals(section, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!a.Name.Contains(marker, StringComparison.OrdinalIgnoreCase)) continue;
+            var dash = a.Name.LastIndexOf(" - ", StringComparison.Ordinal);
+            if (dash < 0) continue;
+
+            var subject = a.Name[(dash + 3)..].Trim();
+            if (subject.Length == 0) continue;
+            // Classes go through the canonical spelling for the reason in
+            // QuestClassFilter.Canonical: the dump writes "Shadowknight" and every catalog
+            // here writes "Shadow Knight". Races are left as the dump spells them —
+            // "Human (Freeport)" and "Human (Qeynos)" are two different unlocks and there
+            // is no canonical race list to fold them into.
+            if (marker == "Class Unlock"
+                && QuestClassFilter.Canonical(subject) is { Length: > 0 } canonical)
+                subject = canonical;
+
+            var criteria = a.Criteria.Select(c => Classify(c.Text, c.Complete)).ToList();
+            // The parent completed AND a bypass line under it is flagged: the children
+            // were marked by the game rather than earned by the player.
+            var inherited = a.Complete
+                && criteria.Any(c => c.Need == UnlockNeed.Bypass && c.Done);
+
+            result.Add(new UnlockProgress(
+                a.Section, a.Name, subject, a.Complete, inherited, criteria));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Which kind of row this is, and what it is about.
+    ///
+    /// Order matters: the two Bypass shapes are checked before Derived, because
+    /// "will autocomplete if your character was created as a Barbarian" and "will
+    /// autocomplete when you unlock Human or Wood Elf" both begin the same way and mean
+    /// opposite things — one is a way the unlock can be handed to you, the other is a real
+    /// consequence of real work.
+    ///
+    /// A trailing period is optional. The dump writes one on most lines and not on
+    /// Beastlord's or Berserker's, which is a difference no rule should depend on.
+    /// </summary>
+    public static UnlockCriterion Classify(string rawText, bool done)
+    {
+        var text = (rawText ?? "").Trim();
+        var bare = text.TrimEnd('.').Trim();
+
+        if (bare.Contains("can be bypassed", StringComparison.OrdinalIgnoreCase)
+            || bare.Contains("if your character was created", StringComparison.OrdinalIgnoreCase)
+            || bare.Contains("if you chose to confirm", StringComparison.OrdinalIgnoreCase))
+            return new UnlockCriterion(UnlockNeed.Bypass, text, "", done);
+
+        if (bare.StartsWith(MaxFactionPrefix, StringComparison.OrdinalIgnoreCase))
+            return new UnlockCriterion(UnlockNeed.MaxFaction, text,
+                bare[MaxFactionPrefix.Length..].Trim(), done);
+
+        if (bare.StartsWith(ObtainPrefix, StringComparison.OrdinalIgnoreCase))
+            return new UnlockCriterion(UnlockNeed.Obtain, text,
+                bare[ObtainPrefix.Length..].Trim(), done);
+
+        if (bare.Contains("will autocomplete", StringComparison.OrdinalIgnoreCase))
+            return new UnlockCriterion(UnlockNeed.Derived, text, "", done);
+
+        return new UnlockCriterion(UnlockNeed.Task, text, bare, done);
+    }
+}

--- a/src/EQBuddy.Core/UnlockSource.cs
+++ b/src/EQBuddy.Core/UnlockSource.cs
@@ -1,0 +1,93 @@
+using System.IO;
+
+namespace EQBuddy.Core;
+
+/// <summary>
+/// Finds and re-reads the two dumps the Unlocks tab is built from, and caches on their
+/// timestamps.
+///
+/// **It re-reads rather than storing what it parsed.** The alternative is persisting the
+/// unlock state into the ledger at import time, and that is the shape behind #204, #210
+/// and #212: data survives a move and the write path does not, so a surface goes on
+/// showing what was true weeks ago. The files are on disk, the game rewrites them
+/// whenever the player asks, and re-reading a 60 KB text file when its timestamp changes
+/// costs nothing. Nothing here writes.
+///
+/// Both dumps live where <see cref="InventoryFile.FindLatest"/> looks — the log folder's
+/// PARENT — which is said in those two finders and nowhere else, so they cannot disagree.
+/// </summary>
+public sealed class UnlockSource
+{
+    private string _achievementsPath = "";
+    private DateTime _achievementsAt;
+    private List<AchievementEntry> _achievements = [];
+
+    private string _factionsPath = "";
+    private DateTime _factionsAt;
+    private FactionsFile.Snapshot? _factions;
+
+    private List<UnlockProgress>? _races;
+    private List<UnlockProgress>? _classes;
+
+    /// <summary>Race unlocks as the newest achievements dump states them. Empty when the
+    /// player has never run the command — which is a different state from "none unlocked"
+    /// and the surface says so.</summary>
+    public IReadOnlyList<UnlockProgress> Races => _races ?? [];
+
+    public IReadOnlyList<UnlockProgress> Classes => _classes ?? [];
+
+    /// <summary>The newest faction dump, or null when there is none. Null is a real state:
+    /// it is the difference between "you are not maxed with anyone" and "EQBuddy has
+    /// never been told where you stand".</summary>
+    public FactionsFile.Snapshot? Factions => _factions;
+
+    /// <summary>Has anything been read at all? Drives the tab's empty state, which must
+    /// ask for the command rather than showing sixteen unlocks at zero.</summary>
+    public bool HasAchievements => _achievements.Count > 0;
+
+    /// <summary>
+    /// Re-read whichever dump has changed. Cheap to call on a tick: it stats two files and
+    /// returns unless a timestamp moved.
+    /// </summary>
+    /// <returns>True when something was re-parsed, so a caller can re-render only then.</returns>
+    public bool Refresh(string? logFolder, string character)
+    {
+        if (string.IsNullOrWhiteSpace(logFolder) || string.IsNullOrWhiteSpace(character))
+            return false;
+        var root = Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(logFolder));
+        if (root is null || !Directory.Exists(root)) return false;
+
+        var changed = false;
+        try
+        {
+            if (Newest(root, $"{character}_*-Achievements.txt") is { } ach
+                && (ach.FullName != _achievementsPath || ach.LastWriteTime != _achievementsAt))
+            {
+                _achievementsPath = ach.FullName;
+                _achievementsAt = ach.LastWriteTime;
+                _achievements = AchievementsImport.Parse(File.ReadLines(ach.FullName));
+                _races = UnlockRequirements.Races(_achievements);
+                _classes = UnlockRequirements.Classes(_achievements);
+                changed = true;
+            }
+
+            if (Newest(root, $"{character}_*-Factions.txt") is { } fac
+                && (fac.FullName != _factionsPath || fac.LastWriteTime != _factionsAt))
+            {
+                _factionsPath = fac.FullName;
+                _factionsAt = fac.LastWriteTime;
+                _factions = new FactionsFile.Snapshot(fac.FullName, fac.LastWriteTime,
+                    FactionsFile.Parse(File.ReadLines(fac.FullName)));
+                changed = true;
+            }
+        }
+        catch { /* a dump being rewritten as we read it is not an error worth surfacing */ }
+        return changed;
+    }
+
+    private static FileInfo? Newest(string root, string pattern) =>
+        Directory.EnumerateFiles(root, pattern)
+            .Select(f => new FileInfo(f))
+            .OrderByDescending(f => f.LastWriteTime)
+            .FirstOrDefault();
+}

--- a/src/EQBuddy.UI.Shared/AltTabPolicy.cs
+++ b/src/EQBuddy.UI.Shared/AltTabPolicy.cs
@@ -1,0 +1,36 @@
+namespace EQBuddy.UI.Shared;
+
+/// <summary>
+/// Whether "keep EQBuddy out of Alt+Tab" can do anything here, and what to say when it
+/// cannot.
+///
+/// It is one flag on Windows — `WS_EX_TOOLWINDOW` — and that flag removes the window
+/// from the Alt+Tab switcher AND from the taskbar. The two are not separable, so the
+/// setting has to say so: the tray icon becomes the only way back to a hidden widget,
+/// and a control that quietly removes someone's way back is the kind of thing this repo
+/// treats as broken rather than as a trade-off.
+///
+/// Written beside <see cref="FocusHide"/> and to the same rule it set for #169: a
+/// platform that cannot honour a tick-box gets a sentence naming the reason, not a box
+/// that persists a choice and does nothing. macOS and Linux have no Alt+Tab in the
+/// Windows sense — the compositor owns the switcher and there is no per-window opt-out
+/// to set — so the answer there is "no", said out loud.
+/// </summary>
+public static class AltTabPolicy
+{
+    public static bool Available => OperatingSystem.IsWindows();
+
+    /// <summary>What Options prints under the tick-box. Empty where it works, so the
+    /// note never appears on Windows.</summary>
+    public static string UnavailableNote =>
+        Available
+            ? ""
+            : "Not available on this platform — the window switcher is the desktop's to "
+              + "decide, with no per-window opt-out for an app to set. Your choice is "
+              + "saved and will start working if that changes.";
+
+    /// <summary>The cost, said where the player is choosing. One flag, both effects.</summary>
+    public const string TaskbarWarning =
+        "Also removes EQBuddy's taskbar button — Windows treats the two as one setting. "
+        + "The tray icon is how you get the widget back.";
+}

--- a/src/EQBuddy.UI.Shared/GameCommands.cs
+++ b/src/EQBuddy.UI.Shared/GameCommands.cs
@@ -16,6 +16,10 @@ public static class GameCommands
     /// <summary>Makes the game write its achievements dump — the import that
     /// pre-marks Sky rewards and raid clears from before EQBuddy.</summary>
     public const string OutputfileAchievements = "/outputfile achievements";
+    /// <summary>Singular, and the file it writes is plural with the class code in the
+    /// middle. Both verified from the game's own usage line and announcement in David's
+    /// log, 2026-08-25 — no public documentation covers this dump.</summary>
+    public const string OutputfileFaction = "/outputfile faction";
 
     /// <summary>The map's breadcrumb social, one command per social-editor line:
     /// /loc drops a position into the log, /doability 1 keeps the key doing what

--- a/src/EQBuddy.UI.Shared/GameCommands.cs
+++ b/src/EQBuddy.UI.Shared/GameCommands.cs
@@ -17,7 +17,7 @@ public static class GameCommands
     /// pre-marks Sky rewards and raid clears from before EQBuddy.</summary>
     public const string OutputfileAchievements = "/outputfile achievements";
     /// <summary>Singular, and the file it writes is plural with the class code in the
-    /// middle. Both verified from the game's own usage line and announcement in David's
+    /// middle. Both verified from the game's own usage line and announcement in Hateborne's
     /// log, 2026-08-25 — no public documentation covers this dump.</summary>
     public const string OutputfileFaction = "/outputfile faction";
 

--- a/src/EQBuddy.UI.Shared/GearLocker.cs
+++ b/src/EQBuddy.UI.Shared/GearLocker.cs
@@ -201,18 +201,15 @@ public static class GearLocker
     /// a wrong guess would gate comparisons on a lie.</summary>
     public static string Code(string className)
     {
-        var key = className.Trim();
-        return ClassCodeMap.TryGetValue(key, out var code) ? code : key.ToUpperInvariant();
+        // This used to be a private 17-row map that carried BOTH "Shadow Knight" and
+        // "Shadowknight" — so the knowledge that the two spellings exist lived here,
+        // and the code doing the comparing in AchievementsImport did not have it.
+        // One fact, two sources (trap 4). QuestClassFilter owns the names and the
+        // codes, so it owns this too.
+        if (QuestClassFilter.Canonical(className) is { Length: > 0 } canonical)
+            return QuestClassFilter.Abbrev(canonical);
+        return className.Trim().ToUpperInvariant();
     }
-
-    private static readonly Dictionary<string, string> ClassCodeMap = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["Bard"] = "BRD", ["Beastlord"] = "BST", ["Berserker"] = "BER", ["Cleric"] = "CLR",
-        ["Druid"] = "DRU", ["Enchanter"] = "ENC", ["Magician"] = "MAG", ["Monk"] = "MNK",
-        ["Necromancer"] = "NEC", ["Paladin"] = "PAL", ["Ranger"] = "RNG", ["Rogue"] = "ROG",
-        ["Shadow Knight"] = "SHD", ["Shadowknight"] = "SHD", ["Shaman"] = "SHM",
-        ["Warrior"] = "WAR", ["Wizard"] = "WIZ",
-    };
 
     private static int LocationRank(string location) =>
         location.StartsWith("Bank", StringComparison.OrdinalIgnoreCase) ? 2

--- a/src/EQBuddy.UI.Shared/IconPaths.cs
+++ b/src/EQBuddy.UI.Shared/IconPaths.cs
@@ -60,6 +60,16 @@ public static class IconPaths
         ["Pin"] = "M14 4v5c0 1.12.37 2.16 1 3H9c.63-.84 1-1.88 1-3V4h4m3-2H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3V4h1c.55 0 1-.45 1-1s-.45-1-1-1Z",
         ["PinFilled"] = "M16 9V4h1c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3Z",
         ["Check"] = "M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17Z",
+        // The partner to Check on a READ-ONLY list: a requirement that is simply not met
+        // yet. A bullet, deliberately — ChevronRight was used here first and it promises a
+        // drill-down that does not exist, which is an affordance lying about itself
+        // (Hateborne, 2026-08-25). Not a checkbox either: nothing on the Unlocks tab is
+        // the player's to tick, and a control that looks tickable and is not is the same
+        // fault from the other side (trap 17).
+        // Check's partner on a READ-ONLY list. A dash, not a chevron (promises a
+        // drill-down) and not a ring (reads as a tickable checkbox). 14 wide because
+        // IconGeometryTests wants half the grid filled; a dot renders as a speck.
+        ["Pending"] = "M5 11h14v2H5Z",
         ["Flag"] = "M6 3h2v18H6V3Zm3 1h10.5l-2.4 3.75L19.5 11.5H9V4Z",
         ["Undo"] = "M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62A8 8 0 0 1 20.4 15.1l2.37-.78A10.5 10.5 0 0 0 12.5 8Z",
         ["Copy"] = "M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1Zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2Zm0 16H8V7h11v14Z",

--- a/src/EQBuddy.UI.Shared/OptionsViewModel.cs
+++ b/src/EQBuddy.UI.Shared/OptionsViewModel.cs
@@ -354,6 +354,11 @@ public sealed class OptionsViewModel : INotifyPropertyChanged
         get => _settings.HideWhenGameNotRunning;
         set { _settings.HideWhenGameNotRunning = value; PersistAnd(); }
     }
+    public bool HideFromAltTab
+    {
+        get => _settings.HideFromAltTab;
+        set { _settings.HideFromAltTab = value; PersistAnd(); }
+    }
     public bool KeepAboveOverlays
     {
         get => _settings.KeepAboveOverlays;

--- a/src/EQBuddy.UI.Shared/WindowSizing.cs
+++ b/src/EQBuddy.UI.Shared/WindowSizing.cs
@@ -30,6 +30,47 @@ public static class WindowSizing
     /// is a value that survived a monitor change or a scaling switch.</summary>
     public const double MaxAny = 10000;
 
+    /// <summary>
+    /// How tall a theme window's scrolling body OPENS, before anyone drags it.
+    ///
+    /// **A cap, not a fill target** — Bevel's words, on these very windows: *"386 lu was a
+    /// cap, not a fill target. ~175 lu on the tallest Progress room is the right
+    /// SizeToContent outcome. 320 stands until a shot overflows it."* The code never used a
+    /// constant. Every pop-out derived its body from the MONITOR
+    /// (<c>BodyScroll.MaxHeight = MaxHeight - chrome</c>, where <c>MaxHeight</c> was 85% of
+    /// the work area), so on a tall screen the Quest Tracker opened with a ~944-unit body
+    /// and filled the display — measured at 1822 physical px (Hateborne, 2026-08-25: *"Let's
+    /// NOT force pop out windows to default to a giant size"*).
+    ///
+    /// 400 rather than Bevel's 320 because Hateborne asked for "25-50% larger than the
+    /// previous default" and 320 x 1.25 = 400. It is the OPENING size only: the window's own
+    /// ceiling stays screen-derived, so a player can still drag one as tall as their monitor
+    /// allows and <see cref="BodyCap"/> follows them there.
+    /// </summary>
+    public const double DefaultBodyHeight = 400;
+
+    /// <summary>
+    /// The body scroller's cap: the design constant while the window is still sizing to its
+    /// content, and the window's own height once the player has taken it.
+    ///
+    /// Both halves matter. Without the first a pop-out opens full-screen; without the
+    /// second, dragging a window taller would gain empty space below a body that refused to
+    /// grow — a resize that visibly does nothing, which is the complaint this whole area
+    /// started with.
+    /// </summary>
+    /// <param name="ceiling">The window's hard ceiling, screen-derived.</param>
+    /// <param name="chrome">What this window spends on everything that is not the body:
+    /// header, tabs, filters, footer. Per window, because they differ by ~160 units.</param>
+    /// <param name="taken">The height the player dragged the window to, or null while it is
+    /// still following its content.</param>
+    public static double BodyCap(double ceiling, double chrome, double? taken)
+    {
+        var room = Math.Max(120, ceiling - chrome);
+        return taken is { } h && IsSaneHeight(h)
+            ? Math.Max(120, Math.Min(h - chrome, room))
+            : Math.Min(DefaultBodyHeight, room);
+    }
+
     /// <summary>Is a stored number worth restoring at all?</summary>
     public static bool IsSaneWidth(double w) => w is >= MinWidth and <= MaxAny;
 

--- a/src/EQBuddy/CreatureWindow.xaml.cs
+++ b/src/EQBuddy/CreatureWindow.xaml.cs
@@ -48,6 +48,9 @@ public partial class CreatureWindow : Window
         // keeps their zoom through the fold — the same courtesy the card keys get.
         WindowZoom.Attach(this, "drops", _settings, baseWidth: Width);
         WindowZoom.AllowResize(this, "drops", _settings);
+        // A drag changes how much room the body has; without this the window grows
+        // and its content does not follow.
+        SizeChanged += (_, _) => UpdateHeightCap();
 
         _drops = new DropsCardView(main);
 
@@ -140,9 +143,12 @@ public partial class CreatureWindow : Window
             ? work.Height
             : SystemParameters.WorkArea.Height;   // before the handle exists
         MaxHeight = Math.Max(220, height * 0.85);
+        // The BODY opens at a design constant, not at a fraction of the monitor. Deriving
+        // it from the screen is what made this window fill a tall display; UI.Shared owns
+        // the number so all seven pop-outs cannot disagree about it.
         // Cap the SCROLLER, not just the window: otherwise the window grows past its own
         // cap on a long drops list and the tab strip walks off the bottom.
-        BodyScroll.MaxHeight = Math.Max(120, MaxHeight - 120);
+        BodyScroll.MaxHeight = WindowSizing.BodyCap(MaxHeight, 120, FramelessResize.ManualHeight(this));
     }
 
     /// <summary>Repaint from the widget's shared snapshot. Throttled the way the other

--- a/src/EQBuddy/FramelessResize.cs
+++ b/src/EQBuddy/FramelessResize.cs
@@ -1,0 +1,201 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+
+namespace EQBuddy;
+
+/// <summary>
+/// Gives a frameless window real resize borders.
+///
+/// **The bug this fixes shipped as a feature.** `WindowStyle="None"` +
+/// `AllowsTransparency="True"` means Windows draws no non-client area, so there is no
+/// border to grab — and `ResizeMode="CanResize"` does not create one. Every theme window
+/// and every pop-out that gained resize on 2026-08-21 and 2026-08-25 had `CanResize`, had
+/// `WindowZoom.AllowResize` wired, persisted a height on close, and **could not be resized
+/// by hand.** Hateborne confirmed it directly on 2026-08-25: *"I cannot resize pop-up
+/// windows."*
+///
+/// **Nothing could see it.** `ResizableWindowTests` asserts that a window does not say
+/// `NoResize` and that it calls `AllowResize` — both true throughout. That is trap 34's
+/// exact shape: a guard that checks for the wrong thing being present cannot see the right
+/// thing being absent. A screenshot cannot see it either; the window looks correct.
+/// `HANDOFF.md` even recorded the opposite as proven, reasoning from "the theme windows
+/// use the same chrome and the owner has been resizing them" — an argument, not a
+/// measurement, and the measurement went the other way.
+///
+/// The mechanism was already here and already right: `BreakoutWindow` has had this hook
+/// since 2026-08-06, when David reported the same thing about the loot window ("I still
+/// can't resize the loot window — a frameless window has no resize borders, and a corner
+/// glyph nobody finds isn't an affordance"). It was never lifted out. This is that hook,
+/// lifted, with the zone math still in the unit-tested
+/// <see cref="EQBuddy.UI.Shared.ResizeZones"/>.
+/// </summary>
+internal static class FramelessResize
+{
+    private const int WmNcHitTest = 0x84;
+    private const int WmNcLButtonDown = 0xA1;
+    private const int WmExitSizeMove = 0x232;
+    private const int HtLeft = 10, HtBottomRight = 17;
+
+    /// <summary>
+    /// Has the PLAYER dragged this window's border? An attached property rather than a
+    /// field, so nothing holds a window alive after it closes.
+    ///
+    /// This is the fact trap 49's reverted follower could not get. That design tried to
+    /// tell the player's resize from its own by flagging its own assignments — and missed
+    /// the toolkit as a third resizer, so a `SizeToContent` re-measure read as a drag.
+    /// `WM_NCLBUTTONDOWN` on a resize hit code followed by `WM_EXITSIZEMOVE` is the native
+    /// size loop and nothing else: no attribution, no guess, no third actor.
+    /// </summary>
+    private static readonly DependencyProperty PlayerSizedProperty =
+        DependencyProperty.RegisterAttached(
+            "PlayerSized", typeof(bool), typeof(FramelessResize), new PropertyMetadata(false));
+
+    /// <summary>Did the player drag this window's border? The persist decision reads this,
+    /// so a height nobody chose is never written to <c>WindowHeights</c>.</summary>
+    public static bool PlayerTookHeight(Window window) =>
+        window.GetValue(PlayerSizedProperty) is true;
+
+    /// <summary>
+    /// A window opening at a RESTORED height starts owned.
+    ///
+    /// Without this, a size the player dragged survives one close and is deleted by the
+    /// next: reopening builds a fresh window with the flag clear, so an undragged close
+    /// then removes the entry. Measured — a run that dragged to 537 and reopened ended
+    /// with WindowHeights empty. "Nobody who has ever dragged a window sees it move by
+    /// itself afterwards" was the reverted follower's rule, and it was right.
+    /// </summary>
+    public static void MarkPlayerSized(Window window) =>
+        window.SetValue(PlayerSizedProperty, true);
+
+    /// <summary>
+    /// The height the window is actually WEARING, or null while it still sizes to content.
+    ///
+    /// The body cap reads this rather than <see cref="PlayerTookHeight"/>, and the
+    /// difference produced a real defect: capping the body at the design constant while the
+    /// WINDOW wore a restored height left a void between the tab strip and the content —
+    /// a tall window with a short body inside it (Hateborne's Kills &amp; Drops, 2026-08-25,
+    /// stored at 1224 units: *"Why is everything minimized in the middle?"*).
+    ///
+    /// So the constant governs the size a window OPENS at, and once it has a concrete
+    /// height — dragged or restored — the body fills it. Those are different questions and
+    /// they need different answers.
+    /// </summary>
+    public static double? ManualHeight(Window window) =>
+        window.SizeToContent == SizeToContent.Manual && window.ActualHeight > 0
+            ? window.ActualHeight
+            : null;
+
+    /// <summary>Call once, any time before the window is shown. Safe on a window that
+    /// already has a native border — it simply never fires, because a bordered window
+    /// hit-tests its own frame before the client area is asked.</summary>
+    public static void Attach(Window window)
+    {
+        window.SourceInitialized += (_, _) =>
+        {
+            var hint = AddHint(window);
+            if (hint is not null) window.MouseLeave += (_, _) => hint.Opacity = 0;
+            if (PresentationSource.FromVisual(window) is HwndSource src)
+                src.AddHook((IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+                    => Hook(window, hint, msg, wParam, lParam, ref handled));
+        };
+    }
+
+    /// <summary>
+    /// The visible hint, asked for by Hateborne on 2026-08-25 the moment the border started
+    /// working: *"Is it possible to show the yellow bar at the bottom, similar to how the
+    /// main window does when one hovers at the bottom?"*
+    ///
+    /// It is the same answer the widget's own `HeightGrip` gives, and for the same reason —
+    /// that grip's XAML records a 1.66 field test where *"dragging the bottom doesn't
+    /// work"* turned out to mean *"I never hit it"*. An edge you cannot see is discoverable
+    /// only by accident, which is the 2026-08-06 note about a corner glyph nobody finds,
+    /// inverted.
+    ///
+    /// Drawn by WRAPPING the window's content rather than by an adorner: an adorner layer
+    /// depends on the content being inside an AdornerDecorator, which is a property of each
+    /// window's XAML and would fail silently on the ones that lack it. The wrap happens once,
+    /// at SourceInitialized, and the bar is <c>IsHitTestVisible="False"</c> so it can never
+    /// take the hit-test the resize itself depends on.
+    /// </summary>
+    private static System.Windows.Shapes.Rectangle? AddHint(Window window)
+    {
+        if (window.Content is not UIElement content) return null;
+
+        var bar = new System.Windows.Shapes.Rectangle
+        {
+            Height = 2.5,
+            RadiusX = 1.25,
+            RadiusY = 1.25,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            IsHitTestVisible = false,
+            Opacity = 0,
+        };
+        // The same brush and the same margins the widget's grip uses, by resource key, so
+        // a theme swap moves both and neither can drift into its own colour.
+        bar.SetResourceReference(System.Windows.Shapes.Shape.FillProperty, "AccentBrush");
+        bar.SetResourceReference(FrameworkElement.MarginProperty, "GripLine");
+
+        window.Content = null;   // a UIElement may have only one parent
+        var host = new Grid();
+        host.Children.Add(content);
+        host.Children.Add(bar);
+        window.Content = host;
+        return bar;
+    }
+
+    private static IntPtr Hook(
+        Window window, System.Windows.Shapes.Rectangle? hint,
+        int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        switch (msg)
+        {
+            case WmNcHitTest:
+            {
+                // lParam: screen coords, low word X, high word Y — SIGNED, because a
+                // second monitor to the left gives negative coordinates.
+                var x = (short)((long)lParam & 0xFFFF);
+                var y = (short)(((long)lParam >> 16) & 0xFFFF);
+                var p = window.PointFromScreen(new Point(x, y));
+                var hit = EQBuddy.UI.Shared.ResizeZones.Hit(
+                    p.X, p.Y, window.ActualWidth, window.ActualHeight,
+                    EQBuddy.UI.Shared.BreakdownRowLayout.ResizeEdge,
+                    EQBuddy.UI.Shared.BreakdownRowLayout.ResizeCorner);
+                // The hint shows exactly when a bottom drag would engage, so it is a
+                // statement about what will happen rather than an approximation of it.
+                if (hint is not null)
+                    hint.Opacity = hit is EQBuddy.UI.Shared.ResizeZones.Bottom
+                        or EQBuddy.UI.Shared.ResizeZones.BottomLeft
+                        or EQBuddy.UI.Shared.ResizeZones.BottomRight ? 0.7 : 0;
+                if (hit != 0) { handled = true; return hit; }
+                break;
+            }
+
+            case WmNcLButtonDown when (long)wParam is >= HtLeft and <= HtBottomRight:
+                // The native size loop is about to start. A window still sizing to its
+                // content would snap straight back the moment layout runs, so hand the
+                // axis over first — and assign the MEASURED size before clearing, or it
+                // jumps to whatever XAML said for one frame.
+                if (window.SizeToContent != SizeToContent.Manual)
+                {
+                    if (window.ActualWidth > 0) window.Width = window.ActualWidth;
+                    if (window.ActualHeight > 0) window.Height = window.ActualHeight;
+                    window.SizeToContent = SizeToContent.Manual;
+                }
+                break;
+
+            case WmExitSizeMove when window.SizeToContent == SizeToContent.Manual:
+                // ActualWidth/Height, not Width/Height: the native size loop moves the
+                // window without writing the dependency properties, so without this the
+                // size the player chose is not the size anything else can read — and
+                // AllowResize's Closed handler is one of the things that reads it.
+                if (window.ActualWidth > 0) window.Width = window.ActualWidth;
+                if (window.ActualHeight > 0) window.Height = window.ActualHeight;
+                // The size loop just ended, so this height is the player's by construction.
+                window.SetValue(PlayerSizedProperty, true);
+                break;
+        }
+        return IntPtr.Zero;
+    }
+}

--- a/src/EQBuddy/GearLootWindow.xaml.cs
+++ b/src/EQBuddy/GearLootWindow.xaml.cs
@@ -45,6 +45,9 @@ public partial class GearLootWindow : Window
         // Base width so Ctrl+wheel shrinks the WINDOW, not just its text (#186).
         WindowZoom.Attach(this, "gearloot", _settings, baseWidth: Width);
         WindowZoom.AllowResize(this, "gearloot", _settings);
+        // A drag changes how much room the body has; without this the window grows
+        // and its content does not follow.
+        SizeChanged += (_, _) => UpdateHeightCap();
 
         _loot = new LootCardView(main, _settings);
         _gear = main.NewGearCard();
@@ -142,9 +145,12 @@ public partial class GearLootWindow : Window
             ? work.Height
             : SystemParameters.WorkArea.Height;   // before the handle exists
         MaxHeight = Math.Max(220, height * 0.85);
+        // The BODY opens at a design constant, not at a fraction of the monitor. Deriving
+        // it from the screen is what made this window fill a tall display; UI.Shared owns
+        // the number so all seven pop-outs cannot disagree about it.
         // Cap the SCROLLER, not just the window: otherwise the window grows past its own
         // cap on a long gear list and the tab strip walks off the bottom.
-        BodyScroll.MaxHeight = Math.Max(120, MaxHeight - 120);
+        BodyScroll.MaxHeight = WindowSizing.BodyCap(MaxHeight, 120, FramelessResize.ManualHeight(this));
     }
 
     /// <summary>Repaint from the widget's shared snapshot. Throttled the way the other

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -449,7 +449,8 @@ public partial class MainWindow : Window, ICardContext
             Loaded += (_, _) => Dispatcher.BeginInvoke(() =>
             {
                 ShowQuestsWindow();
-                if (questsMode.Split(':')[0] is "sky" or "epic") _questsWindow?.SetTab(questsMode);
+                if (QuestSurface.TabForKey(questsMode.Split(':')[0]) is not null)
+                    _questsWindow?.SetTab(questsMode);
                 else if (questsMode is "zone" or "all") _questsWindow?.SetMode(questsMode);
             }, System.Windows.Threading.DispatcherPriority.ApplicationIdle);
 
@@ -2891,7 +2892,7 @@ public partial class MainWindow : Window, ICardContext
                     // doing nothing, because this profile has no paired device.
                     $"companionPumpTicks={_companionPumpTicks} " +
                     $"companionPushes={_companionPushes} " +
-                    // Alt+Tab (David, 2026-08-25). Reported as the EFFECT — the ex-style
+                    // Alt+Tab (Hateborne, 2026-08-25). Reported as the EFFECT — the ex-style
                     // actually on the HWND — not as the setting, because "present in the
                     // build" and "in effect at runtime" are different claims and trap 42
                     // cost two builds to learn it. The setting is beside it so a
@@ -3047,7 +3048,12 @@ public partial class MainWindow : Window, ICardContext
             if (kind == OutputfileKind.Unknown) return;
             if (OutputfileAutoImport.ResolvePath(_settings.LogFolder, ev.FileName) is not { } path) return;
 
-            if (kind == OutputfileKind.Inventory)
+            // A SWITCH, never `if (Inventory) … else …`: that else meant "not inventory",
+            // so a new enum member routed faction dumps into ImportAchievements and wiped
+            // the class list. Pinned by AFactionDumpIsNotAnAchievementsDump.
+            switch (kind)
+            {
+            case OutputfileKind.Inventory:
             {
                 // refresh: true re-scans and runs the existing auto-check; the outcome
                 // below is what makes it VISIBLE, which is the half that was missing.
@@ -3066,13 +3072,22 @@ public partial class MainWindow : Window, ICardContext
                 // that can make it stale. A surface that shows a file has to repaint when
                 // the file it shows is replaced.
                 _gearLootWindow?.InventoryChanged();
+                break;
             }
-            else
-            {
+
+            case OutputfileKind.Achievements:
                 LastAchievementsImport =
                     OutputfileAutoImport.ImportAchievements(path, _settings, _raidLedger,
                         QuestLedger, QuestCharacterKey);
                 _settings.Save();
+                break;
+
+            case OutputfileKind.Factions:
+                // Nothing to import — UnlockSource reads it off disk. Just nudge the tab.
+                _questsWindow?.FactionsChanged();
+                break;
+
+            default: break;   // Unknown returned above; a new kind lands here, not silently
             }
         }
         catch (Exception ex) { App.LogError(ex); }   // a half-written dump must not kill the tail
@@ -4307,40 +4322,12 @@ public partial class MainWindow : Window, ICardContext
         // the ONE window with ShowInTaskbar="True", and the style has to land before the
         // first Show() or Windows has already decided this window belongs in the switcher.
         NoActivate.SetToolWindow(this, _settings.HideFromAltTab);
-        ArmAltTabStyleForSatellites();
+        NoActivate.ArmSatellites(this, () => _settings.HideFromAltTab);
     }
 
-    /// <summary>
-    /// Every other window as it loads, so the setting means what it says.
-    ///
-    /// The satellites all ship `ShowInTaskbar="False"`, which gives them a hidden owner and
-    /// USUALLY keeps them out of the switcher on its own — but "usually" is a claim about
-    /// a shell behaviour nobody here has measured, and the cost of being wrong is the
-    /// feature quietly covering the widget and nothing else. Setting the bit is cheap and
-    /// is a fact rather than an inference.
-    ///
-    /// `SourceInitialized` is a plain CLR event, so it cannot be class-handled; `Loaded` is
-    /// routed and can. Post-show is fine here precisely because these windows are not the
-    /// taskbar case — and `SetToolWindow` re-shows if it has to.
-    /// </summary>
-    private void ArmAltTabStyleForSatellites() =>
-        EventManager.RegisterClassHandler(typeof(Window), LoadedEvent,
-            new RoutedEventHandler((sender, _) =>
-            {
-                if (sender is Window w && !ReferenceEquals(w, this))
-                    NoActivate.SetToolWindow(w, _settings.HideFromAltTab);
-            }));
-
-    /// <summary>Apply the current setting to every open window. Called when the box is
-    /// flipped in Options, because a setting that waits for a relaunch to do anything is
-    /// indistinguishable from one that is broken.</summary>
-    internal void ApplyAltTabStyle()
-    {
-        NoActivate.SetToolWindow(this, _settings.HideFromAltTab);
-        foreach (Window w in Application.Current.Windows)
-            if (!ReferenceEquals(w, this))
-                NoActivate.SetToolWindow(w, _settings.HideFromAltTab);
-    }
+    /// <summary>@see NoActivate.ApplyToAll — called when the Options box is flipped.</summary>
+    internal void ApplyAltTabStyle() =>
+        NoActivate.ApplyToAll(this, _settings.HideFromAltTab);
 
     // ---- global hotkeys, opt-in only (#100 — see HotkeyManager) ----
 
@@ -4437,6 +4424,13 @@ public partial class MainWindow : Window, ICardContext
     /// the log has seen since it was written (loot in, sells out — David, 2026-08-11);
     /// the dump itself is memoized, the log overlay is always current. Pass refresh to
     /// re-scan the game folder (the ⟳ button, the held tab).</summary>
+    internal UnlockSource Unlocks
+    {
+        get { _unlockSource.Refresh(_settings.LogFolder, Identity.Character); return _unlockSource; }
+    }
+
+    private readonly UnlockSource _unlockSource = new();
+
     internal InventoryFile.Snapshot? LatestInventory(bool refresh = false)
     {
         if (refresh || _inventory is null)

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -2890,7 +2890,14 @@ public partial class MainWindow : Window, ICardContext
                     // EQBuddy Mobile's pump: it should be running, and it should be
                     // doing nothing, because this profile has no paired device.
                     $"companionPumpTicks={_companionPumpTicks} " +
-                    $"companionPushes={_companionPushes}";
+                    $"companionPushes={_companionPushes} " +
+                    // Alt+Tab (David, 2026-08-25). Reported as the EFFECT — the ex-style
+                    // actually on the HWND — not as the setting, because "present in the
+                    // build" and "in effect at runtime" are different claims and trap 42
+                    // cost two builds to learn it. The setting is beside it so a
+                    // disagreement between the two is visible rather than inferable.
+                    $"altTabWanted={(_settings.HideFromAltTab ? 1 : 0)} " +
+                    $"altTabStyle={(NoActivate.IsToolWindow(this) ? 1 : 0)}";
                 System.IO.File.WriteAllText(Core.AppPaths.File("debug.txt"), dump);
             }
             catch { }
@@ -4296,6 +4303,43 @@ public partial class MainWindow : Window, ICardContext
         ApplyHotkeys();
         // Under Wine + opt-in only: don't steal focus from a fullscreen game when clicked.
         WineOverlay.MakeNonActivating(this);
+        // Opt-in only. Here rather than in the Loaded class handler below because this is
+        // the ONE window with ShowInTaskbar="True", and the style has to land before the
+        // first Show() or Windows has already decided this window belongs in the switcher.
+        NoActivate.SetToolWindow(this, _settings.HideFromAltTab);
+        ArmAltTabStyleForSatellites();
+    }
+
+    /// <summary>
+    /// Every other window as it loads, so the setting means what it says.
+    ///
+    /// The satellites all ship `ShowInTaskbar="False"`, which gives them a hidden owner and
+    /// USUALLY keeps them out of the switcher on its own — but "usually" is a claim about
+    /// a shell behaviour nobody here has measured, and the cost of being wrong is the
+    /// feature quietly covering the widget and nothing else. Setting the bit is cheap and
+    /// is a fact rather than an inference.
+    ///
+    /// `SourceInitialized` is a plain CLR event, so it cannot be class-handled; `Loaded` is
+    /// routed and can. Post-show is fine here precisely because these windows are not the
+    /// taskbar case — and `SetToolWindow` re-shows if it has to.
+    /// </summary>
+    private void ArmAltTabStyleForSatellites() =>
+        EventManager.RegisterClassHandler(typeof(Window), LoadedEvent,
+            new RoutedEventHandler((sender, _) =>
+            {
+                if (sender is Window w && !ReferenceEquals(w, this))
+                    NoActivate.SetToolWindow(w, _settings.HideFromAltTab);
+            }));
+
+    /// <summary>Apply the current setting to every open window. Called when the box is
+    /// flipped in Options, because a setting that waits for a relaunch to do anything is
+    /// indistinguishable from one that is broken.</summary>
+    internal void ApplyAltTabStyle()
+    {
+        NoActivate.SetToolWindow(this, _settings.HideFromAltTab);
+        foreach (Window w in Application.Current.Windows)
+            if (!ReferenceEquals(w, this))
+                NoActivate.SetToolWindow(w, _settings.HideFromAltTab);
     }
 
     // ---- global hotkeys, opt-in only (#100 — see HotkeyManager) ----

--- a/src/EQBuddy/MainWindow.xaml.cs
+++ b/src/EQBuddy/MainWindow.xaml.cs
@@ -246,8 +246,13 @@ public partial class MainWindow : Window, ICardContext
                             ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase),
                         Hidden = QuestLedger?.HiddenFor(QuestCharacterKey)
                             ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase),
-                        Completed = QuestLedger?.CompletedFor(QuestCharacterKey)
-                            ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+                        // Sky turn-ins folded in, so the phone's quest list answers what
+                        // its own Sky tab already knows — parity by shared module, not by
+                        // a feature list kept level by hand.
+                        Completed = SkyTestSplit.WithTurnIns(
+                            QuestLedger?.CompletedFor(QuestCharacterKey)
+                                ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+                            _settings.SkyQuestCompleted),
                         Classes = QuestLedger?.ClassesFor(QuestCharacterKey) ?? [],
                         InferredClass = snap.InferredClass,
                         // The RESOLVED list and its source, decided here so the phone cannot decide it

--- a/src/EQBuddy/NoActivate.cs
+++ b/src/EQBuddy/NoActivate.cs
@@ -67,6 +67,34 @@ internal static class NoActivate
         if (visible) window.Show();
     }
 
+    /// <summary>
+    /// Arm every OTHER window as it loads, so the setting means what it says.
+    ///
+    /// The satellites all ship `ShowInTaskbar="False"`, which gives them a hidden owner and
+    /// usually keeps them out of the switcher on its own — but "usually" is a claim about a
+    /// shell behaviour nobody here has measured, and the cost of being wrong is the feature
+    /// covering the widget and nothing else. Setting the bit is a fact rather than an
+    /// inference.
+    ///
+    /// `SourceInitialized` is a plain CLR event and cannot be class-handled; `Loaded` is
+    /// routed and can. Post-show is fine for these because they are not the taskbar case,
+    /// and <see cref="SetToolWindow"/> re-shows if it has to.
+    /// </summary>
+    public static void ArmSatellites(Window main, Func<bool> wanted) =>
+        EventManager.RegisterClassHandler(typeof(Window), FrameworkElement.LoadedEvent,
+            new RoutedEventHandler((sender, _) =>
+            {
+                if (sender is Window w && !ReferenceEquals(w, main)) SetToolWindow(w, wanted());
+            }));
+
+    /// <summary>Apply to every open window at once, for the moment the box is flipped — a
+    /// setting that waits for a relaunch is indistinguishable from a broken one.</summary>
+    public static void ApplyToAll(Window main, bool on)
+    {
+        foreach (Window w in Application.Current.Windows) SetToolWindow(w, on);
+        SetToolWindow(main, on);
+    }
+
     /// <summary>Is the style actually ON the window right now? For the E2E dump, which
     /// has to report the EFFECT rather than the intent — the whole lesson of trap 42 is
     /// that a feature can be in the binary and not in force, and the two look identical

--- a/src/EQBuddy/NoActivate.cs
+++ b/src/EQBuddy/NoActivate.cs
@@ -37,6 +37,47 @@ internal static class NoActivate
         };
     }
 
+    /// <summary>
+    /// The Alt+Tab half on its own, for windows that must still take focus.
+    ///
+    /// <see cref="Attach"/> sets WS_EX_TOOLWINDOW together with WS_EX_NOACTIVATE, which is
+    /// right for a chip nobody types into and wrong for every window a player clicks in:
+    /// NOACTIVATE would leave the widget's search boxes and the Options tabs unable to
+    /// take the keyboard. So this sets the one bit.
+    ///
+    /// **The hide/show is not optional when the window is already up.** Windows samples a
+    /// window's taskbar and switcher membership when it is SHOWN, so flipping the style on
+    /// a visible window changes the bit and nothing the player can see — which reads as a
+    /// dead tick-box (trap 42's shape: present in the build, not in effect at runtime). It
+    /// costs one frame, and only on the click that flips the setting.
+    /// </summary>
+    public static void SetToolWindow(Window window, bool on)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero) return;
+        var style = GetWindowLong(hwnd, GwlExStyle);
+        var wanted = on ? style | WsExToolWindow : style & ~WsExToolWindow;
+        if (wanted == style) return;
+
+        var visible = window.IsVisible;
+        // Never re-show something that is deliberately hidden: the focus-hide feature owns
+        // the widget's visibility on its own tick and would be fighting us for it.
+        if (visible) window.Hide();
+        SetWindowLong(hwnd, GwlExStyle, wanted);
+        if (visible) window.Show();
+    }
+
+    /// <summary>Is the style actually ON the window right now? For the E2E dump, which
+    /// has to report the EFFECT rather than the intent — the whole lesson of trap 42 is
+    /// that a feature can be in the binary and not in force, and the two look identical
+    /// from anywhere except the HWND.</summary>
+    public static bool IsToolWindow(Window window)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        return hwnd != IntPtr.Zero
+            && (GetWindowLong(hwnd, GwlExStyle) & WsExToolWindow) != 0;
+    }
+
     [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hwnd, int index);
     [DllImport("user32.dll")] private static extern int SetWindowLong(IntPtr hwnd, int index, int value);
 }

--- a/src/EQBuddy/OptionsWindow.xaml
+++ b/src/EQBuddy/OptionsWindow.xaml
@@ -471,6 +471,13 @@
             <TextBlock Text="The overlay exists only while you play: quit the game and everything disappears, launch it and everything returns (within a few seconds). Need it back without the game — say, to browse session history? Launch EQBuddy again from the Start menu: the running copy surfaces, and stays visible while any of its windows has focus."
                        Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="20,2,0,0"/>
 
+            <CheckBox x:Name="HideAltTabCheck" Margin="0,8,0,0"
+                      Checked="OnHideAltTabToggled" Unchecked="OnHideAltTabToggled">
+                <TextBlock Text="Keep EQBuddy out of the Alt+Tab switcher" FontSize="12"
+                           Foreground="{DynamicResource TextBrush}"/>
+            </CheckBox>
+            <TextBlock x:Name="HideAltTabNote" Style="{StaticResource Dim}" TextWrapping="Wrap" Margin="20,2,0,0"/>
+
             <CheckBox x:Name="KeepAboveCheck" Margin="0,10,0,0"
                       Checked="OnKeepAboveToggled" Unchecked="OnKeepAboveToggled">
                 <TextBlock Text="Keep EQBuddy above fullscreen overlays (Lossless Scaling and kin)" FontSize="12"

--- a/src/EQBuddy/OptionsWindow.xaml.cs
+++ b/src/EQBuddy/OptionsWindow.xaml.cs
@@ -49,6 +49,12 @@ public partial class OptionsWindow : Window
         TargetDropsCheck.IsChecked = _vm.ShowTargetDrops;
         HideUnfocusedCheck.IsChecked = _vm.HideWhenGameUnfocused;
         HideNotRunningCheck.IsChecked = _vm.HideWhenGameNotRunning;
+        HideAltTabCheck.IsChecked = _vm.HideFromAltTab;
+        // The cost is stated where the choice is made: one flag, both effects.
+        HideAltTabNote.Text = string.Join(" ",
+            new[] { EQBuddy.UI.Shared.AltTabPolicy.TaskbarWarning,
+                    EQBuddy.UI.Shared.AltTabPolicy.UnavailableNote }
+                .Where(s => s.Length > 0));
         KeepAboveCheck.IsChecked = _vm.KeepAboveOverlays;
         SpawnGrowUpCheck.IsChecked = _vm.SpawnChipsGrowUp;
         MezGrowUpCheck.IsChecked = _vm.MezChipsGrowUp;
@@ -567,6 +573,16 @@ public partial class OptionsWindow : Window
     private void OnHideNotRunningToggled(object sender, RoutedEventArgs e)
     {
         if (_ready) _vm.HideWhenGameNotRunning = HideNotRunningCheck.IsChecked == true;
+    }
+
+    /// <summary>Applied to every open window immediately, not on the next launch — a
+    /// tick-box whose effect waits for a relaunch is indistinguishable from a broken
+    /// one, and this one has a visible answer the moment it lands.</summary>
+    private void OnHideAltTabToggled(object sender, RoutedEventArgs e)
+    {
+        if (!_ready) return;
+        _vm.HideFromAltTab = HideAltTabCheck.IsChecked == true;
+        _main.ApplyAltTabStyle();
     }
 
     /// <summary>

--- a/src/EQBuddy/ProgressWindow.xaml.cs
+++ b/src/EQBuddy/ProgressWindow.xaml.cs
@@ -60,6 +60,9 @@ public partial class ProgressWindow : Window
         // Base width so Ctrl+wheel shrinks the WINDOW, not just its text (#186).
         WindowZoom.Attach(this, "progress", _settings, baseWidth: Width);
         WindowZoom.AllowResize(this, "progress", _settings);
+        // A drag changes how much room the body has; without this the window grows
+        // and its content does not follow.
+        SizeChanged += (_, _) => UpdateHeightCap();
 
         var surfaces = main.NewProgressSurfaces();
         (_experience, _money, _motes, _faction, _raids) =
@@ -166,9 +169,12 @@ public partial class ProgressWindow : Window
             ? work.Height
             : SystemParameters.WorkArea.Height;   // before the handle exists
         MaxHeight = Math.Max(220, height * 0.85);
+        // The BODY opens at a design constant, not at a fraction of the monitor. Deriving
+        // it from the screen is what made this window fill a tall display; UI.Shared owns
+        // the number so all seven pop-outs cannot disagree about it.
         // Cap the SCROLLER, not just the window: otherwise the window grows past its own
         // cap on a long list and the star row walks off the bottom.
-        BodyScroll.MaxHeight = Math.Max(120, MaxHeight - 160);
+        BodyScroll.MaxHeight = WindowSizing.BodyCap(MaxHeight, 160, FramelessResize.ManualHeight(this));
     }
 
     /// <summary>Open this window on a tab by its wire key — the EQBUDDY_PROGRESS hook and

--- a/src/EQBuddy/QuestsWindow.xaml
+++ b/src/EQBuddy/QuestsWindow.xaml
@@ -44,7 +44,14 @@
                  so the main widget stops carrying Epic and Sky as separate lines.
                  Labels and order come from Core's QuestSurface so mobile shows the
                  same three in the same order. -->
-            <StackPanel x:Name="TabStrip" Orientation="Horizontal" Margin="{DynamicResource StackS}"/>
+            <!-- A WrapPanel, not a StackPanel (trap 25). A stack measures with INFINITE
+                 width in its stacking direction, so a chip past the panel's edge is
+                 clipped — no ellipsis, no overflow, simply not on screen. The Progress
+                 window shipped exactly that with four tabs, and these chips carry their
+                 counts in the label ("Plane of Sky  76 / 222"), so their width is not
+                 something anyone can eyeball as safe. Nothing in a diff, a build or a
+                 unit test can see it; the first screenshot can. -->
+            <WrapPanel x:Name="TabStrip" Margin="{DynamicResource StackS}"/>
 
             <!-- The search box now spans the header, which is the whole point: it was
                  "so compressed I missed it" (David, 2026-08-15) sharing a row with a
@@ -83,6 +90,17 @@
                           Height="{DynamicResource ControlHeight}"
                           SelectionChanged="OnEraChanged"
                           ToolTip="Hide quests from later eras than the world has (unmarked quests always show)"/>
+                <!-- The Unlocks tab's own lens: which SECTION to show. It shares the era
+                     combo's column because the two are never visible together — era is a
+                     catalog concept and Unlocks is not a catalog. Options come from Core
+                     (UnlockLayout.Sections), so this cannot offer a section the tab does
+                     not render. -->
+                <ComboBox x:Name="UnlockSectionCombo" Grid.Column="0" Width="104"
+                          FontSize="{DynamicResource FontCaption}"
+                          Height="{DynamicResource ControlHeight}"
+                          Visibility="Collapsed"
+                          SelectionChanged="OnUnlockSectionChanged"
+                          ToolTip="Show every unlock, or narrow to races or to classes"/>
                 <!-- State filter (Reddit ask, 2026-08-11): every tab and search can
                      narrow to open / ready / completed. -->
                 <ComboBox x:Name="StateCombo" Grid.Column="1" Width="86"

--- a/src/EQBuddy/QuestsWindow.xaml.cs
+++ b/src/EQBuddy/QuestsWindow.xaml.cs
@@ -461,8 +461,14 @@ public partial class QuestsWindow : Window
             ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var hidden = _main.QuestLedger?.HiddenFor(key)
             ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var completed = _main.QuestLedger?.CompletedFor(key)
-            ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        // Folded with the Sky checklist, because a "<Class> Sky Test: <Reward>" row on
+        // THIS tab and the reward row on the Sky tab are the same fact. The ledger never
+        // knew about SkyQuestCompleted, so a reward the game's own achievements dump said
+        // was handed in still sat here as live work.
+        var completed = SkyTestSplit.WithTurnIns(
+            _main.QuestLedger?.CompletedFor(key)
+                ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+            _settings.SkyQuestCompleted);
         var filter = FilterBox.Text.Trim();
         var picks = _main.QuestLedger?.ClassesFor(key) ?? [];
         SyncClassChecks(picks);
@@ -962,8 +968,7 @@ public partial class QuestsWindow : Window
             entry.CompletedCount > 0
                 ? $"Completed ×{entry.CompletedCount} — click to unmark"
                 : "Did this before EQBuddy? Mark it completed (consumes nothing; click again to undo)",
-            (_, _) => WithLedger(l => l.SetCompleted(_main.QuestCharacterKey, m.Quest.Name,
-                entry.CompletedCount == 0)),
+            (_, _) => ToggleCompleted(m.Quest.Name, entry.CompletedCount == 0),
             entry.CompletedCount > 0 ? "GoodBrush" : "DimBrush",
             entry.CompletedCount > 0 ? 1.0 : 0.55));
         // Close = "not interested": drops the quest from the overlap view AND un-greens
@@ -1257,6 +1262,39 @@ public partial class QuestsWindow : Window
         Refresh(force: true);
     }
 
+    /// <summary>
+    /// Mark or unmark a catalog quest, sending a Plane of Sky test to the Sky checklist
+    /// instead of the quest ledger.
+    ///
+    /// The read side folds `SkyQuestCompleted` into the completed map, so writing to the
+    /// ledger here would leave the merge undoing the player's un-mark on the next render
+    /// — a control that visibly does nothing, which is the "silent no-ops are broken"
+    /// rule with the switch on the other side. One fact, one store, both directions.
+    ///
+    /// It also means turning a Sky Test in HERE acquires its pieces and resolves any
+    /// parked auto-tick, exactly as the Sky tab's own button does — those rules live in
+    /// <see cref="SkyCompleteToggle"/> and are not re-decided here. The Sky checklist is
+    /// per profile rather than per character, which is how it has always been; this makes
+    /// the two tabs agree rather than introducing it.
+    /// </summary>
+    private void ToggleCompleted(string questName, bool done)
+    {
+        var rewardKey = SkyTestSplit.RewardKeyFor(questName);
+        if (rewardKey.Length == 0)
+        {
+            WithLedger(l => l.SetCompleted(_main.QuestCharacterKey, questName, done));
+            return;
+        }
+
+        if (done)
+            SkyCompleteToggle.MarkTurnedIn(_settings, rewardKey,
+                SkyCompleteToggle.ItemsFor(_settings.SkyQuestChecklist, rewardKey));
+        else
+            SkyCompleteToggle.Reopen(_settings, rewardKey);
+        _settings.Save();
+        Refresh(force: true);
+    }
+
     // ---- shared small pieces ----
 
     /// <summary>A leading note above the list — the search scope, the current zone, the
@@ -1524,6 +1562,41 @@ public partial class QuestsWindow : Window
 
     private ImportReportView? _skyImport;
 
+    /// <summary>
+    /// The Sky tab's route to its own data source.
+    ///
+    /// This surface is FED by the achievements dump — the import is what tells it which
+    /// rewards were handed in before EQBuddy existed, and a hand-in never appears in the
+    /// log — and it named no way to produce one. The command lived on the widget's menu
+    /// and on the Raids card, neither of which is where a player wondering about Sky
+    /// rewards is looking. `GameCommandsTests.SurfacesNeedingACommand` is the curated
+    /// list this row is now on: a negative assertion cannot see an absence (trap 34), and
+    /// the Gear tab fell through the same hole for as long as it existed.
+    ///
+    /// Above the rows, beside the import report, for the reason in trap 44 — it is read
+    /// on arrival, and the widget caps its own height.
+    /// </summary>
+    private UIElement SkyAchievementsPrompt()
+    {
+        var wrap = new StackPanel { Margin = new Thickness(0, 0, 0, DesignTokens.SpaceS) };
+        wrap.Children.Add(Note(
+            "Turned rewards in before EQBuddy? The game's achievements dump knows. Run this "
+            + "in game and EQBuddy reads the file it writes — it never scans the game itself.",
+            "Info"));
+        var b = new Button
+        {
+            Style = (Style)FindResource("ActionButton"),
+            FontSize = DesignTokens.Spec(Role.Caption).Size,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Margin = new Thickness(0, DesignTokens.SpaceXs, 0, 0),
+            ToolTip = "Copies the command — paste it into the game's chat. The game writes "
+                + "<name>_<server>-Achievements.txt beside its own folders and EQBuddy "
+                + "imports it on its own; the report appears here.",
+        };
+        wrap.Children.Add(Theming.WireCopyCommand(b, GameCommands.OutputfileAchievements));
+        return wrap;
+    }
+
     private void RenderChecklist(QuestTab tab, string filter, List<string> classes)
     {
         // ABOVE the rows and re-added on every render, because QuestsPanel is cleared
@@ -1533,6 +1606,7 @@ public partial class QuestsWindow : Window
         {
             SkyImport.Render();
             QuestsPanel.Children.Add(SkyImport.Body);
+            QuestsPanel.Children.Add(SkyAchievementsPrompt());
         }
         // Grouping, ordering and the detail line come from Core so this window, the
         // Avalonia one and EQBuddy Mobile cannot disagree about what a checklist row

--- a/src/EQBuddy/QuestsWindow.xaml.cs
+++ b/src/EQBuddy/QuestsWindow.xaml.cs
@@ -45,6 +45,9 @@ public partial class QuestsWindow : Window
         // Base width so Ctrl+wheel shrinks the WINDOW, not just its text (#186).
         WindowZoom.Attach(this, "quests", _settings, baseWidth: Width);
         WindowZoom.AllowResize(this, "quests", _settings);
+        // A drag changes how much room the body has; without this the window grows
+        // and its content does not follow.
+        SizeChanged += (_, _) => UpdateHeightCaps();
         _tabs = new EqSegmentedStrip(TabStrip);
         _classes = new EqSegmentedStrip(ClassStrip);
         _modes = new EqSegmentedStrip(ModeStrip);
@@ -60,6 +63,8 @@ public partial class QuestsWindow : Window
         // offering three different vocabularies for one lens.
         foreach (var s in QuestChecklistLayout.States) StateCombo.Items.Add(s);
         StateCombo.SelectedIndex = 0;
+        foreach (var s in UnlockLayout.Sections) UnlockSectionCombo.Items.Add(s);
+        UnlockSectionCombo.SelectedIndex = 0;
         BuildModeStrip();
         // No ChipScale here — quests read at widget size, not chip size. That used to be
         // said as ChipScale.Apply(this, 1.0), which is not a no-op: it CLEARS the content
@@ -147,10 +152,13 @@ public partial class QuestsWindow : Window
             ? work.Height
             : SystemParameters.WorkArea.Height;   // before the handle exists
         MaxHeight = Math.Max(220, height * 0.85);
+        // The BODY opens at a design constant, not at a fraction of the monitor. Deriving
+        // it from the screen is what made this window fill a tall display; UI.Shared owns
+        // the number so all seven pop-outs cannot disagree about it.
         // The list and the pane share the window's height, so cap the SCROLLERS rather
         // than the window: without this the window grows past its cap on a long catalog
         // and the footnotes walk off the bottom of the screen.
-        BodyScroll.MaxHeight = Math.Max(120, MaxHeight - 280);
+        BodyScroll.MaxHeight = WindowSizing.BodyCap(MaxHeight, 280, FramelessResize.ManualHeight(this));
         DetailScroll.MaxHeight = BodyScroll.MaxHeight;
     }
 
@@ -184,9 +192,11 @@ public partial class QuestsWindow : Window
     {
         var state = "";
         if (tab.Split(':') is [var name, var wanted]) { tab = name; state = wanted; }
-        _tab = tab.Equals("sky", StringComparison.OrdinalIgnoreCase) ? QuestTab.Sky
-            : tab.Equals("epic", StringComparison.OrdinalIgnoreCase) ? QuestTab.Epic
-            : QuestTab.General;
+        // Core's own key table, not a ladder repeated here: it already maps every tab,
+        // so a new one is openable by its wire key the day it exists. The ladder knew
+        // only sky and epic, which is why the Unlocks tab could not be opened for review
+        // at all — a surface nobody can put on screen reads as reviewed anyway (trap 22).
+        _tab = QuestSurface.TabForKey(tab) ?? QuestTab.General;
         if (QuestChecklistLayout.States.Contains(state))
         {
             _state = state;
@@ -222,7 +232,7 @@ public partial class QuestsWindow : Window
     private void BuildTabs()
     {
         _tabs.Clear();
-        foreach (var header in QuestSurface.Tabs(EpicCounts(), SkyCounts()))
+        foreach (var header in QuestSurface.Tabs(EpicCounts(), SkyCounts(), UnlockCounts()))
         {
             var tab = header.Tab;
             _tabs.Add(header.Label, tab, header.Badge, onClick: () =>
@@ -291,17 +301,17 @@ public partial class QuestsWindow : Window
                 onClick: () => { _classLens = cls; Refresh(force: true); });
     }
 
-    private (int Done, int Total)? EpicCounts()
-    {
-        var items = _settings.EpicQuestChecklist;
-        return items.Count == 0 ? null : (items.Count(i => i.Acquired), items.Count);
-    }
+    // The counting RULE is Core's (QuestSurface.CountOf) — this window, the Avalonia one
+    // and the phone each had their own hand-rolled copy of the same expression, and a
+    // fourth copy is how #184 happened.
+    private (int Done, int Total)? EpicCounts() =>
+        QuestSurface.CountOf(_settings.EpicQuestChecklist, i => i.Acquired);
 
-    private (int Done, int Total)? SkyCounts()
-    {
-        var items = _settings.SkyQuestChecklist;
-        return items.Count == 0 ? null : (items.Count(i => i.Acquired), items.Count);
-    }
+    private (int Done, int Total)? SkyCounts() =>
+        QuestSurface.CountOf(_settings.SkyQuestChecklist, i => i.Acquired);
+
+    private (int Done, int Total)? UnlockCounts() =>
+        QuestSurface.UnlockCounts(_main.Unlocks.Races, _main.Unlocks.Classes);
 
     private void ApplyTabVisual()
     {
@@ -320,12 +330,23 @@ public partial class QuestsWindow : Window
         // "done" mean the most, because the reward you can hand in RIGHT NOW is the only
         // thing on the page with anything to do about it. The widget's Sky card had this
         // lens and it did not come across when the card became a launcher.
-        StateCombo.Visibility = Visibility.Visible;
         // The Epic tab's own lens, which followed the Epic card here when the widget
         // consolidated its quest cards (2026-08-16).
         EpicClassicOnlyCheck.Visibility = _tab == QuestTab.Epic ? Visibility.Visible : Visibility.Collapsed;
         SkyIslandRepeatCheck.Visibility = _tab == QuestTab.Sky ? Visibility.Visible : Visibility.Collapsed;
-        ClassBtn.Visibility = Visibility.Visible;
+        // Unlocks is divided by SECTION, not by class, so the class picker is replaced by
+        // a section lens; the state lens is not wired here and an inert filter is worse
+        // than an absent one. EVERY CONTROL BELOW IS ASSIGNED EXACTLY ONCE — an earlier
+        // cut hid ClassBtn in an `if` that a later unconditional assignment overwrote,
+        // which only a screenshot could catch.
+        var unlocks = _tab == QuestTab.Unlocks;
+        UnlockSectionCombo.Visibility = unlocks ? Visibility.Visible : Visibility.Collapsed;
+        StateCombo.Visibility = unlocks ? Visibility.Collapsed : Visibility.Visible;
+        ClassBtn.Visibility = unlocks ? Visibility.Collapsed : Visibility.Visible;
+        // "scan bags" copies /outputfile inventory, which is not what this tab reads.
+        CopyInvBtn.Visibility = unlocks ? Visibility.Collapsed : Visibility.Visible;
+        ClassStrip.Visibility = !unlocks && _classes.Count > 1
+            ? Visibility.Visible : Visibility.Collapsed;
         FilterRow.Visibility = Visibility.Visible;
         // A checklist has nothing to select, so the pane would only ever be empty. Give
         // its width back to the rows instead.
@@ -336,6 +357,25 @@ public partial class QuestsWindow : Window
     }
 
     private void ApplyModeVisual() => _modes.Select(_mode);
+
+    /// <summary>A faction dump just landed. Nothing to import — UnlockSource re-reads it
+    /// off disk — but an OPEN Unlocks tab should fill in now rather than on the next
+    /// reopen, which is the difference between the command appearing to work and appearing
+    /// to do nothing.</summary>
+    internal void FactionsChanged()
+    {
+        if (_tab == QuestTab.Unlocks) Refresh(force: true);
+    }
+
+    /// <summary>Which section of the Unlocks tab is in view. Session-scoped, like the
+    /// class lens and the search box: a sticky filter reads as a broken tracker tomorrow.</summary>
+    private string _unlockSection = UnlockLayout.SectionAll;
+
+    private void OnUnlockSectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (UnlockSectionCombo.SelectedItem is string s) _unlockSection = s;
+        Refresh(force: true);
+    }
 
     // ---- multiclass filter (Legends: up to three active classes; David 2026-08-07) ----
 
@@ -507,6 +547,12 @@ public partial class QuestsWindow : Window
         _suppressed = 0;
         SummaryRow.Visibility = Visibility.Collapsed;
         BuildTabs();
+        if (_tab == QuestTab.Unlocks)
+        {
+            DetailPane.Children.Clear();
+            RenderUnlocks();
+            return;
+        }
         if (_tab != QuestTab.General)
         {
             DetailPane.Children.Clear();
@@ -1605,6 +1651,158 @@ public partial class QuestsWindow : Window
         };
         wrap.Children.Add(Theming.WireCopyCommand(b, GameCommands.OutputfileAchievements));
         return wrap;
+    }
+
+    /// <summary>
+    /// Race and class unlocks (Hateborne, 2026-08-25).
+    ///
+    /// **Rows are read-only, and that is the design rather than a shortcut.** An unlock is
+    /// the GAME's answer — it comes from the achievements dump and, for a race, from the
+    /// faction dump. There is nothing for the player to tick, so there is no checkbox: a
+    /// disabled one would render exactly like a live one and swallow clicks (trap 17), and
+    /// a live one would invite a player to record something EQBuddy would overwrite on the
+    /// next dump.
+    /// </summary>
+    private void RenderUnlocks()
+    {
+        var races = _main.Unlocks.Races;
+        var classes = _main.Unlocks.Classes;
+        var factions = _main.Unlocks.Factions;
+
+        // BOTH commands, always — not only in the empty states they used to hide behind
+        // (Hateborne, 2026-08-25). This tab is built from two dumps and neither is a
+        // one-off: a race unlock moves every time you grind faction, so the button a
+        // player needs most is the one on the POPULATED surface. That is the same rule
+        // the Gear tab learned in #217, and the reason its ⧉ is not empty-state-only.
+        QuestsPanel.Children.Add(UnlockCommandRow());
+
+        if (!_main.Unlocks.HasAchievements)
+        {
+            QuestsPanel.Children.Add(EmptyState(
+                "No achievements dump yet. Race and class unlocks are the game's own record "
+                + "— EQBuddy reads the file the game writes and never scans the game itself. "
+                + "Run the achievements command above and this fills in."));
+            return;
+        }
+
+        // What the second dump is for, said only when something in view wants it.
+        if (UnlockLayout.NeedsFactionDump(races, factions))
+        {
+            QuestsPanel.Children.Add(Note(
+                "Race unlocks are faction work, and the log only ever sees faction CHANGES "
+                + "— never where you stand. Run the faction command above and the rows "
+                + "below fill in.", "Info"));
+        }
+        else if (factions is { } f)
+        {
+            QuestsPanel.Children.Add(Note(
+                $"Standings as of {f.WrittenAt:d MMM HH:mm}. Re-run the faction command "
+                + "after a grind to refresh them.", "Info"));
+        }
+
+        Section(UnlockLayout.RacesHeading, races);
+        Section(UnlockLayout.ClassesHeading, classes);
+
+        void Section(string heading, IReadOnlyList<UnlockProgress> unlocks)
+        {
+            if (unlocks.Count == 0) return;
+            if (!UnlockLayout.InSection(heading, _unlockSection)) return;
+            var title = DesignSystem.Text(Role.TitleSection, heading);
+            title.Margin = new Thickness(DesignTokens.SpaceXxs, DesignTokens.SpaceL, 0,
+                DesignTokens.SpaceXs);
+            title.Ink("AccentBrush");
+            QuestsPanel.Children.Add(title);
+
+            var groups = UnlockLayout.Groups(unlocks, factions, heading);
+            for (var i = 0; i < groups.Count; i++)
+            {
+                var g = groups[i];
+                var u = unlocks[i];
+                var score = u.Score is { } s ? $"   {s.Done}/{s.Total}" : "";
+                var head = DesignSystem.Text(Role.Body, g.Title + score);
+                head.FontWeight = FontWeights.SemiBold;
+                head.TextWrapping = TextWrapping.Wrap;
+                head.Margin = new Thickness(DesignTokens.SpaceS, DesignTokens.SpaceM, 0, 0);
+                head.Ink(u.Complete ? "GoodBrush" : "TextBrush");
+                QuestsPanel.Children.Add(head);
+
+                // Why it is complete matters as much as that it is: a granted unlock sits
+                // beside factions near zero, and a player who is not told reads the
+                // tracker as broken rather than the unlock as free.
+                if (UnlockLayout.Note(u) is { Length: > 0 } note)
+                    QuestsPanel.Children.Add(Note(note, "Info"));
+
+                foreach (var row in g.Rows)
+                {
+                    var line = new Grid { Margin = new Thickness(DesignTokens.SpaceL, 1, 0, 1) };
+                    line.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                    line.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                    // Two columns, never a horizontal StackPanel: a stack measures with
+                    // infinite width, so wrapping text beside an icon is clipped with no
+                    // ellipsis to say so (trap 14).
+                    var icon = DesignSystem.Icon(row.Acquired ? "Check" : "Pending",
+                        row.Acquired ? "GoodBrush" : "DimBrush", size: DesignTokens.IconInline);
+                    icon.VerticalAlignment = VerticalAlignment.Center;
+                    icon.Margin = new Thickness(0, 0, DesignTokens.SpaceXs, 0);
+                    Grid.SetColumn(icon, 0);
+                    line.Children.Add(icon);
+
+                    var text = DesignSystem.Text(Role.Body, "");
+                    text.TextWrapping = TextWrapping.Wrap;
+                    text.Inlines.Add(new System.Windows.Documents.Run(row.Title));
+                    if (row.Detail.Length > 0)
+                    {
+                        var detail = new System.Windows.Documents.Run("   " + row.Detail);
+                        detail.SetResourceReference(
+                            System.Windows.Documents.Run.ForegroundProperty, "DimBrush");
+                        text.Inlines.Add(detail);
+                    }
+                    text.Ink(row.Acquired ? "DimBrush" : "TextBrush");
+                    Grid.SetColumn(text, 1);
+                    line.Children.Add(text);
+                    QuestsPanel.Children.Add(line);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The two commands this tab is built from, side by side and always on screen.
+    ///
+    /// The header's "scan bags" button is hidden on this tab (see ApplyTabVisual): it
+    /// copies <c>/outputfile inventory</c>, which has nothing to do with race or class
+    /// unlocks, and its tooltip said so in as many words. A button that works and answers
+    /// a question the surface is not asking is its own kind of wrong.
+    /// </summary>
+    private UIElement UnlockCommandRow()
+    {
+        var row = new WrapPanel { Margin = new Thickness(0, 0, 0, DesignTokens.SpaceS) };
+        row.Children.Add(CommandPrompt(GameCommands.OutputfileAchievements,
+            "Copies the command. The game writes <name>_<server>-Achievements.txt beside "
+            + "its own folders; EQBuddy reads it on its own and this tab fills in. "
+            + "This is what says which races and classes you have unlocked."));
+        row.Children.Add(CommandPrompt(GameCommands.OutputfileFaction,
+            "Copies the command. The game writes <name>_<server>-<CLASS>-Factions.txt; "
+            + "EQBuddy reads it the moment the game says it is written. This is what says "
+            + "how far along each race's factions are — the log can only see faction "
+            + "CHANGES, never where you stand."));
+        return row;
+    }
+
+    /// <summary>A ⧉ copy of an in-game command, off <see cref="GameCommands"/>. Never its
+    /// own literal — GameCommandsTests forbids that, and the reason is that a button and
+    /// the prose beside it drifted.</summary>
+    private Button CommandPrompt(string command, string tip)
+    {
+        var b = new Button
+        {
+            Style = (Style)FindResource("ActionButton"),
+            FontSize = DesignTokens.Spec(Role.Caption).Size,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Margin = new Thickness(DesignTokens.SpaceS, DesignTokens.SpaceXs, 0, DesignTokens.SpaceS),
+            ToolTip = tip,
+        };
+        return Theming.WireCopyCommand(b, command);
     }
 
     private void RenderChecklist(QuestTab tab, string filter, List<string> classes)

--- a/src/EQBuddy/QuestsWindow.xaml.cs
+++ b/src/EQBuddy/QuestsWindow.xaml.cs
@@ -805,7 +805,17 @@ public partial class QuestsWindow : Window
         $"questsDetailShown={(DetailCard.Visibility == Visibility.Visible ? 1 : 0)} " +
         $"questsReadySummary={(SummaryRow.Visibility == Visibility.Visible ? 1 : 0)} " +
         $"questsTabs={_tabs.Count} " +
-        $"questsModes={_modes.Count}";
+        $"questsModes={_modes.Count} " +
+        // The Sky tab's ⧉ copy of /outputfile achievements. Counted off the real visual
+        // tree rather than from a flag, for the same reason gearCopyCmd exists: an absent
+        // control photographs as an unremarkable panel (trap 29), and a bool that nobody
+        // resets goes stale without anything noticing.
+        $"questsSkyCopyCmd={SkyCopyCommandsOnScreen()}";
+
+    private int SkyCopyCommandsOnScreen() => QuestsPanel.Children.OfType<StackPanel>()
+        .SelectMany(p => p.Children.OfType<Button>())
+        .Count(b => b.Content is string s
+            && s.Contains(GameCommands.OutputfileAchievements, StringComparison.Ordinal));
 
     // ---- the list ----
 

--- a/src/EQBuddy/WindowZoom.cs
+++ b/src/EQBuddy/WindowZoom.cs
@@ -76,12 +76,21 @@ internal static class WindowZoom
         window.ResizeMode = ResizeMode.CanResize;
         window.MinWidth = Math.Max(window.MinWidth, WindowSizing.MinWidth);
         window.MinHeight = Math.Max(window.MinHeight, WindowSizing.MinHeight);
+        // AND A BORDER TO GRAB: CanResize creates no non-client area on a frameless
+        // window, so every window through here was resizable in settings and immovable
+        // under a mouse. Here rather than at the call sites, so a window cannot join the
+        // feature and miss the affordance. FramelessResize has the evidence.
+        if (window.WindowStyle == WindowStyle.None) FramelessResize.Attach(window);
 
         if (settings.WindowHeights.TryGetValue(key, out var savedHeight)
             && WindowSizing.IsSaneHeight(savedHeight))
         {
             window.SizeToContent = SizeToContent.Manual;
             window.Height = savedHeight;
+            // A stored height only exists because the player dragged for it, so the window
+            // opens already owning its height — otherwise the next undragged close would
+            // delete the very choice this line just restored.
+            FramelessResize.MarkPlayerSized(window);
         }
         else
         {
@@ -94,8 +103,16 @@ internal static class WindowZoom
             var zoom = settings.WindowZooms.TryGetValue(key, out var z) && z > 0 ? z : 1.0;
             if (WindowSizing.BaseWidthToStore(window.Width, zoom) is { } basis)
                 settings.WindowBaseWidths[key] = basis;
-            if (WindowSizing.HeightToStore(window.ActualHeight) is { } h)
+            // ONLY a height the player dragged to. Persisting ActualHeight unconditionally
+            // recorded whatever a window happened to measure, including an empty first
+            // frame — four such entries in one real profile, none of them chosen. A value
+            // nobody chose is REMOVED, so a profile carrying one heals itself.
+            // MigrateWindowHeights explains why they all had to go.
+            if (FramelessResize.PlayerTookHeight(window)
+                && WindowSizing.HeightToStore(window.ActualHeight) is { } h)
                 settings.WindowHeights[key] = h;
+            else
+                settings.WindowHeights.Remove(key);
             settings.Save();
         };
 

--- a/tests/EQBuddy.Avalonia.Tests/OptionsRenderTests.cs
+++ b/tests/EQBuddy.Avalonia.Tests/OptionsRenderTests.cs
@@ -127,6 +127,37 @@ public class OptionsRenderTests : IDisposable
         main.Close();
     }
 
+    /// <summary>
+    /// The Alt+Tab tick-box is really on screen on this lane, and it says what it costs.
+    ///
+    /// An absent control photographs as an unremarkable panel (trap 29) and a setting with
+    /// no writer is trap 20, so neither a screenshot nor `DeadSettingTests` would catch
+    /// this lane simply not having the row. The warning text is asserted too, because
+    /// WS_EX_TOOLWINDOW takes the taskbar button with it and the tray icon then becomes
+    /// the only way back — a control that removes someone's way back without saying so is
+    /// the failure, not the flag.
+    /// </summary>
+    [AvaloniaFact]
+    public void TheAltTabBoxIsOnScreenAndNamesWhatItCosts()
+    {
+        var (main, options) = Open();
+        var toggle = options.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => (c.Content as TextBlock)?.Text?.Contains("Alt+Tab") == true);
+
+        Assert.False(toggle.IsChecked);
+        toggle.IsChecked = true;
+        Assert.True(main.Settings.HideFromAltTab);
+
+        // The cost is beside the box, off the shared table rather than spelled here.
+        var texts = options.GetVisualDescendants().OfType<TextBlock>()
+            .Select(t => t.Text ?? "").ToList();
+        Assert.Contains(texts, t => t.Contains("taskbar button"));
+        Assert.Contains(texts, t => t == EQBuddy.UI.Shared.AltTabPolicy.TaskbarWarning);
+
+        options.Close();
+        main.Close();
+    }
+
     [AvaloniaFact]
     public void TargetDropsToggleAndAlertColorControlsAreAvailable()
     {

--- a/tests/EQBuddy.Avalonia.Tests/QuestsRenderTests.cs
+++ b/tests/EQBuddy.Avalonia.Tests/QuestsRenderTests.cs
@@ -46,6 +46,14 @@ public sealed class QuestsRenderTests : IDisposable
         /// null is the ordinary case (no dump has been read this session).</summary>
         public AutoImportOutcome? LastAchievementsImport { get; set; }
         public InventoryFile.Snapshot? LatestInventory(bool refresh = false) => null;
+
+        // The Unlocks tab's two dumps. Settable so a test can stage them; the default is
+        // the honest "this player has never run either command" state, which is the one
+        // the tab has to handle without showing sixteen races at zero.
+        public IReadOnlyList<UnlockProgress> RaceUnlocks { get; set; } = [];
+        public IReadOnlyList<UnlockProgress> ClassUnlocks { get; set; } = [];
+        public FactionsFile.Snapshot? LatestFactions { get; set; }
+        public bool HasUnlockDump { get; set; }
         public string? CachedItemStats(string itemName) => null;
         public Task<string?> FetchItemTooltip(string itemName) => Task.FromResult<string?>(null);
     }

--- a/tests/EQBuddy.E2E/EndToEndTests.cs
+++ b/tests/EQBuddy.E2E/EndToEndTests.cs
@@ -832,6 +832,49 @@ public sealed class EndToEndTests
     }
 
     /// <summary>
+    /// The Sky tab hands over the command that FEEDS it.
+    ///
+    /// A hand-in never appears in the log, so `/outputfile achievements` is the only thing
+    /// that can say a Sky reward was turned in before EQBuddy existed — and until
+    /// 2026-08-25 this surface named no way to produce one, with the copy living on the
+    /// widget menu and the Raids card. Same absence the Gear tab had, and the same reason
+    /// nothing caught it: a negative assertion cannot see a missing control (trap 34), and
+    /// an absent control photographs as an unremarkable panel (trap 29).
+    ///
+    /// The count is read off the real visual tree, so this is the WPF lane's only proof
+    /// that the button EXISTS rather than that the constant is referenced somewhere.
+    /// </summary>
+    [Fact]
+    public void TheSkyTabOffersTheAchievementsCommandItRunsOn()
+    {
+        using var app = new AppHarness(
+            environment: new Dictionary<string, string> { ["EQBUDDY_QUESTS"] = "sky" });
+        app.Launch();
+
+        Wait.Until(() => app.DumpValue("questsTabs") > 0, TimeSpan.FromSeconds(45),
+            "the Quest Tracker to open on the Sky tab", app.Artifacts);
+        Assert.Equal(1, app.DumpValue("questsSkyCopyCmd"));
+    }
+
+    /// <summary>
+    /// Alt+Tab exclusion is off by default, and the window agrees with the setting.
+    ///
+    /// Both halves are reported because they are different claims: `altTabWanted` is what
+    /// `settings.json` says and `altTabStyle` is the ex-style actually on the HWND. Trap
+    /// 42 is exactly the gap between them — a feature genuinely in the binary, genuinely
+    /// not in force, and indistinguishable from a stale build from anywhere but here.
+    /// </summary>
+    [Fact]
+    public void TheWidgetStaysInAltTabUntilAskedNotTo()
+    {
+        using var app = new AppHarness();
+        app.Launch();
+
+        Assert.Equal(0, app.DumpValue("altTabWanted"));
+        Assert.Equal(0, app.DumpValue("altTabStyle"));
+    }
+
+    /// <summary>
     /// EQBuddy Mobile's 20 Hz pump costs nothing when nobody is paired.
     ///
     /// `CompanionPumpGateTests` proves the gate returns false; it cannot prove the real

--- a/tests/EQBuddy.Tests/AchievementsImportTests.cs
+++ b/tests/EQBuddy.Tests/AchievementsImportTests.cs
@@ -13,6 +13,13 @@ public class AchievementsImportTests
         File.ReadAllLines(Path.Combine(AppContext.BaseDirectory,
             "..", "..", "..", "..", "fixtures", "achievements", "averaj.txt"));
 
+    /// <summary>David's own dump, 2026-08-25 — the one that found the Shadow Knight
+    /// hole. Kept beside averaj's because the two spell the class differently and only
+    /// a real pair proves which spelling the game writes.</summary>
+    private static string[] Hateborne() =>
+        File.ReadAllLines(Path.Combine(AppContext.BaseDirectory,
+            "..", "..", "..", "..", "fixtures", "achievements", "hateborne.txt"));
+
     [Fact]
     public void ParsesSectionsAchievementsAndFlaggedCriteria()
     {
@@ -165,6 +172,67 @@ public class AchievementsImportTests
         // The unearned class is untouched by all of it.
         Assert.DoesNotContain(autoGranted, g => g.Contains("Skycleaver"));
         Assert.DoesNotContain(matches, m => m.ClassName == "Berserker");
+    }
+
+    /// <summary>
+    /// The dump writes "Shadowknight"; the catalog writes "Shadow Knight".
+    ///
+    /// `SkyRewards` compared the two with an exact match and, finding no checklist rows,
+    /// `continue`d — so every Shadow Knight reward was dropped BEFORE the auto-grant
+    /// guard, before the matcher, and before `unmatched`, which exists precisely so that
+    /// nothing is swallowed. Fifteen classes spell identically on both sides, so the hole
+    /// was invisible to anyone who was not a Shadow Knight, and David is one. In his own
+    /// dump it cost two real turn-ins.
+    ///
+    /// The repo already knew both spellings existed (`SpellLevelCatalog`'s doc comment
+    /// names the hazard; `GearLocker` carried a private map with both strings in it) —
+    /// one fact with two sources, and neither of them was the one doing the comparing.
+    /// </summary>
+    [Fact]
+    public void ShadowknightIsTheSameClassAsShadowKnight()
+    {
+        var checklist = new List<SkyQuestChecklistItem>
+        {
+            new() { Id = "1", ClassName = "Shadow Knight", Reward = "Obtenebrate Mithril Guard", QuestItem = "x" },
+            new() { Id = "2", ClassName = "Shadow Knight", Reward = "Crimson Ring of the Djinni", QuestItem = "y" },
+            new() { Id = "3", ClassName = "Shadow Knight", Reward = "Pegasus-Hide Belt", QuestItem = "z" },
+        };
+
+        var (matches, _, _) = AchievementsImport.SkyRewards(
+            AchievementsImport.Parse(Hateborne()), checklist);
+
+        // Both are flagged C under an INCOMPLETE unlock, so the per-criterion flags are
+        // trustworthy — and both items are in his inventory dump, which is what makes
+        // this a fact about the game rather than about the parser.
+        Assert.Contains(matches, m => m.Reward == "Obtenebrate Mithril Guard");
+        Assert.Contains(matches, m => m.Reward == "Crimson Ring of the Djinni");
+        // Still I in the dump: the fix must not tick everything it can now see.
+        Assert.DoesNotContain(matches, m => m.Reward == "Pegasus-Hide Belt");
+        // The match carries the CATALOG's spelling, because that is what keys
+        // SkyQuestCompleted ("Class|Reward") and what every surface reads back.
+        Assert.All(matches, m => Assert.Equal("Shadow Knight", m.ClassName));
+    }
+
+    /// <summary>The other half of the same hole: a class unlock the checklist has no
+    /// rows for used to vanish without a word. An unresolvable name is REPORTED — the
+    /// rule `unmatched` already enforces one level down, and the reason a player can
+    /// see why nothing ticked instead of guessing.</summary>
+    [Fact]
+    public void AClassTheChecklistDoesNotCarryIsReportedNotDropped()
+    {
+        var lines = new[]
+        {
+            "Untapped Potential: Classes",
+            "I\tPrimary Class Unlock - Bard",
+            "C\t\tObtain Mask of Song.",
+        };
+
+        var (matches, unmatched, autoGranted) = AchievementsImport.SkyRewards(
+            AchievementsImport.Parse(lines), []);
+
+        Assert.Empty(matches);
+        Assert.Empty(autoGranted);
+        Assert.Contains(unmatched, u => u.Contains("Mask of Song"));
     }
 
     [Fact]

--- a/tests/EQBuddy.Tests/AchievementsImportTests.cs
+++ b/tests/EQBuddy.Tests/AchievementsImportTests.cs
@@ -13,7 +13,7 @@ public class AchievementsImportTests
         File.ReadAllLines(Path.Combine(AppContext.BaseDirectory,
             "..", "..", "..", "..", "fixtures", "achievements", "averaj.txt"));
 
-    /// <summary>David's own dump, 2026-08-25 — the one that found the Shadow Knight
+    /// <summary>Hateborne's own dump, 2026-08-25 — the one that found the Shadow Knight
     /// hole. Kept beside averaj's because the two spell the class differently and only
     /// a real pair proves which spelling the game writes.</summary>
     private static string[] Hateborne() =>
@@ -181,7 +181,7 @@ public class AchievementsImportTests
     /// `continue`d — so every Shadow Knight reward was dropped BEFORE the auto-grant
     /// guard, before the matcher, and before `unmatched`, which exists precisely so that
     /// nothing is swallowed. Fifteen classes spell identically on both sides, so the hole
-    /// was invisible to anyone who was not a Shadow Knight, and David is one. In his own
+    /// was invisible to anyone who was not a Shadow Knight, and Hateborne is one. In that
     /// dump it cost two real turn-ins.
     ///
     /// The repo already knew both spellings existed (`SpellLevelCatalog`'s doc comment
@@ -202,7 +202,7 @@ public class AchievementsImportTests
             AchievementsImport.Parse(Hateborne()), checklist);
 
         // Both are flagged C under an INCOMPLETE unlock, so the per-criterion flags are
-        // trustworthy — and both items are in his inventory dump, which is what makes
+        // trustworthy — and both items are in the inventory dump, which is what makes
         // this a fact about the game rather than about the parser.
         Assert.Contains(matches, m => m.Reward == "Obtenebrate Mithril Guard");
         Assert.Contains(matches, m => m.Reward == "Crimson Ring of the Djinni");

--- a/tests/EQBuddy.Tests/AltTabPolicyTests.cs
+++ b/tests/EQBuddy.Tests/AltTabPolicyTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace EQBuddy.Tests;
 
 /// <summary>
-/// "Keep EQBuddy out of Alt+Tab" (David, 2026-08-25), and the two honesty rules around it.
+/// "Keep EQBuddy out of Alt+Tab" (Hateborne, 2026-08-25), and the two honesty rules around it.
 ///
 /// The setting is one Windows flag with two effects, and both of them matter to a player:
 /// it leaves the switcher AND it leaves the taskbar. There is no way to have one without

--- a/tests/EQBuddy.Tests/AltTabPolicyTests.cs
+++ b/tests/EQBuddy.Tests/AltTabPolicyTests.cs
@@ -1,0 +1,56 @@
+using EQBuddy.UI.Shared;
+using Xunit;
+
+namespace EQBuddy.Tests;
+
+/// <summary>
+/// "Keep EQBuddy out of Alt+Tab" (David, 2026-08-25), and the two honesty rules around it.
+///
+/// The setting is one Windows flag with two effects, and both of them matter to a player:
+/// it leaves the switcher AND it leaves the taskbar. There is no way to have one without
+/// the other, so the only honest design is to say so where the choice is made.
+/// </summary>
+public class AltTabPolicyTests
+{
+    [Fact]
+    public void OnlyWindowsHasAPerWindowOptOut()
+    {
+        Assert.Equal(OperatingSystem.IsWindows(), AltTabPolicy.Available);
+    }
+
+    /// <summary>
+    /// The #169 rule, applied to a second setting: a platform that cannot honour a
+    /// tick-box gets a sentence naming the reason. A box that saves a choice and does
+    /// nothing is the silent no-op CLAUDE.md treats as broken — and it is worse than a
+    /// missing feature, because the player believes they have turned something on.
+    /// </summary>
+    [Fact]
+    public void ThePlatformThatCannotDoItSaysSoAndTheOneThatCanStaysQuiet()
+    {
+        if (AltTabPolicy.Available)
+        {
+            Assert.Equal("", AltTabPolicy.UnavailableNote);
+        }
+        else
+        {
+            Assert.NotEqual("", AltTabPolicy.UnavailableNote);
+            // Names the reason rather than just refusing — the difference between a
+            // player closing Options and a player spending an evening on it.
+            Assert.Contains("switcher", AltTabPolicy.UnavailableNote);
+            Assert.Contains("saved", AltTabPolicy.UnavailableNote);
+        }
+    }
+
+    /// <summary>
+    /// The cost is not a footnote. WS_EX_TOOLWINDOW removes the taskbar button in the
+    /// same stroke, so a widget that is also hidden by the focus-hide settings has
+    /// exactly one way back: the tray icon. Both facts have to be in the sentence, or
+    /// this setting can strand someone.
+    /// </summary>
+    [Fact]
+    public void TheWarningNamesBothTheTaskbarAndTheWayBack()
+    {
+        Assert.Contains("taskbar", AltTabPolicy.TaskbarWarning);
+        Assert.Contains("tray icon", AltTabPolicy.TaskbarWarning);
+    }
+}

--- a/tests/EQBuddy.Tests/ClassSourceWritersTests.cs
+++ b/tests/EQBuddy.Tests/ClassSourceWritersTests.cs
@@ -56,6 +56,24 @@ public class ClassSourceWritersTests
         },
     };
 
+    /// <summary>
+    /// Routes that READ a dump and deliberately record nothing, each with the reason.
+    ///
+    /// An exemption nobody can see is a blind spot rather than an exemption
+    /// (`SurfaceOwnershipTests` says the same thing about its two lanes), so this is a
+    /// list and not a hole in the scan below.
+    /// </summary>
+    public static readonly (string File, string Why)[] ReadsButDoesNotRecord =
+    [
+        ("src/EQBuddy.Core/UnlockSource.cs",
+            "It re-reads both dumps on a RENDER path, when their timestamps move, so that "
+            + "the Unlocks tab cannot show what was true last week. Recording from there "
+            + "would make a getter write to the per-character ledger on a UI tick — a "
+            + "second writer racing the import path for one fact (trap 4), and a ledger "
+            + "save per repaint. The import routes above are the writers, and they run on "
+            + "the same dump the moment the game announces it."),
+    ];
+
     [Theory]
     [MemberData(nameof(Writers))]
     public void EveryAchievementsImportRouteRecordsTheClassesItRead(string file, string why)
@@ -76,6 +94,7 @@ public class ClassSourceWritersTests
     public void NoOtherFileParsesAnAchievementsDumpUnnoticed()
     {
         var known = Writers.Select(row => (string)row[0]!)
+            .Concat(ReadsButDoesNotRecord.Select(r => r.File))
             .Select(f => f.Replace('/', Path.DirectorySeparatorChar))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
@@ -96,7 +115,20 @@ public class ClassSourceWritersTests
 
         Assert.True(offenders.Count == 0,
             "these files read an achievements dump and are not on the writers list — either "
-            + "record UnlockedClasses there or add a row saying why not: "
-            + string.Join(", ", offenders));
+            + "record UnlockedClasses there or add a row to ReadsButDoesNotRecord saying "
+            + "why not: " + string.Join(", ", offenders));
+    }
+
+    /// <summary>An exemption needs a REASON, and the file it names has to still exist —
+    /// otherwise the list decays into a set of names nobody can evaluate.</summary>
+    [Fact]
+    public void EveryExemptionNamesARealFileAndSaysWhy()
+    {
+        Assert.All(ReadsButDoesNotRecord, row =>
+        {
+            Assert.True(File.Exists(Path.Combine(Root, row.File)),
+                $"{row.File} has moved — update this exemption");
+            Assert.True(row.Why.Length > 40, $"{row.File}: an exemption needs a real reason");
+        });
     }
 }

--- a/tests/EQBuddy.Tests/CompanionQuestsTests.cs
+++ b/tests/EQBuddy.Tests/CompanionQuestsTests.cs
@@ -107,8 +107,8 @@ public class CompanionQuestsTests
             SkyQuestChecklist = [new SkyQuestChecklistItem { Id = "s1", ClassName = "Bard", Reward = "y", QuestItem = "z" }],
         };
         var quests = Build(new CompanionQuestRequest { Catalog = Catalog() }, settings).Quests!;
-        Assert.Equal(["general", "epic", "sky"], quests.Tabs.Select(t => t.Key));
-        Assert.Equal(["Quests", "Epic 1.0", "Plane of Sky"], quests.Tabs.Select(t => t.Label));
+        Assert.Equal(["general", "epic", "sky", "unlocks"], quests.Tabs.Select(t => t.Key));
+        Assert.Equal(["Quests", "Epic 1.0", "Plane of Sky", "Unlocks"], quests.Tabs.Select(t => t.Label));
         Assert.Null(quests.Tabs[0].Badge);       // a catalog you search, not a checklist you finish
         Assert.Equal("1 / 1", quests.Tabs[1].Badge);
         Assert.Equal("0 / 1", quests.Tabs[2].Badge);

--- a/tests/EQBuddy.Tests/GameCommandsTests.cs
+++ b/tests/EQBuddy.Tests/GameCommandsTests.cs
@@ -70,6 +70,14 @@ public class GameCommandsTests
             "the tab IS the dump — ranked by slot, or listed by bag"),
         ("EQBuddy/QuestsWindow.xaml.cs", nameof(GameCommands.OutputfileInventory),
             "the held and ready views answer what-can-I-turn-in from bags and bank"),
+        // The Sky tab is FED by the achievements dump — a hand-in never appears in the
+        // log, so that dump is the only thing that can say a reward was turned in before
+        // EQBuddy existed — and it named no way to produce one. The command lived on the
+        // widget menu and the Raids card, neither of which is where someone looking at
+        // Sky rewards is looking. Same absence as the Gear tab in 2026-08-20, found the
+        // same way: by asking what a surface needs rather than what it must not carry.
+        ("EQBuddy/QuestsWindow.xaml.cs", nameof(GameCommands.OutputfileAchievements),
+            "the Sky tab's turn-in state comes from the achievements dump"),
         ("EQBuddy/RaidsCardView.cs", nameof(GameCommands.OutputfileAchievements),
             "clears from before EQBuddy come from the achievements dump — the worked example"),
         ("EQBuddy/QuestChecklistView.cs", nameof(GameCommands.OutputfileAchievements),
@@ -92,6 +100,7 @@ public class GameCommandsTests
         ("EQBuddy.Avalonia/InventoryView.cs", nameof(GameCommands.OutputfileInventory),
             "the tab IS the dump — ranked by slot, or listed by bag"),
         ("EQBuddy.Avalonia/QuestsWindow.cs", nameof(GameCommands.OutputfileInventory), "WPF twin"),
+        ("EQBuddy.Avalonia/QuestsWindow.cs", nameof(GameCommands.OutputfileAchievements), "WPF twin"),
         ("EQBuddy.Avalonia/MapWindow.cs", nameof(GameCommands.LocSocial), "WPF twin"),
     ];
 

--- a/tests/EQBuddy.Tests/GameCommandsTests.cs
+++ b/tests/EQBuddy.Tests/GameCommandsTests.cs
@@ -78,6 +78,12 @@ public class GameCommandsTests
         // same way: by asking what a surface needs rather than what it must not carry.
         ("EQBuddy/QuestsWindow.xaml.cs", nameof(GameCommands.OutputfileAchievements),
             "the Sky tab's turn-in state comes from the achievements dump"),
+        // The Unlocks tab is built from TWO dumps and neither is a one-off — a race unlock
+        // moves every time you grind faction — so both buttons are on the populated
+        // surface, not only in an empty state (#217's rule, and the reason the Gear tab's
+        // copy is not empty-state-only either).
+        ("EQBuddy/QuestsWindow.xaml.cs", nameof(GameCommands.OutputfileFaction),
+            "the Unlocks tab's race progress is faction standings, which the log never sees"),
         ("EQBuddy/RaidsCardView.cs", nameof(GameCommands.OutputfileAchievements),
             "clears from before EQBuddy come from the achievements dump — the worked example"),
         ("EQBuddy/QuestChecklistView.cs", nameof(GameCommands.OutputfileAchievements),
@@ -101,6 +107,7 @@ public class GameCommandsTests
             "the tab IS the dump — ranked by slot, or listed by bag"),
         ("EQBuddy.Avalonia/QuestsWindow.cs", nameof(GameCommands.OutputfileInventory), "WPF twin"),
         ("EQBuddy.Avalonia/QuestsWindow.cs", nameof(GameCommands.OutputfileAchievements), "WPF twin"),
+        ("EQBuddy.Avalonia/QuestsWindow.cs", nameof(GameCommands.OutputfileFaction), "WPF twin"),
         ("EQBuddy.Avalonia/MapWindow.cs", nameof(GameCommands.LocSocial), "WPF twin"),
     ];
 

--- a/tests/EQBuddy.Tests/OutputfileAutoImportTests.cs
+++ b/tests/EQBuddy.Tests/OutputfileAutoImportTests.cs
@@ -39,8 +39,15 @@ public class OutputfileAutoImportTests
     // Case varies across servers in the filenames we HAVE seen, so the match is
     // case-insensitive rather than trusting one capitalisation.
     [InlineData("dranak_freeport-inventory.txt", OutputfileKind.Inventory)]
+    // The faction dump, and the reason it is a SUFFIX rule: the game splices the
+    // character's class code into the middle of the name. Counting segments would refuse
+    // a real dump forever, which is trap 48's distinction on a different filename.
+    // Verified from David's own log, 2026-08-25:
+    //   Outputfile Complete: Hateborne_neriak-ENC-Factions.txt
+    [InlineData("Hateborne_neriak-ENC-Factions.txt", OutputfileKind.Factions)]
+    [InlineData("Dranak_freeport-Factions.txt", OutputfileKind.Factions)]
     // A dump EQBuddy has no reader for is named as such, not silently treated as one of
-    // the two it does read — guessing here would apply the wrong importer to a real file.
+    // the ones it does read — guessing here would apply the wrong importer to a real file.
     [InlineData("Dranak_freeport-Spellbook.txt", OutputfileKind.Unknown)]
     [InlineData("", OutputfileKind.Unknown)]
     public void TheFilenameDecidesWhichImporterRuns(string file, OutputfileKind expected) =>

--- a/tests/EQBuddy.Tests/OutputfileAutoImportTests.cs
+++ b/tests/EQBuddy.Tests/OutputfileAutoImportTests.cs
@@ -42,7 +42,7 @@ public class OutputfileAutoImportTests
     // The faction dump, and the reason it is a SUFFIX rule: the game splices the
     // character's class code into the middle of the name. Counting segments would refuse
     // a real dump forever, which is trap 48's distinction on a different filename.
-    // Verified from David's own log, 2026-08-25:
+    // Verified from Hateborne's own log, 2026-08-25:
     //   Outputfile Complete: Hateborne_neriak-ENC-Factions.txt
     [InlineData("Hateborne_neriak-ENC-Factions.txt", OutputfileKind.Factions)]
     [InlineData("Dranak_freeport-Factions.txt", OutputfileKind.Factions)]
@@ -379,5 +379,47 @@ public class OutputfileAutoImportTests
         var again = OutputfileAutoImport.ImportInventory(dump, settings);
         Assert.Equal(0, again.GearTicked);
         Assert.Null(again.Undo);
+    }
+
+    /// <summary>
+    /// A faction dump must never reach the achievements importer.
+    ///
+    /// Both widgets routed the announcement with `if (kind == Inventory) … else …`, so the
+    /// else branch meant "everything that is not inventory". Adding OutputfileKind.Factions
+    /// to the enum on 2026-08-25 therefore fed TSV faction rows to a parser that looks for
+    /// C/I achievement lines: it finds none, and ImportAchievements then records the empty
+    /// result — SetUnlockedClasses(key, []) — WIPING the class list the real achievements
+    /// dump established, while reporting "read your achievements dump" about a file that
+    /// was nothing of the kind.
+    ///
+    /// This pins the parser half, which is where the damage came from: an achievements
+    /// parse of a faction dump yields nothing, so anything that writes what it yields is
+    /// destroying data. Both widgets now switch on the kind exhaustively.
+    /// </summary>
+    [Fact]
+    public void AFactionDumpIsNotAnAchievementsDump()
+    {
+        // The real shape: a header row and tab-separated integers, no C/I column at all.
+        var factionLines = new[]
+        {
+            "ID	Name	StandingValue	PointsToMax",
+            "236	Dark Bargainers	0	2000",
+            "330	The Freeport Militia	-15	2015",
+        };
+
+        var asAchievements = AchievementsImport.Parse(factionLines);
+        Assert.Empty(asAchievements.Where(a => a.Criteria.Count > 0));
+        Assert.Empty(AchievementsImport.UnlockedClasses(asAchievements));
+
+        // Which is exactly why the kind must be told apart BEFORE anything is applied.
+        Assert.Equal(OutputfileKind.Factions,
+            OutputfileAutoImport.KindOf("Hateborne_neriak-ENC-Factions.txt"));
+        Assert.NotEqual(OutputfileKind.Achievements,
+            OutputfileAutoImport.KindOf("Hateborne_neriak-ENC-Factions.txt"));
+
+        // And it really does parse as factions.
+        var standings = FactionsFile.Parse(factionLines);
+        Assert.Equal(2, standings.Count);
+        Assert.Equal("Dark Bargainers", standings[0].Name);
     }
 }

--- a/tests/EQBuddy.Tests/QuestSurfaceTests.cs
+++ b/tests/EQBuddy.Tests/QuestSurfaceTests.cs
@@ -11,12 +11,12 @@ namespace EQBuddy.Tests;
 public class QuestSurfaceTests
 {
     [Fact]
-    public void AllThreeTabsAlwaysExistInAFixedOrder()
+    public void EveryTabAlwaysExistsInAFixedOrder()
     {
         // Nothing ticked anywhere: the tabs still show. A Sky tab that appears only
         // once you've started Sky hides itself from the player who most needs it.
         var tabs = QuestSurface.Tabs();
-        Assert.Equal([QuestTab.General, QuestTab.Epic, QuestTab.Sky], tabs.Select(t => t.Tab));
+        Assert.Equal([QuestTab.General, QuestTab.Epic, QuestTab.Sky, QuestTab.Unlocks], tabs.Select(t => t.Tab));
     }
 
     [Fact]

--- a/tests/EQBuddy.Tests/QuestTrackerTests.cs
+++ b/tests/EQBuddy.Tests/QuestTrackerTests.cs
@@ -338,6 +338,51 @@ public class QuestTrackerTests : IDisposable
         Assert.Empty(reloaded.ClassesFor("vex_legends"));
     }
 
+    /// <summary>
+    /// One class name, several spellings, one answer. The game's achievements dump writes
+    /// "Shadowknight" and every catalog in this repo writes "Shadow Knight" — an exact
+    /// compare between the two is false, and that dropped all sixteen Shadow Knight Sky
+    /// rewards silently until 2026-08-25.
+    ///
+    /// The negatives are the half that keeps this honest (trap 39): a resolver that says
+    /// yes to everything would satisfy every positive above and be worse than no resolver
+    /// at all, because callers would start trusting it.
+    /// </summary>
+    [Fact]
+    public void ClassNamesResolveToOneCatalogSpelling()
+    {
+        Assert.Equal("Shadow Knight", QuestClassFilter.Canonical("Shadowknight"));
+        Assert.Equal("Shadow Knight", QuestClassFilter.Canonical("Shadow Knight"));
+        Assert.Equal("Shadow Knight", QuestClassFilter.Canonical("shadow knight"));
+        Assert.Equal("Shadow Knight", QuestClassFilter.Canonical("Shadow-Knight"));
+        // Codes ask the same question, and both of Shadow Knight's answer it.
+        Assert.Equal("Shadow Knight", QuestClassFilter.Canonical("SHD"));
+        Assert.Equal("Shadow Knight", QuestClassFilter.Canonical("SK"));
+        Assert.Equal("Beastlord", QuestClassFilter.Canonical("BST"));
+        // Every one of the sixteen resolves to itself, so no caller has to special-case.
+        Assert.All(QuestClassFilter.Classes,
+            c => Assert.Equal(c, QuestClassFilter.Canonical(c)));
+
+        // Not a class: "" rather than a guess, so a caller can tell and say so.
+        Assert.Equal("", QuestClassFilter.Canonical("Shadow"));
+        Assert.Equal("", QuestClassFilter.Canonical("Knight"));
+        Assert.Equal("", QuestClassFilter.Canonical("Dark Elf"));
+        Assert.Equal("", QuestClassFilter.Canonical(""));
+        Assert.Equal("", QuestClassFilter.Canonical("   "));
+    }
+
+    /// <summary>The code map that used to live privately in GearLocker — with BOTH
+    /// spellings in it while the code doing the comparing had neither — now comes off
+    /// QuestClassFilter. Same answers, one source.</summary>
+    [Fact]
+    public void GearLockerCodesComeFromTheSameTable()
+    {
+        Assert.Equal("SHD", EQBuddy.UI.Shared.GearLocker.Code("Shadowknight"));
+        Assert.Equal("SHD", EQBuddy.UI.Shared.GearLocker.Code("Shadow Knight"));
+        Assert.Equal("PAL", EQBuddy.UI.Shared.GearLocker.Code("PAL"));
+        Assert.Equal("NEWCLASS", EQBuddy.UI.Shared.GearLocker.Code("NewClass"));
+    }
+
     [Fact]
     public void BerserkerIsAKnownClass()
     {

--- a/tests/EQBuddy.Tests/SkyTestSplitTests.cs
+++ b/tests/EQBuddy.Tests/SkyTestSplitTests.cs
@@ -50,4 +50,62 @@ public class SkyTestSplitTests
         Assert.NotEmpty(wizardOnly);
         Assert.DoesNotContain(wizardOnly, q => q.Name.StartsWith("Monk "));
     }
+
+    /// <summary>The split quest name and the Sky checklist key are two spellings of one
+    /// fact, and the round trip is what stops them drifting. The negatives matter as much:
+    /// an ordinary catalog quest must resolve to "" or every quest in the catalog would
+    /// start reading its completion off the Sky checklist.</summary>
+    [Fact]
+    public void ASplitQuestNameRoundTripsToItsRewardKey()
+    {
+        Assert.Equal("Wizard Sky Test: Nargon's Staff",
+            SkyTestSplit.QuestName("Wizard", "Nargon's Staff"));
+        Assert.Equal("Wizard|Nargon's Staff",
+            SkyTestSplit.RewardKeyFor("Wizard Sky Test: Nargon's Staff"));
+        // The class with a space in it is the one that broke everything else.
+        Assert.Equal("Shadow Knight|Obtenebrate Mithril Guard",
+            SkyTestSplit.RewardKeyFor("Shadow Knight Sky Test: Obtenebrate Mithril Guard"));
+
+        Assert.Equal("", SkyTestSplit.RewardKeyFor("Journey to the Plane of Sky"));
+        Assert.Equal("", SkyTestSplit.RewardKeyFor("Sky Test: no class"));
+        Assert.Equal("", SkyTestSplit.RewardKeyFor("Wizard Sky Test: "));
+        Assert.Equal("", SkyTestSplit.RewardKeyFor(""));
+
+        // Every SHIPPED split quest resolves — the property that makes the fold total,
+        // asserted against the real catalog rather than a hand-built one.
+        var split = QuestCatalog.LoadEmbedded().Quests
+            .Where(q => q.Name.Contains(" Sky Test: ", StringComparison.Ordinal)).ToList();
+        Assert.True(split.Count >= 60, $"only {split.Count} split quests");
+        Assert.All(split, q => Assert.NotEqual("", SkyTestSplit.RewardKeyFor(q.Name)));
+    }
+
+    /// <summary>
+    /// #101/#204's other half: the Quests tab read the per-character quest ledger and the
+    /// Sky tab read `SkyQuestCompleted`, and nothing joined them — so a reward the game's
+    /// own achievements dump reported as handed in still sat on the Quests tab as work to
+    /// do. The fold is read-only and additive; a ledger count already there wins.
+    /// </summary>
+    [Fact]
+    public void ASkyRewardTurnedInReadsCompletedOnTheCatalogTabToo()
+    {
+        var ledger = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Journey to the Plane of Sky"] = 1,
+            ["Wizard Sky Test: Nargon's Staff"] = 3,   // repeatable count the player set
+        };
+
+        var merged = SkyTestSplit.WithTurnIns(ledger,
+            ["Shadow Knight|Obtenebrate Mithril Guard", "Wizard|Nargon's Staff"]);
+
+        Assert.Equal(1, merged["Shadow Knight Sky Test: Obtenebrate Mithril Guard"]);
+        // The ledger's own answer is not overwritten by the fold.
+        Assert.Equal(3, merged["Wizard Sky Test: Nargon's Staff"]);
+        Assert.Equal(1, merged["Journey to the Plane of Sky"]);
+        // Nothing invented: a reward nobody turned in stays absent, so a quest with no
+        // entry is still "not completed" rather than "completed zero times".
+        Assert.DoesNotContain("Bard Sky Test: Mask of Song", merged.Keys);
+
+        // A null/empty checklist is the common case and must not throw.
+        Assert.Equal(ledger.Count, SkyTestSplit.WithTurnIns(ledger, null).Count);
+    }
 }

--- a/tests/EQBuddy.Tests/UnlockRequirementsTests.cs
+++ b/tests/EQBuddy.Tests/UnlockRequirementsTests.cs
@@ -1,0 +1,286 @@
+using EQBuddy.Core;
+using Xunit;
+
+namespace EQBuddy.Tests;
+
+/// <summary>
+/// Race and class unlocks read out of `/outputfile achievements`, cross-referenced with
+/// `/outputfile faction`.
+///
+/// The fixtures are David's own pair, written by the same game for the same character
+/// three minutes apart on 2026-08-25. That matters more than usual here: the two files
+/// disagree about how to spell four factions, and only a real pair could have shown that.
+/// </summary>
+public class UnlockRequirementsTests
+{
+    private static string[] Achievements() =>
+        File.ReadAllLines(Path.Combine(AppContext.BaseDirectory,
+            "..", "..", "..", "..", "fixtures", "achievements", "hateborne.txt"));
+
+    private static FactionsFile.Snapshot Factions()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory,
+            "..", "..", "..", "..", "fixtures", "factions", "hateborne.txt");
+        return new FactionsFile.Snapshot(path, DateTime.Now,
+            FactionsFile.Parse(File.ReadAllLines(path)));
+    }
+
+    // ---- the faction dump itself ------------------------------------------------
+
+    [Fact]
+    public void TheFactionDumpParsesAndMaxedIsPointsToMaxZero()
+    {
+        var f = Factions();
+        Assert.True(f.Standings.Count > 150, $"only {f.Standings.Count} standings parsed");
+
+        // The header row must not become a standing — it fails to parse rather than being
+        // special-cased by name.
+        Assert.DoesNotContain(f.Standings, s => s.Name == "Name");
+
+        var guk = f["Frogloks of Guk"];
+        Assert.NotNull(guk);
+        Assert.Equal(2000, guk!.Value);
+        Assert.True(guk.Maxed);
+        Assert.Equal(1.0, guk.Fraction);
+
+        var heretics = f["Heretics"];
+        Assert.NotNull(heretics);
+        Assert.Equal(-420, heretics!.Value);
+        Assert.False(heretics.Maxed);
+        // Negative standing draws as an empty bar, not a negative one.
+        Assert.Equal(0, heretics.Fraction);
+
+        var qeynos = f["Guards of Qeynos"];
+        Assert.NotNull(qeynos);
+        Assert.Equal(1535, qeynos!.Value);
+        Assert.Equal(465, qeynos.PointsToMax);
+        Assert.False(qeynos.Maxed);
+    }
+
+    /// <summary>The ceiling the progress bar divides by, asserted rather than assumed —
+    /// every row in a real dump agrees, and if one ever does not, this says so instead of
+    /// a bar quietly reading wrong.</summary>
+    [Fact]
+    public void EveryRowAgreesOnTheCap()
+    {
+        Assert.All(Factions().Standings,
+            s => Assert.Equal(FactionsFile.Cap, s.Value + s.PointsToMax));
+    }
+
+    /// <summary>The class code sits in the MIDDLE of the filename, so the rule is a
+    /// suffix and never a segment count — trap 48's distinction, on a different file.</summary>
+    [Fact]
+    public void TheClassCodeInTheFilenameDoesNotStopItBeingAFactionDump()
+    {
+        Assert.True(FactionsFile.IsFactionDump("Hateborne_neriak-ENC-Factions.txt"));
+        Assert.True(FactionsFile.IsFactionDump("Dranak_freeport-Factions.txt"));
+        Assert.False(FactionsFile.IsFactionDump("Hateborne_neriak-Inventory.txt"));
+        Assert.False(FactionsFile.IsFactionDump("eqlog_Hateborne_neriak.txt"));
+
+        // And the auto-import agrees, so the game's own announcement lands on a reader.
+        Assert.Equal(OutputfileKind.Factions,
+            OutputfileAutoImport.KindOf("Hateborne_neriak-ENC-Factions.txt"));
+    }
+
+    // ---- classifying the criteria -----------------------------------------------
+
+    /// <summary>
+    /// The two "will autocomplete" shapes mean opposite things and start the same way.
+    /// One is a way the unlock can be handed to you (and the tell that its children are
+    /// meaningless); the other is a real consequence of real work, and Half Elf has only
+    /// that one.
+    /// </summary>
+    [Fact]
+    public void BypassAndDerivedAreToldApart()
+    {
+        Assert.Equal(UnlockNeed.Bypass, UnlockRequirements.Classify(
+            "This achievement will autocomplete if your character was created as a Barbarian.", false).Need);
+        Assert.Equal(UnlockNeed.Bypass, UnlockRequirements.Classify(
+            "This achievement can be bypassed using a Race Unlock Token.", false).Need);
+        Assert.Equal(UnlockNeed.Bypass, UnlockRequirements.Classify(
+            "This achievement will autocomplete if you chose to confirm your Primary Class as a Bard.", false).Need);
+
+        Assert.Equal(UnlockNeed.Derived, UnlockRequirements.Classify(
+            "This achievement will autocomplete when you unlock Human or Wood Elf as a race.", false).Need);
+
+        var faction = UnlockRequirements.Classify("Get maximum faction with Dark Bargainers.", true);
+        Assert.Equal(UnlockNeed.MaxFaction, faction.Need);
+        Assert.Equal("Dark Bargainers", faction.Subject);
+
+        // No trailing period on Beastlord's and Berserker's rows, and no rule may depend
+        // on that difference.
+        var obtain = UnlockRequirements.Classify("Obtain Skycleaver", false);
+        Assert.Equal(UnlockNeed.Obtain, obtain.Need);
+        Assert.Equal("Skycleaver", obtain.Subject);
+        Assert.Equal("Sash of Ferocity",
+            UnlockRequirements.Classify("Obtain Sash of Ferocity.", false).Subject);
+
+        var task = UnlockRequirements.Classify(
+            "Complete the 'Aid the Kerrans of Kerra Isle' Task.", false);
+        Assert.Equal(UnlockNeed.Task, task.Need);
+    }
+
+    // ---- the races ---------------------------------------------------------------
+
+    [Fact]
+    public void EveryRaceUnlockIsReadWithItsOwnRequirements()
+    {
+        var races = UnlockRequirements.Races(AchievementsImport.Parse(Achievements()));
+        Assert.Equal(16, races.Count);   // fourteen races, and Human twice
+
+        var barb = Assert.Single(races, r => r.Subject == "Barbarian");
+        Assert.False(barb.Complete);
+        Assert.Equal(3, barb.Actionable.Count);
+        Assert.All(barb.Actionable, c => Assert.Equal(UnlockNeed.MaxFaction, c.Need));
+        Assert.Equal((0, 3), barb.Score);
+
+        // Human has two separate paths and they are two separate unlocks, so the race
+        // name is left exactly as the dump spells it.
+        Assert.Contains(races, r => r.Subject == "Human (Freeport)");
+        Assert.Contains(races, r => r.Subject == "Human (Qeynos)");
+
+        // Kerran is a task, not a faction grind — shown, never guessed at.
+        var kerran = Assert.Single(races, r => r.Subject == "Kerran");
+        Assert.Equal(UnlockNeed.Task, Assert.Single(kerran.Actionable).Need);
+
+        // Iksar wants exactly one faction; a surface that assumed three would be wrong
+        // about a sixteenth of its rows.
+        Assert.Single(Assert.Single(races, r => r.Subject == "Iksar").Actionable);
+    }
+
+    /// <summary>
+    /// Half Elf's only rows are Derived and Bypass — there is no work to count. "0 of 0"
+    /// reads as a stalled checklist, so the score is null and the surface says the
+    /// sentence instead.
+    /// </summary>
+    [Fact]
+    public void AnUnlockWithNoWorkOfItsOwnScoresNothingAndSaysWhy()
+    {
+        var races = UnlockRequirements.Races(AchievementsImport.Parse(Achievements()));
+        var halfElf = Assert.Single(races, r => r.Subject == "Half Elf");
+
+        Assert.Empty(halfElf.Actionable);
+        Assert.Null(halfElf.Score);
+        Assert.NotNull(halfElf.DerivedNote);
+        Assert.Contains("Human or Wood Elf", halfElf.DerivedNote!);
+    }
+
+    /// <summary>
+    /// **The measurement this whole feature turns on.** "Race Unlock - Dark Elf" is
+    /// COMPLETE in David's dump with all three faction criteria flagged complete — and
+    /// the faction dump, written three minutes later for the same character, says those
+    /// three factions stand at 0/2000, 5/1995 and 0/2000.
+    ///
+    /// He was created a Dark Elf. The game marked the children when the parent completed.
+    /// So a completed unlock's per-criterion flags prove nothing, and a surface that
+    /// believed them would tell a player they had maxed three factions they have barely
+    /// touched. This is #101 and #193 generalised from classes to races rather than a
+    /// second copy of the same guard.
+    /// </summary>
+    [Fact]
+    public void AGrantedUnlocksTicksAreNotEvidenceAndTheFactionDumpProvesIt()
+    {
+        var races = UnlockRequirements.Races(AchievementsImport.Parse(Achievements()));
+        var factions = Factions();
+
+        var darkElf = Assert.Single(races, r => r.Subject == "Dark Elf");
+        Assert.True(darkElf.Complete);
+        Assert.True(darkElf.Inherited);
+        // The dump really does flag all three...
+        Assert.All(darkElf.Actionable, c => Assert.True(c.Done));
+        // ...and the other dump really does say they are nowhere near maxed.
+        foreach (var c in darkElf.Actionable)
+        {
+            var standing = FactionNames.Resolve(factions, c.Subject);
+            Assert.NotNull(standing);
+            Assert.False(standing!.Maxed,
+                $"{c.Subject} reads maxed in the faction dump; the premise of this test is gone");
+        }
+
+        // An INCOMPLETE unlock keeps its per-criterion trust — the control that stops
+        // this from simply distrusting everything.
+        var wood = Assert.Single(races, r => r.Subject == "Wood Elf");
+        Assert.False(wood.Complete);
+        Assert.False(wood.Inherited);
+    }
+
+    // ---- the names -------------------------------------------------------------
+
+    /// <summary>
+    /// Four of the forty-two race requirement lines name a faction the other dump spells
+    /// differently. Every one of the forty-two must resolve, or a player sees "not found"
+    /// where the answer exists.
+    /// </summary>
+    [Fact]
+    public void EveryFactionARaceUnlockNamesIsFoundInTheFactionDump()
+    {
+        var races = UnlockRequirements.Races(AchievementsImport.Parse(Achievements()));
+        var factions = Factions();
+
+        var missing = races
+            .SelectMany(r => r.Actionable.Where(c => c.Need == UnlockNeed.MaxFaction))
+            .Select(c => c.Subject)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(n => FactionNames.Resolve(factions, n) is null)
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "unresolved faction names: " + string.Join(", ", missing));
+    }
+
+    /// <summary>The four measured pairs, named individually so a change to the resolver
+    /// cannot silently drop one — and one negative, because a resolver that answers
+    /// everything would satisfy every assertion above and be useless (trap 39).</summary>
+    [Fact]
+    public void TheFourMeasuredSpellingMismatchesResolve()
+    {
+        var f = Factions();
+
+        Assert.Equal("Coalition of Tradefolk",
+            FactionNames.Resolve(f, "Coalition of Tradesfolk")?.Name);
+        Assert.Equal("The Freeport Militia",
+            FactionNames.Resolve(f, "Freeport Militia")?.Name);
+        Assert.Equal("Corrupt Qeynos Guards",
+            FactionNames.Resolve(f, "Corrupt Qeynos Guard")?.Name);
+        Assert.Equal("DaBashers", FactionNames.Resolve(f, "Da Bashers")?.Name);
+
+        // Exact names still work, and a name that is not a faction gets null rather than
+        // the nearest thing.
+        Assert.Equal("Dark Bargainers", FactionNames.Resolve(f, "Dark Bargainers")?.Name);
+        Assert.Null(FactionNames.Resolve(f, "Coalition of Nobody"));
+        Assert.Null(FactionNames.Resolve(f, "Guards"));
+        Assert.Null(FactionNames.Resolve(f, ""));
+        Assert.Null(FactionNames.Resolve(null, "Dark Bargainers"));
+    }
+
+    // ---- the classes -------------------------------------------------------------
+
+    [Fact]
+    public void ClassUnlocksReadTheirObtainLinesAndUseTheCatalogSpelling()
+    {
+        var classes = UnlockRequirements.Classes(AchievementsImport.Parse(Achievements()));
+        Assert.Equal(16, classes.Count);
+
+        // "Shadowknight" in the dump, "Shadow Knight" everywhere else.
+        var shd = Assert.Single(classes, c => c.Subject == "Shadow Knight");
+        Assert.DoesNotContain(classes, c => c.Subject == "Shadowknight");
+        Assert.False(shd.Complete);
+        Assert.Equal(7, shd.Actionable.Count);
+        Assert.All(shd.Actionable, c => Assert.Equal(UnlockNeed.Obtain, c.Need));
+        Assert.Equal((2, 7), shd.Score);   // both confirmed present in his inventory dump
+
+        // Shaman was bought with a token: complete, every child flagged, nothing earned.
+        var shaman = Assert.Single(classes, c => c.Subject == "Shaman");
+        Assert.True(shaman.Complete);
+        Assert.True(shaman.Inherited);
+
+        // Enchanter is his primary and autocompleted — the other inheritance shape.
+        var enc = Assert.Single(classes, c => c.Subject == "Enchanter");
+        Assert.True(enc.Inherited);
+
+        // Untouched classes stay untouched: nothing done, nothing inherited.
+        var warrior = Assert.Single(classes, c => c.Subject == "Warrior");
+        Assert.False(warrior.Inherited);
+        Assert.Equal((0, 6), warrior.Score);
+    }
+}

--- a/tests/EQBuddy.Tests/UnlockRequirementsTests.cs
+++ b/tests/EQBuddy.Tests/UnlockRequirementsTests.cs
@@ -76,10 +76,9 @@ public class UnlockRequirementsTests
         Assert.True(FactionsFile.IsFactionDump("Dranak_freeport-Factions.txt"));
         Assert.False(FactionsFile.IsFactionDump("Hateborne_neriak-Inventory.txt"));
         Assert.False(FactionsFile.IsFactionDump("eqlog_Hateborne_neriak.txt"));
-
-        // And the auto-import agrees, so the game's own announcement lands on a reader.
-        Assert.Equal(OutputfileKind.Factions,
-            OutputfileAutoImport.KindOf("Hateborne_neriak-ENC-Factions.txt"));
+        // That the AUTO-IMPORT agrees is asserted in OutputfileAutoImportTests, beside its
+        // siblings — naming that type here would put this file in the serial settings.json
+        // collection for a call that writes nothing.
     }
 
     // ---- classifying the criteria -----------------------------------------------

--- a/tests/EQBuddy.Tests/UnlockRequirementsTests.cs
+++ b/tests/EQBuddy.Tests/UnlockRequirementsTests.cs
@@ -7,7 +7,7 @@ namespace EQBuddy.Tests;
 /// Race and class unlocks read out of `/outputfile achievements`, cross-referenced with
 /// `/outputfile faction`.
 ///
-/// The fixtures are David's own pair, written by the same game for the same character
+/// The fixtures are Hateborne's own pair, written by the same game for the same character
 /// three minutes apart on 2026-08-25. That matters more than usual here: the two files
 /// disagree about how to spell four factions, and only a real pair could have shown that.
 /// </summary>
@@ -166,11 +166,12 @@ public class UnlockRequirementsTests
 
     /// <summary>
     /// **The measurement this whole feature turns on.** "Race Unlock - Dark Elf" is
-    /// COMPLETE in David's dump with all three faction criteria flagged complete — and
+    /// COMPLETE in Hateborne's dump with all three faction criteria flagged complete — and
     /// the faction dump, written three minutes later for the same character, says those
     /// three factions stand at 0/2000, 5/1995 and 0/2000.
     ///
-    /// He was created a Dark Elf. The game marked the children when the parent completed.
+    /// The character was created a Dark Elf. The game marked the children when the parent
+    /// completed.
     /// So a completed unlock's per-criterion flags prove nothing, and a surface that
     /// believed them would tell a player they had maxed three factions they have barely
     /// touched. This is #101 and #193 generalised from classes to races rather than a
@@ -266,14 +267,14 @@ public class UnlockRequirementsTests
         Assert.False(shd.Complete);
         Assert.Equal(7, shd.Actionable.Count);
         Assert.All(shd.Actionable, c => Assert.Equal(UnlockNeed.Obtain, c.Need));
-        Assert.Equal((2, 7), shd.Score);   // both confirmed present in his inventory dump
+        Assert.Equal((2, 7), shd.Score);   // both confirmed present in the inventory dump
 
         // Shaman was bought with a token: complete, every child flagged, nothing earned.
         var shaman = Assert.Single(classes, c => c.Subject == "Shaman");
         Assert.True(shaman.Complete);
         Assert.True(shaman.Inherited);
 
-        // Enchanter is his primary and autocompleted — the other inheritance shape.
+        // Enchanter is the primary class and autocompleted — the other inheritance shape.
         var enc = Assert.Single(classes, c => c.Subject == "Enchanter");
         Assert.True(enc.Inherited);
 
@@ -281,5 +282,35 @@ public class UnlockRequirementsTests
         var warrior = Assert.Single(classes, c => c.Subject == "Warrior");
         Assert.False(warrior.Inherited);
         Assert.Equal((0, 6), warrior.Score);
+    }
+
+    // ---- the section lens ---------------------------------------------------------
+
+    /// <summary>
+    /// The tab is divided by SECTION, so that is what its filter narrows by — the class
+    /// picker it replaced would have hidden every race while claiming to filter the tab
+    /// (Hateborne, 2026-08-25).
+    ///
+    /// The list is asserted to hold exactly what the tab renders. A lens offering a section
+    /// nobody draws is a dead option, and Deity is the live example: its requirements are
+    /// undefined in the game, so it is neither rendered nor offered.
+    /// </summary>
+    [Fact]
+    public void TheSectionLensOffersOnlyTheSectionsTheTabDraws()
+    {
+        Assert.Equal(
+            [UnlockLayout.SectionAll, UnlockLayout.RacesHeading, UnlockLayout.ClassesHeading],
+            UnlockLayout.Sections);
+        Assert.DoesNotContain("Deity", UnlockLayout.Sections);
+
+        // "All" and an unset lens both mean no filtering — a null lens must not blank the tab.
+        Assert.True(UnlockLayout.InSection(UnlockLayout.RacesHeading, UnlockLayout.SectionAll));
+        Assert.True(UnlockLayout.InSection(UnlockLayout.ClassesHeading, UnlockLayout.SectionAll));
+        Assert.True(UnlockLayout.InSection(UnlockLayout.RacesHeading, ""));
+
+        // And narrowing really narrows, in both directions.
+        Assert.True(UnlockLayout.InSection(UnlockLayout.RacesHeading, UnlockLayout.RacesHeading));
+        Assert.False(UnlockLayout.InSection(UnlockLayout.ClassesHeading, UnlockLayout.RacesHeading));
+        Assert.False(UnlockLayout.InSection(UnlockLayout.RacesHeading, UnlockLayout.ClassesHeading));
     }
 }

--- a/tests/EQBuddy.Tests/WindowSizingTests.cs
+++ b/tests/EQBuddy.Tests/WindowSizingTests.cs
@@ -1,0 +1,105 @@
+using EQBuddy.UI.Shared;
+using Xunit;
+
+namespace EQBuddy.Tests;
+
+/// <summary>
+/// How tall a theme window's body opens, and how it behaves once the player has taken the
+/// height.
+///
+/// It is a SUM rather than a pixel, so it lives in UI.Shared and is tested here — the
+/// standing reason this repo lifts window arithmetic out of the WPF layer, which has no
+/// test project of its own.
+/// </summary>
+public class WindowSizingTests
+{
+    /// <summary>
+    /// The defect this replaces: every pop-out sized its body from the MONITOR, so a tall
+    /// screen produced a window that filled it. On a 1440-unit work area the old rule gave
+    /// the Quest Tracker a 944-unit body (1440 x 0.85 - 280); measured on a real display it
+    /// opened at 1822 physical px.
+    /// </summary>
+    [Fact]
+    public void ABigMonitorNoLongerMeansABigWindow()
+    {
+        var ceiling = 1440 * 0.85;                      // what the window allows itself
+        var body = WindowSizing.BodyCap(ceiling, chrome: 280, taken: null);
+
+        Assert.Equal(WindowSizing.DefaultBodyHeight, body);
+        Assert.True(body < ceiling - 280,
+            "the whole point is that the body no longer takes every unit the screen offers");
+    }
+
+    /// <summary>A small screen still wins. The constant is a CAP, not a floor — asking for
+    /// 400 units of body on a laptop would push the window off the bottom, which is the
+    /// failure the screen-derived rule existed to prevent in the first place.</summary>
+    [Fact]
+    public void ASmallScreenStillGetsTheLastWord()
+    {
+        var ceiling = 600 * 0.85;                       // 510
+        var body = WindowSizing.BodyCap(ceiling, chrome: 280, taken: null);
+
+        Assert.Equal(230, body);                        // 510 - 280, not the 400 constant
+        Assert.True(body < WindowSizing.DefaultBodyHeight);
+    }
+
+    /// <summary>
+    /// Once the player has dragged, the body follows THEM.
+    ///
+    /// Without this half, dragging a window taller would add empty space beneath a body
+    /// that refused to grow — a resize that visibly does nothing, which is the complaint
+    /// this whole area started with.
+    /// </summary>
+    [Fact]
+    public void AWindowThePlayerMadeTallerGetsATallerBody()
+    {
+        var ceiling = 1440 * 0.85;
+        var following = WindowSizing.BodyCap(ceiling, chrome: 280, taken: null);
+        var taken = WindowSizing.BodyCap(ceiling, chrome: 280, taken: 900);
+
+        Assert.Equal(WindowSizing.DefaultBodyHeight, following);
+        Assert.Equal(620, taken);                       // 900 - 280
+        Assert.True(taken > following);
+    }
+
+    /// <summary>Dragged SHORTER is just as much a choice as dragged taller, and the body
+    /// has to shrink with it or the window clips its own content.</summary>
+    [Fact]
+    public void AWindowThePlayerMadeShorterGetsAShorterBody()
+    {
+        var body = WindowSizing.BodyCap(1440 * 0.85, chrome: 280, taken: 420);
+        Assert.Equal(140, body);
+    }
+
+    /// <summary>
+    /// Never below a usable sliver, never past the room, and never trusting a number that
+    /// is not a size anyone chose.
+    ///
+    /// The last row is the one worth reading: 99,999 fails <see cref="WindowSizing.IsSaneHeight"/>,
+    /// so it is not treated as a height the player took at all — the window opens at its
+    /// design default instead of at a value that survived a monitor change. Clamping it to
+    /// the screen would have been the obvious thing and the wrong one: it would hand the
+    /// player a full-height window they never asked for, off a stored number nobody can
+    /// account for.
+    /// </summary>
+    [Theory]
+    [InlineData(1224, 280, 300d, 120)]      // taken smaller than the chrome: floor, not negative
+    [InlineData(1224, 280, 1100d, 820)]     // a big but SANE choice is honoured
+    [InlineData(1224, 280, 99999d, 400)]    // insane: distrusted, so the default stands
+    [InlineData(250, 280, null, 120)]       // chrome exceeds the ceiling: floor
+    public void TheBodyIsNeverASliverAndNeverTallerThanTheRoom(
+        double ceiling, double chrome, double? taken, double expected)
+    {
+        Assert.Equal(expected, WindowSizing.BodyCap(ceiling, chrome, taken));
+    }
+
+    /// <summary>The constant is what Hateborne asked for on 2026-08-25 — "25-50% larger
+    /// than the previous default" — measured against Bevel's already-signed 320. Pinned so
+    /// a later change is a decision rather than a drift.</summary>
+    [Fact]
+    public void TheDefaultIsTwentyFivePercentAboveBevelsThreeTwenty()
+    {
+        Assert.Equal(400, WindowSizing.DefaultBodyHeight);
+        Assert.Equal(320 * 1.25, WindowSizing.DefaultBodyHeight);
+    }
+}

--- a/tests/fixtures/achievements/hateborne.txt
+++ b/tests/fixtures/achievements/hateborne.txt
@@ -1,0 +1,1841 @@
+Untapped Potential: Races
+I	Race Unlock - Barbarian
+I		Get maximum faction with Rogues of the White Rose.
+I		Get maximum faction with Wolves of the North.
+I		Get maximum faction with Merchants of Halas.
+I		This achievement will autocomplete if your character was created as a Barbarian.
+I		This achievement can be bypassed using a Race Unlock Token.
+C	Race Unlock - Dark Elf
+C		Get maximum faction with Dark Bargainers.
+C		Get maximum faction with Dreadguard Outer.
+C		Get maximum faction with Dreadguard Inner.
+C		This achievement will autocomplete if your character was created as a Dark Elf.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Dwarf
+I		Get maximum faction with Kazon Stormhammer.
+I		Get maximum faction with Merchants of Kaladim.
+I		Get maximum faction with Storm Guard.
+I		This achievement will autocomplete if your character was created as a Dwarf.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Erudite
+I		Get maximum faction with Deepwater Knights.
+I		Get maximum faction with Heretics.
+I		Get maximum faction with High Council of Erudin.
+I		This achievement will autocomplete if your character was created as a Erudite.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Froglok
+I		Get maximum faction with Protectors of Gukta.
+I		Get maximum faction with Guktan Elders.
+I		Get maximum faction with Guktan Suppliers.
+I		This achievement will autocomplete if your character was created as a Froglok.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Gnome
+I		Get maximum faction with Eldritch Collective.
+I		Get maximum faction with Gem Choppers.
+I		Get maximum faction with King Ak`Anon.
+I		This achievement will autocomplete if your character was created as a Gnome.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Half Elf
+I		This achievement will autocomplete when you unlock Human or Wood Elf as a race.
+I		This achievement will autocomplete if your character was created as a Half Elf.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Halfling
+I		Get maximum faction with Guardians of the Vale.
+I		Get maximum faction with Merchants of Rivervale.
+I		Get maximum faction with Priests of Mischief.
+I		This achievement will autocomplete if your character was created as a Halfling.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - High Elf
+I		Get maximum faction with Clerics of Tunare.
+I		Get maximum faction with Keepers of the Art.
+I		Get maximum faction with Merchants of Felwithe.
+I		This achievement will autocomplete if your character was created as a High Elf.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Human (Freeport)
+I		Get maximum faction with Coalition of Tradesfolk.
+I		Get maximum faction with Knights of Truth.
+I		Get maximum faction with Freeport Militia.
+I		This achievement will autocomplete if your character was created as a Human.
+I		This achievement can by bypassed using a Race Unlock Token.
+I	Race Unlock - Human (Qeynos)
+I		Get maximum faction with Corrupt Qeynos Guard.
+I		Get maximum faction with Guards of Qeynos.
+I		Get maximum faction with Merchants of Qeynos.
+I		This achievement will autocomplete if your character was created as a Human.
+I		This achievement can by bypassed using a Race Unlock Token.
+I	Race Unlock - Iksar
+I		Get maximum faction with New Sebilisian Expedition.
+I		This achievement will autocomplete if your character was created as a Iksar.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Ogre
+I		Get maximum faction with Clurg.
+I		Get maximum faction with Oggok Guards.
+I		Get maximum faction with Merchants of Oggok.
+I		This achievement will autocomplete if your character was created as a Ogre.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Troll
+I		Get maximum faction with Da Bashers.
+I		Get maximum faction with Dark Ones.
+I		Get maximum faction with Grobb Merchants.
+I		This achievement will autocomplete if your character was created as a Troll.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Kerran
+I		Complete the 'Aid the Kerrans of Kerra Isle' Task.
+I		This achievement will autocomplete if your character was created as a Kerran.
+I		This achievement can be bypassed using a Race Unlock Token.
+I	Race Unlock - Wood Elf
+I		Get maximum faction with Kelethin Merchants.
+I		Get maximum faction with Soldiers of Tunare.
+I		Get maximum faction with Emerald Warriors.
+I		This achievement will autocomplete if your character was created as a Wood Elf.
+I		This achievement can be bypassed using a Race Unlock Token.
+Untapped Potential: Classes
+I	Primary Class Unlock - Bard
+I		Obtain Mask of Song.
+I		Obtain Mantle of the Songweaver.
+I		Obtain Ervaj's Flute of Flight.
+I		Obtain Amulet of the Fae.
+I		Obtain Denon's Horn of Disaster.
+I		Obtain Spear of Harmony.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Bard.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Beastlord
+I		Obtain Windhowl and Spirit Render
+I		Obtain Diaphonous Waistband
+I		Obtain Spiroc Beak Earcuff
+I		Obtain Griffin-Hide Armguards
+I		Obtain Azarack Skin Wristwraps
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Beastlord.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Berserker
+I		Obtain Skycleaver
+I		Obtain Cudgel of the Fool
+I		Obtain Sash of Ferocity
+I		Obtain Molten Coil
+I		Obtain Shroud of the Sky
+I		Obtain Blood-Drawn Runes
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Berserker.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Cleric
+I		Obtain Necklace of Resolution.
+C		Obtain Truewind Earring.
+I		Obtain Aegis of the Wind.
+I		Obtain Pauldrons of Piety.
+I		Obtain Theurgist's Star.
+I		Obtain Baton of the Sky.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Cleric.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Druid
+I		Obtain Nature Walker's Mantle.
+I		Obtain Drake-Hide Mask.
+I		Obtain Shillelagh.
+I		Obtain Espri.
+I		Obtain Honeycomb Belt.
+I		Obtain Spiroc Banisher Focus.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Druid.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+C	Primary Class Unlock - Enchanter
+C		Obtain Ivory Mask.
+C		Obtain Wind Walker's Mantle.
+C		Obtain Sphinx Hair Cord.
+C		Obtain Necklace of Whispering Winds.
+C		Obtain Earring of Displacement.
+C		Obtain Rod of the Protecting Winds.
+C		This achievement will autocomplete if you chose to confirm your Primary Class as a Enchanter.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Magician
+I		Obtain Bracelet of Clarification.
+I		Obtain Mask of Empowerment.
+I		Obtain Drake-Hide Amice.
+I		Obtain Staff of Elemental Mastery: Air.
+I		Obtain Staff of the Magister.
+I		Obtain Duennan Shielding Ring.
+I		Obtain Gold White Pendant.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Magician.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Monk
+I		Obtain Sandals of Alacrity.
+I		Obtain Ton Po's Eye Patch.
+I		Obtain Ton Po's Shoulder Wraps.
+I		Obtain Golden Sash of Tranquility.
+I		Obtain Back Straps of Mastery.
+I		Obtain Wu's Fist of Mastery.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Monk.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Necromancer
+C		Obtain Cloak of Spiroc Feathers.
+I		Obtain Bloodsoaked Raiment.
+I		Obtain Gorgon Head Staff.
+I		Obtain Sphinx Heart Amulet.
+I		Obtain Bloody Griffon-Hide Wrist Guard.
+I		Obtain Band of Wailing Winds.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Necromancer.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Paladin
+I		Obtain Girdle of Faith.
+I		Obtain Truvinan.
+I		Obtain Aldryn, Blade of the Ocean.
+I		Obtain Thelvorn, Blade of Light.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Paladin.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Ranger
+I		Obtain Earthshaker's Mantle.
+I		Obtain Windstriker.
+I		Obtain Griffon Talon Necklace.
+I		Obtain Thunderforged Earring.
+I		Obtain Dark Cloak of the Sky.
+I		Obtain Arydryidriyorn.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Ranger.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Rogue
+I		Obtain Griffon Wing Spaulders.
+I		Obtain Renard's Belt of Quickness.
+I		Obtain Wispy Choker of Vigor.
+I		Obtain Crystal Mask.
+I		Obtain Shimmering Bracer of Protection.
+I		Obtain Thornstinger.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Rogue.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Shadowknight
+I		Obtain Pegasus-Hide Belt.
+I		Obtain Blood Sky Face Plate.
+C		Obtain Obtenebrate Mithril Guard.
+I		Obtain Pearlescent Pauldrons.
+I		Obtain Amulet of the Sphinx Eye.
+C		Obtain Crimson Ring of the Djinni.
+I		Obtain Khyldorn the Blood Drinker.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Shadowknight.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+C	Primary Class Unlock - Shaman
+C		Obtain Garduk.
+C		Obtain Amulet of the Fang.
+C		Obtain Bracelet of the Spirits.
+C		Obtain Fairy-Hide Mantle.
+C		Obtain Warhammer of the Wind.
+C		Obtain Vermilion Sky Ring.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Shaman.
+C		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Warrior
+I		Obtain Belt of the Four Winds.
+I		Obtain Dagas.
+I		Obtain Fangol.
+I		Obtain Azure Ruby Ring.
+I		Obtain Runed Wind Amulet.
+I		Obtain Pauldrons of the Blue Sky.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Warrior.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+I	Primary Class Unlock - Wizard
+I		Obtain Al`Kabor's Cap of Binding.
+I		Obtain Augmentor's Mask.
+I		Obtain Raiment of Thunder.
+I		Obtain Nargon's Staff.
+I		Obtain Solidate Mithril Ring.
+I		Obtain Amulet of the Void.
+I		This achievement will autocomplete if you chose to confirm your Primary Class as a Wizard.
+I		This achievement can be bypassed using a Primary Class Unlock Token.
+Untapped Potential: Deity
+C	Deity Unlock - Agnostic
+C		Complete the 'Renouncing Your Faith' task for a mysterious Emissary.
+C		This achievement will autocomplete if your character was created as Agnostic.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Bertoxxulous
+I		Future Placeholder for Bertoxxulous Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Bertoxxulous.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Brell Serilis
+I		Future Placeholder for Brell Serilis Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Brell Serilis.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Cazic Thule
+I		Future Placeholder for Cazic Thule Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Cazic Thule.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Erollisi Marr
+I		Future Placeholder for Erollisi Marr Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Erollisi Marr.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Bristlebane
+I		Future Placeholder for Bristlebane Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Bristlebane.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Innoruuk
+I		Future Placeholder for Innoruuk Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Innoruuk.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Karana
+I		Future Placeholder for Karana Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Karana.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Mithaniel Marr
+I		Future Placeholder for Mithaniel Marr Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Mithaniel Marr.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Prexus
+I		Future Placeholder for Prexus Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Prexus.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Quellious
+I		Future Placeholder for Quellious Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Quellious.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Rallos Zek
+I		Future Placeholder for Rallos Zek Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Rallos Zek.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Rodcet Nife
+I		Future Placeholder for Rodcet Nife Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Rodcet Nife.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Solusek Ro
+I		Future Placeholder for Solusek Ro Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Solusek Ro.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Tribunal
+I		Future Placeholder for Tribunal Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Tribunal.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Tunare
+I		Future Placeholder for Tunare Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Tunare.
+I		This achievement can be bypassed using a Deity Unlock Token.
+I	Deity Unlock - Veeshan
+I		Future Placeholder for Veeshan Requirements.
+I		This achievement will autocomplete if you chose to confirm your Deity as Veeshan.
+I		This achievement can be bypassed using a Deity Unlock Token.
+General: Advancement
+C	5 Alternate Advancement Points
+C		Spend 5 Alternate Advancement Points
+C	10 Alternate Advancement Points
+C		Spend 10 Alternate Advancement Points
+General: Keys
+I	Bone Crafted Key
+I		Bone Crafted Key
+I	Hole Key
+I		Hole Key
+C	Islands of Sky Keys
+C		Key of Swords
+C		Key of the Misplaced
+C		Key of Misfortune
+C		Key of Beasts
+C		Avian Key
+C		Key of the Swarm
+C		Key of Scale
+C		Veeshan's Key
+C	Efreeti's Key
+C		Efreeti's Key
+General: Level
+C	Level 5
+C		Reach Level 5
+C	Level 10
+C		Reach Level 10
+C	Level 15
+C		Reach Level 15
+C	Level 20
+C		Reach Level 20
+C	Level 25
+C		Reach Level 25
+C	Level 30
+C		Reach Level 30
+C	Level 35
+C		Reach Level 35
+C	Level 40
+C		Reach Level 40
+C	Level 45
+C		Reach Level 45
+C	Level 50
+C		Reach Level 50
+General: Skills
+I	Cleric's Casting Proficiency, Level 50
+C		Reach the maximum skill in Abjuration at level 50.
+C		Reach the maximum skill in Alteration at level 50.
+C		Reach the maximum skill in Channelling at level 50.
+C		Reach the maximum skill in Conjuration at level 50.
+I		Reach the maximum skill in Divination at level 50.
+C		Reach the maximum skill in Evocation at level 50.
+C		Reach the maximum skill in Meditate at level 50.
+C	Cleric's Combat Proficiency, Level 50
+C		Reach the maximum skill in Defense at level 50.
+C		Reach the maximum skill in Dodge at level 50.
+C		Reach the maximum skill in Offense at level 50.
+I	Cleric's Utility Proficiency, Level 50
+I		Reach the maximum skill in Bind Wound at level 50.
+C		Reach the maximum skill in Sense Heading at level 50.
+I		Reach the maximum skill in Swimming at level 50.
+I		Reach the maximum skill in Alcohol Tolerance at level 50.
+I		Reach the maximum skill in Begging at level 50.
+I	Cleric's Weapon Proficiency, Level 50
+I		Reach the maximum skill in 1H Blunt at level 50.
+I		Reach the maximum skill in 2H Blunt at level 50.
+C		Reach the maximum skill in Bash at level 50.
+I		Reach the maximum skill in Hand To Hand at level 50.
+I		Reach the maximum skill in Throwing at level 50.
+I	Enchanter's Casting Proficiency, Level 50
+C		Reach the maximum skill in Abjuration at level 50.
+C		Reach the maximum skill in Alteration at level 50.
+C		Reach the maximum skill in Channelling at level 50.
+C		Reach the maximum skill in Conjuration at level 50.
+I		Reach the maximum skill in Divination at level 50.
+C		Reach the maximum skill in Evocation at level 50.
+C		Reach the maximum skill in Meditate at level 50.
+C	Enchanter's Combat Proficiency, Level 50
+C		Reach the maximum skill in Defense at level 50.
+C		Reach the maximum skill in Dodge at level 50.
+C		Reach the maximum skill in Offense at level 50.
+I	Enchanter's Utility Proficiency, Level 50
+I		Reach the maximum skill in Bind Wound at level 50.
+C		Reach the maximum skill in Sense Heading at level 50.
+I		Reach the maximum skill in Swimming at level 50.
+I		Reach the maximum skill in Alcohol Tolerance at level 50.
+I		Reach the maximum skill in Begging at level 50.
+I	Enchanter's Weapon Proficiency, Level 50
+I		Reach the maximum skill in 1H Blunt at level 50.
+I		Reach the maximum skill in 2H Blunt at level 50.
+I		Reach the maximum skill in Hand To Hand at level 50.
+I		Reach the maximum skill in 1H Piercing at level 50.
+I		Reach the maximum skill in Throwing at level 50.
+I	Shadow Knight's Casting Proficiency, Level 50
+C		Reach the maximum skill in Abjuration at level 50.
+C		Reach the maximum skill in Alteration at level 50.
+C		Reach the maximum skill in Channelling at level 50.
+C		Reach the maximum skill in Conjuration at level 50.
+I		Reach the maximum skill in Divination at level 50.
+C		Reach the maximum skill in Evocation at level 50.
+C		Reach the maximum skill in Meditate at level 50.
+C	Shadow Knight's Combat Proficiency, Level 50
+C		Reach the maximum skill in Defense at level 50.
+C		Reach the maximum skill in Dodge at level 50.
+C		Reach the maximum skill in Double Attack at level 50.
+C		Reach the maximum skill in Offense at level 50.
+C		Reach the maximum skill in Parry at level 50.
+C		Reach the maximum skill in Riposte at level 50.
+C		Reach the maximum skill in Triple Attack at level 50.
+I	Shadow Knight's Utility Proficiency, Level 50
+I		Reach the maximum skill in Bind Wound at level 50.
+I		Reach the maximum skill in Disarm at level 50.
+I		Reach the maximum skill in Hide at level 50.
+C		Reach the maximum skill in Sense Heading at level 50.
+I		Reach the maximum skill in Swimming at level 50.
+I		Reach the maximum skill in Alcohol Tolerance at level 50.
+I		Reach the maximum skill in Begging at level 50.
+I		Reach the maximum skill in Taunt at level 50.
+I	Shadow Knight's Weapon Proficiency, Level 50
+I		Reach the maximum skill in 1H Blunt at level 50.
+C		Reach the maximum skill in 1H Slashing at level 50.
+I		Reach the maximum skill in 2H Blunt at level 50.
+I		Reach the maximum skill in 2H Slashing at level 50.
+I		Reach the maximum skill in Archery at level 50.
+C		Reach the maximum skill in Bash at level 50.
+I		Reach the maximum skill in Hand To Hand at level 50.
+I		Reach the maximum skill in 1H Piercing at level 50.
+I		Reach the maximum skill in Throwing at level 50.
+I		Reach the maximum skill in 2H Piercing at level 50.
+C	Wizard's Combat Proficiency, Level 50
+C		Reach the maximum skill in Defense at level 50.
+C		Reach the maximum skill in Dodge at level 50.
+C		Reach the maximum skill in Offense at level 50.
+Tradeskill: Baking
+I	Baking (50)
+I		Reach 50 skill in Baking
+I	Baking (100)
+I		Reach 100 skill in Baking
+I	Baking (150)
+I		Reach 150 skill in Baking
+I	Baking (200)
+I		Reach 200 skill in Baking
+I	Baking (250)
+I		Reach 250 skill in Baking
+I	Baking (300)
+I		Reach 300 skill in Baking
+Tradeskill: Blacksmithing
+I	Smithing (50)
+I		Reach 50 skill in Smithing
+I	Smithing (100)
+I		Reach 100 skill in Smithing
+I	Smithing (150)
+I		Reach 150 skill in Smithing
+I	Smithing (200)
+I		Reach 200 skill in Smithing
+I	Smithing (250)
+I		Reach 250 skill in Smithing
+I	Smithing (300)
+I		Reach 300 skill in Smithing
+Tradeskill: Brewing
+I	Brewing (50)
+I		Reach 50 skill in Brewing
+I	Brewing (100)
+I		Reach 100 skill in Brewing
+I	Brewing (150)
+I		Reach 150 skill in Brewing
+I	Brewing (200)
+I		Reach 200 skill in Brewing
+I	Brewing (250)
+I		Reach 250 skill in Brewing
+I	Brewing (300)
+I		Reach 300 skill in Brewing
+Tradeskill: Fishing
+I	Fishing (50)
+I		Reach 50 skill in Fishing
+I	Fishing (100)
+I		Reach 100 skill in Fishing
+I	Fishing (150)
+I		Reach 150 skill in Fishing
+I	Fishing (200)
+I		Reach 200 skill in Fishing
+Tradeskill: Fletching
+I	Fletching (50)
+I		Reach 50 skill in Fletching
+I	Fletching (100)
+I		Reach 100 skill in Fletching
+I	Fletching (150)
+I		Reach 150 skill in Fletching
+I	Fletching (200)
+I		Reach 200 skill in Fletching
+I	Fletching (250)
+I		Reach 250 skill in Fletching
+I	Fletching (300)
+I		Reach 300 skill in Fletching
+Tradeskill: Jewelcrafting
+I	Jewelcrafting (50)
+I		Reach 50 skill in Jewelcrafting
+I	Jewelcrafting (100)
+I		Reach 100 skill in Jewelcrafting
+I	Jewelcrafting (150)
+I		Reach 150 skill in Jewelcrafting
+I	Jewelcrafting (200)
+I		Reach 200 skill in Jewelcrafting
+I	Jewelcrafting (250)
+I		Reach 250 skill in Jewelcrafting
+I	Jewelcrafting (300)
+I		Reach 300 skill in Jewelcrafting
+Tradeskill: Pottery
+I	Pottery (50)
+I		Reach 50 skill in Pottery
+I	Pottery (100)
+I		Reach 100 skill in Pottery
+I	Pottery (150)
+I		Reach 150 skill in Pottery
+I	Pottery (200)
+I		Reach 200 skill in Pottery
+I	Pottery (250)
+I		Reach 250 skill in Pottery
+I	Pottery (300)
+I		Reach 300 skill in Pottery
+Tradeskill: Tailoring
+I	Tailoring (50)
+I		Reach 50 skill in Tailoring
+I	Tailoring (100)
+I		Reach 100 skill in Tailoring
+I	Tailoring (150)
+I		Reach 150 skill in Tailoring
+I	Tailoring (200)
+I		Reach 200 skill in Tailoring
+I	Tailoring (250)
+I		Reach 250 skill in Tailoring
+I	Tailoring (300)
+I		Reach 300 skill in Tailoring
+Tradeskill: Special
+I	Alchemy (50)
+I		Reach 50 skill in Alchemy
+I	Alchemy (100)
+I		Reach 100 skill in Alchemy
+I	Alchemy (150)
+I		Reach 150 skill in Alchemy
+I	Alchemy (200)
+I		Reach 200 skill in Alchemy
+I	Alchemy (250)
+I		Reach 250 skill in Alchemy
+I	Alchemy (300)
+I		Reach 300 skill in Alchemy
+Slayer: General
+I	Megadeath
+I		Complete the achievement "A Force of Nature"
+I		Complete the achievement "Highly Decorated"
+I		Complete the achievement "Progressive"
+I	A Force of Nature
+I		Complete the achievement "Doesn't Play Well With Others"
+I		Complete the achievement "Don't Bug Me"
+I		Complete the achievement "I Hate Snakes!"
+I		Complete the achievement "Pesticide"
+I		Complete the achievement "We are the dead!"
+I		Complete the achievement "Strange Weather"
+I		Complete the achievement "The Zookeeper"
+I		Complete the achievement "Swordfishmermaid"
+I		Complete the achievement "Orc stomp!"
+I		Complete the achievement "Ugly creature near my feet..."
+I		Complete the achievement "BBBBBAAAARRRKKKK!!!!!"
+I		Complete the achievement "Puttin' On The Dog"
+I		Complete the achievement "It's Alive!"
+I		Complete the achievement "Plants Concrete and Stone"
+I		Complete the achievement "Here Be Dragons!"
+I		Complete the achievement "Might They Be Giants?"
+I		Complete the achievement "Legendary Creatures"
+I		Complete the achievement "Planes, Trains and Element-iles"
+I		Complete the achievement "A Sight for Sore Eyes"
+I		Complete the achievement "Domo Arigato"
+I		Complete the achievement "Foreign Affair"
+I		Complete the achievement "Invaders in a Strange Land"
+I		Complete the achievement "Your god has found you lacking."
+I		Complete the achievement "Table Flipper"
+I	Highly Decorated
+I		Complete the achievement "I'm a People Person!"
+I		Complete the achievement "What Keeps Mankind Alive?"
+I		Complete the achievement "Three letter word for dead..."
+I		Complete the achievement "Short People"
+I		Complete the achievement "Simple Folk of the Ykesha"
+I		Complete the achievement "Bounced!"
+I		Complete the achievement "Mostly Kunzar"
+I		Complete the achievement "Catnipped in the bud."
+I		Complete the achievement "Amphibicide"
+I		Complete the achievement "Rats!"
+I		Complete the achievement "Eight legs are better than one!"
+I		Complete the achievement "The Hounds"
+I		Complete the achievement "The Cat's Pajamas"
+I		Complete the achievement "Bird Flew"
+I		Complete the achievement "Monkey Business"
+I		Complete the achievement "I'm Boared!"
+I		Complete the achievement "Orc Kill!"
+I		Complete the achievement "Me thinks that you'll be good to eat!"
+I		Complete the achievement "Gnolling is Half the Battle"
+I		Complete the achievement "Kobolded Killer"
+I		Complete the achievement "Gooooooooooooooolem!"
+I		Complete the achievement "Drawing Life From a Stone"
+I		Complete the achievement "Living Stone I presume?"
+I		Complete the achievement "Herbicide"
+I		Complete the achievement "Dragonbane"
+I		Complete the achievement "You call that a dragon?"
+I		Complete the achievement "A Giant Problem"
+I		Complete the achievement "Shorter People"
+I		Complete the achievement "Slayer of Mystical Horses"
+I		Complete the achievement "It's Plane to See"
+I		Complete the achievement "Breakdown Dead Ahead"
+I		Complete the achievement "Natives of Velious"
+I		Complete the achievement "Navies of Luclin"
+I		Complete the achievement "Natives of Taelosia"
+I		Complete the achievement "Natives of Kuua"
+I		Complete the achievement "Natives of Alaris"
+I		Complete the achievement "Such Anguish"
+I	Progressive
+I		Complete the achievement "Oh the Humanity!"
+I		Complete the achievement "Barbarous"
+I		Complete the achievement "Hardly Erudite of You"
+I		Complete the achievement "Drackity Drak"
+I		Complete the achievement "Wood you could you?"
+I		Complete the achievement "Highly Uncivilized"
+C		Complete the achievement "Dark Elf Antonican, Please!"
+I		Complete the achievement "Now .49999%"
+I		Complete the achievement "It was called Tunaria"
+I		Complete the achievement "Axe me no questions."
+I		Complete the achievement "Dainy it's cold outside."
+I		Complete the achievement "Fuzzyfeet"
+I		Complete the achievement "A Clockwork Gnome"
+I		Complete the achievement "Here's Yer Grozmok"
+I		Complete the achievement "Get Stupid"
+I		Complete the achievement "Icky!"
+I		Complete the achievement "Why the Kylong faces?"
+I		Complete the achievement "Good Luck, Bad Guk"
+I		Complete the achievement "It's a frog eat frog world"
+I		Complete the achievement "Rrrribit!"
+I		Complete the achievement "Moonkitty"
+I		Complete the achievement "Not a Kerran the world!"
+I		Complete the achievement "Bat Country!"
+I		Complete the achievement "Rat Killer"
+I		Complete the achievement "Armadilloed and Dangerous"
+I		Complete the achievement "It Stinks!"
+I		Complete the achievement "Bunnyslayer"
+I		Complete the achievement "You dirty ratman!"
+I		Complete the achievement "Of Micelike Men"
+I		Complete the achievement "Badger, Badger, Badger..."
+I		Complete the achievement "Beetlemania"
+I		Complete the achievement "Leechy Keen"
+I		Complete the achievement "Corathus!"
+I		Complete the achievement "Army Ants"
+I		Complete the achievement "Shoo fly!"
+I		Complete the achievement "Get the broom!"
+I		Complete the achievement "A Web of Lies"
+I		Complete the achievement "Fury of Soriz"
+I		Complete the achievement "Snake in the Grass"
+C		Complete the achievement "A Bone to Pick With You"
+I		Complete the achievement "Stake Dinner"
+C		Complete the achievement "Hide your brains!"
+C		Complete the achievement "Mummy Dearest"
+C		Complete the achievement "Ghoul on the Hill"
+I		Complete the achievement "Round of Applause"
+I		Complete the achievement "Ghosts of Frostfell Past"
+I		Complete the achievement "50 Shades Repaid"
+I		Complete the achievement "Suit up!"
+I		Complete the achievement "New Tricks"
+I		Complete the achievement "Got your Tongue?"
+I		Complete the achievement "Featherbrained Plan"
+I		Complete the achievement "Better Get a Barrel"
+I		Complete the achievement "Bear with me"
+I		Complete the achievement "The Elephant in the Room"
+I		Complete the achievement "Overthere in the Wastes"
+I		Complete the achievement "These boots were made for..."
+I		Complete the achievement "Guess you didn't like turtles."
+I		Complete the achievement "What has science done!?"
+I		Complete the achievement "Have you seen my bucket?"
+I		Complete the achievement "Seacow!"
+I		Complete the achievement "A molkor?"
+I		Complete the achievement "Sealephant"
+I		Complete the achievement "A Horse of Course"
+C		Complete the achievement "Plenty of fish in the sea."
+I		Complete the achievement "Why so crabby?"
+I		Complete the achievement "Orc weapons, your blood will spill!"
+C		Complete the achievement "New Frontiers"
+C		Complete the achievement "The More You Gnoll!"
+C		Complete the achievement "World Warrens Three"
+I		Complete the achievement "Alliz Tae Ew"
+I		Complete the achievement "Sarnak Slayer"
+I		Complete the achievement "Don't be Shellfish!"
+I		Complete the achievement "Innoruuk's Gift"
+I		(Optional) Complete the achievement "Shadows of Lxanvom"
+I		(Optional) Complete the achievement "Achievement: Spider-Bear"
+I		Complete the achievement "A Fallen Empire"
+I		Complete the achievement "You can call me Alaran"
+I		Complete the achievement "Re-Extinction"
+C		Complete the achievement "Aquatic Allure"
+I		Complete the achievement "I said Argyle!"
+I		Complete the achievement "You're not scaring anyone."
+I		Complete the achievement "Lumberer"
+I		Complete the achievement "Mushroom Hunting"
+I		Complete the achievement "Stop dragon this out."
+I		Complete the achievement "Quit dragon your heels!"
+I		Complete the achievement "You keep dragon me into this."
+I		Complete the achievement "A Small Giant Problem"
+I		Complete the achievement "Fairicide"
+I		Complete the achievement "For the Hive!"
+I		Complete the achievement "Jumjummery"
+I		Complete the achievement "Self Centaured"
+I		Complete the achievement "You're Faunny"
+I		Complete the achievement "Amazing!"
+I		Complete the achievement "No Vacancy"
+I		Complete the achievement "Half Man, Half Scorpion, Half Lion."
+I		Complete the achievement "Puzzling"
+I		Complete the achievement "My Golden Boots"
+C		Complete the achievement "Imp-atient"
+I		(Optional) Complete the achievement "Reader's Die Jest"
+I		(Optional) Complete the achievement "Witch Mount?"
+I		(Optional) Complete the achievement "Dino-sore!"
+I		(Optional) Complete the achievement "In Your Eyes"
+C		Complete the achievement "Elementary"
+I		Complete the achievement "Spin Me Right Round"
+I		Complete the achievement "They Call Me The Riftseeker"
+I		Complete the achievement "Terrorible Tentacles"
+I		Complete the achievement "Denizens of Fear"
+I		Complete the achievement "Insatiable"
+I		Complete the achievement "You look lovely"
+I		Complete the achievement "Eye see what you did there!"
+I		Complete the achievement "Goo-dness Gracious!"
+I		Complete the achievement "Cubic"
+I		Complete the achievement "Gnome Tested, Steamwork Approved!"
+I		Complete the achievement "Discord Sounds Out of Tune"
+I		(Optional) Complete the achievement "Terror from the Stars"
+Slayer: Conquest
+I	Doesn't Play Well With Others
+I		The playable races.	1223/10000
+I	Don't Bug Me
+I		Beetles, Cliknars, Corathus Beasts, Drachnids, Insects, Leeches, Mosquitoes, Spiders, Ursarachnids.	162/5000
+I	I Hate Snakes!
+I		Alligators, Basilisks, Crocodiles, Lizard Men, Sarnaks, Shissar, Snakes, Sokokar, and Turtles.	42/5000
+I	Pesticide
+I		Armadillos, Bats, Bubonians, Burynai, Molerats, Rabbits, Ratmen, Rats, Skunks and Werebats.	145/5000
+I	We Are the Dead!
+I		Animated Armors, Ghosts, Ghouls, Mummies, Shades, Skeletons, Spectres, Vampires, and Zombies.	1570/10000
+I	Strange Weather
+I		Chokidais, Drolvargs, Hynids, Lions, Pumas, Rotdogs, Tigers, Werewolves, Wolves, Worgs, and Wrulons.	81/5000
+I	The Zookeeper
+I		Apes, Bears, Birds, Boars, Mammoths, Mystical Horses, Othmirs, Rhinos, Sea Mammals, and Swinetors.	97/5000
+I	Swordfishmermaid
+I		Crabs, Fishes, Hraquis, Kedge, Krakens, Mermaids, Nymphs, Piranhas, Seahorses, Sharks, and Sirens.	832/5000
+I	Orc Stomp!
+I		Orcs and Wereorcs.	4/5000
+I	Ugly Creature Near My Feet...
+I		Goblins and Nightmare Goblins.	127/5000
+I	BBBBBAAAARRRKKKK!!!!!
+I		Gnolls	594/5000
+I	Puttin' On The Dog
+I		Kobolds	139/5000
+I	It's Alive!
+I		Brellian Constructs, Gargoyles, Gingerbread Men, Golems, Marionettes, Muddites, and Scarecrows.	126/5000
+I	Plants Concrete and Stone
+I		Crystal Creatures, Grekens, Living Plants, Shriekers, Sporalis, Stonegrabbers, and Treants.	0/5000
+I	Here Be Dragons!
+I		Dinosaurs, Dracoliches, Dragons, Drakes, Drixies, Raptors, Witherans, Wurms, and Wyverns.	21/5000
+I	Might They Be Giants?
+I		Giants	66/5000
+I	Legendary Creatures
+I		Bixies, Brownies, Centaurs, Fairies, Griffins, Manticores, Minotaurs, Pixies, Satyr, and Sphinxes.	80/5000
+I	Planes, Trains and Element-iles
+I		Dervishes, Efreetis, Elementals, Imps, Nilborien, Riftseekers, Scrykin, Stormriders, and Wraiths.	536/10000
+I	A Sight for Sore Eyes
+I		Amygdalans, Cubes, Eyes, Goos, Gorgons, Harpies, Luggalds, Shiliskins, Tentacle Terrors, and Xulous.	96/5000
+I	Domo Arigato
+I		Clockwork: Beetles, Boars, Dragons, Rats, Snakes, Spiders, Gnomeworks, Copters, and Tin Soldiers.	0/5000
+I	Your God Has Found You Lacking
+I		The avatar of a deity.	3/100
+I	Table Flipper
+I		Barrels, Bones, Boxes, Chests, Clocks, Coffins, Mimics, Tables, Totems, Traps, Vases, and Webs.	10/5000
+Slayer: Special
+I	I'm a People Person!
+C		Humans
+I		Barbarians	1/10
+C		Erudites
+I		Wood Elves	0/10
+I		High Elves	5/10
+C		Dark Elves
+C		Half Elves
+C		Dwarves
+I		Halflings	2/10
+C		Gnomes
+I		Trolls	3/10
+C		Ogres
+I		Iksars	0/10
+I		Frogloks	5/10
+C		Kerran
+I	What Keeps Mankind Alive?
+I		Barbarians, Drakkin, Erudites, and Humans.	124/1000
+I	Three Letter Word for Dead...
+I		Dark Elves, Elddar Elves, Fire Elves, Half Elves, High Elves, Sand Elves, and Wood Elves.	860/1000
+I	Short People
+I		Coldain, Dwarves, Gnomes, and Halflings.	58/1000
+I	Simple Folk of the Ykesha
+I		Trolls	3/1000
+I	Bounced!
+I		Ogres	64/1000
+I	Mostly Kunzar
+I		Iksars and Kylong Iksars of Veksar.	1/1000
+I	Catnipped In the Bud
+I		Kerrans and Vah Shir.	113/1000
+I	Amphibicide
+I		Frogloks, Frogs, Guktans, and Tadpoles.	571/1000
+I	Rats!
+I		Armadillos, Bubonians, Burynai, Molerats, Rabbits, Ratmen, Rats, and Skunks.	99/1000
+I	Eight Legs Are Better Than One!
+I		Drachnids, Scorpions, Spiders, and Ursarachnids.	91/1000
+I	The Hounds
+I		Chokidais, Drolvargs, Hynids, Rotdogs, Werewolves, Wolves, and Worgs.	19/1000
+I	The Cat's Pajamas
+I		Cats, Lions, Pumas, Sabertooths, Scarlet Cheetahs, Tigers, Topiary Lions, and Wrulons.	62/1000
+I	Bird Flew
+I		Aviaks, Blood Ravens, Cockatrices, Hawks, and Parrots.	40/500
+I	Monkey Business
+I		Gorillas, Holgresh, and Yetis.	14/500
+I	Orc Kill!
+I		Orcs and Wereorcs.	4/1000
+I	Me Thinks That You'll Be Good to Eat!
+I		Goblins and Nightmare Goblins.	127/1000
+I	Gnolling is Half the Battle
+I		Gnolls	594/1000
+I	Kobolded Killer
+I		Kobolds	139/1000
+I	Gooooooooooooooolem!
+I		Gingerbread Men, Golems, Muddites, and Statues.	52/1000
+I	Dragonbane
+I		True Dragons	3/250
+I	You Call That a Dragon?
+I		Dinosaurs, Dracoliches, Lesser Dragons, Drakes, Drixies, Raptors, Witherans, Wurms, and Wyverns.	18/1000
+I	A Giant Problem
+I		Giants	66/1000
+I	Shorter People
+I		Bixies, Brownies, Dryads, Fairies, and Pixies.	32/1000
+I	Slayer of Mystical Horses
+I		Kirins, Nightmares, Pegasus, and Unicorns.	35/250
+I	It's Plane to See
+I		Fiends, Guardians, Planar Manifestations, Scrykin, Stormriders, Tormentors, Vegerogs, Wraiths.	0/1000
+I	Breakdown Dead Ahead
+I		Clockwork: Beetles, Boars, Dragons, Rats, Snakes, Spiders, Gnomeworks, Copters, and Tin Soldiers.	0/1000
+Slayer: Skill
+I	Oh the Humanity!
+I		Humans	55/100
+I	Barbarous
+I		Barbarians	1/100
+I	Hardly Erudite of You
+I		Erudites	68/100
+I	Wood You Could You?
+I		Wood Elves	0/100
+I	Highly Uncivilized
+I		High Elves	5/100
+C	Love Will Teir Them Apart
+C		Dark Elves
+I	Now .49999%
+I		Half Elves	40/100
+I	Axe Me No Questions
+I		Dwarves	12/100
+I	Fuzzyfeet
+I		Halflings	2/100
+I	A Clockwork Gnome
+I		Gnomes	44/100
+I	Here's Yer Grozmok
+I		Trolls	3/100
+I	Get Stupid
+I		Ogres	64/100
+I	Icky!
+I		Iksars	1/100
+I	It's a Frog Eat Frog World
+I		Frogloks and Tadpoles.	5/100
+I	Not a Kerran the World!
+I		Kerrans	0/50
+I	Bat Country!
+I		Bats and Werebats.	46/100
+I	Rat Killer
+I		Rats and Molerats.	97/100
+I	Armadilloed and Dangerous
+I		Armadillos	0/50
+I	It Stinks!
+I		Skunks	0/5
+I	You Dirty Ratman!
+I		Ratmen	2/100
+I	Beetlemania
+I		Beetles, Insects, Lightcrawlers, Shik'Nars, and Underbulks.	29/100
+I	Leechy Keen
+I		Leeches, Ticks, and Vacuum Worms.	0/100
+I	Shoo fly!
+I		Butterflies, Flies, Malarians, Mosquitoes, Tsetsians, and Wasps.	42/100
+I	Get the Broom!
+I		Scorpions and Spiders.	91/100
+I	Snake in the Grass
+I		Snakes	34/100
+C	A Bone to Pick With You
+C		Skeletons
+I	Stake Dinner
+I		Vampires	36/100
+C	Hide Your Brains!
+C		Hags, Ghouls, and Zombies.
+C	Mummy Dearest
+C		Mummies
+C	Ghoul On the Hill
+C		Ghouls
+I	Round of Applause
+I		Animated Hands	14/25
+I	Ghosts of Frostfell Past
+I		Banshees, Ghosts, Spectres, Spirits, and Wisps.	62/100
+I	New Tricks
+I		Chokidais, Drolvargs, Hynids, Rotdogs, Scaled Wolves, Sonic Wolves, Werewolves, Wolves, and Worgs.	19/100
+I	Got Your Tongue?
+I		Cats, Lions, Pumas, Sabertooths, Scarlet Cheetahs, Tigers, Topiary Lions, and Wrulons.	62/100
+I	Featherbrained Plan
+I		Aviaks, Blood Ravens, Cockatrices, Hawks, and Parrots.	40/100
+I	Better Get a Barrel
+I		Gorillas, Holgresh, and Yetis.	14/100
+I	Bear With Me
+I		Bears, Kodiaks, Owlbears, and Pandas.	8/100
+I	The Elephant in the Room
+I		Elephants and Mammoths.	0/100
+I	These Boots Were Made For...
+I		Alligators, Basilisks, and Crocodiles.	1/100
+C	Plenty of Fish In the Sea
+C		Fishes, Piranhas, Seahorses, Sharks, Swordfishes, and Wetfang Minnows.
+I	Orc Weapons, Your Blood Will Spill!
+I		Orcs and Wereorcs.	4/100
+C	New Frontiers
+C		Goblins and Nightmare Goblins.
+C	The More You Gnoll!
+C		Gnolls
+C	World Warrens Three
+C		Kobolds
+I	Alliz Tae Ew
+I		Lizard Men	7/100
+I	Re-Extinction
+I		Kedge	0/50
+C	Aquatic Allure
+C		Nagas, Mermaids, Nymphs, and Sirens.
+I	I Said Argyle!
+I		Gargoyles	68/100
+I	You're Not Scaring Anyone
+I		Scarecrows and Totems.	6/50
+I	Lumberer
+I		Treants	0/100
+I	Mushroom Hunting
+I		Sporalis	0/100
+I	Stop Dragon This Out
+I		Dracoliches, Water Dragons, and Witherans.	10/100
+I	You Keep Dragon Me Into This
+I		Drakes, Drixies, and Fay Drakes.	8/100
+I	A Small Giant Problem
+I		Giants	66/100
+I	Fairicide
+I		Dryads, Fairies, and Pixies.	18/100
+I	For the Hive!
+I		Bixies	14/100
+I	Jumjummery
+I		Brownies	0/100
+I	Self Centaured
+I		Centaurs	0/100
+I	Amazing!
+I		Minotaurs and Tizmak.	2/100
+I	No Vacancy
+I		Griffons, Griffennes, and Griffins.	44/100
+I	Puzzling
+I		Sphinxes	2/10
+I	My Golden Boots
+I		Djinns and Efreetis.	32/100
+C	Imp-atient
+C		Imps and Mephits.
+C	Elementary
+C		Elementals
+I	Spin Me Right Round
+I		Dervishes	7/100
+I	Terrorible Tentacles
+I		Tentacle Terrors	21/50
+I	Denizens of Fear
+I		Amygdalans	20/50
+I	Eye See What You Did There!
+I		Evil Eyes	23/100
+I	Cubic
+I		Gelatinous Cubes	6/50
+I	Gnome Tested, Steamwork Approved!
+I		Clockwork: Beetles, Boars, Dragons, Rats, Snakes, Spiders, Gnomeworks, Copters, and Tin Soldiers.	0/100
+EverQuest: General
+I	Norrathian Slayer
+I		Hunter of Faydwer
+I		Hunter of Odus
+I		Hunter of Northwest Antonica
+I		Hunter of Northeast Antonica
+I		Hunter of Southwest Antonica
+I		Hunter of Southeast Antonica
+I		Hunter of The Planes
+I	Conqueror of Norrath
+I		Conqueror of The Caverns of Exile
+I		Conqueror of Kedge Keep
+I		Conqueror of Nagafen's Lair
+I		Conqueror of The Permafrost Caverns
+I		Conqueror of The Plane of Fear
+I		Conqueror of The Plane of Hate
+I		Conqueror of The Plane of Sky
+I		Conqueror of The Ruins of Old Paineel or The Hole
+I	Norrathian Explorer
+I		Faydwer Explorer
+I		Odus Explorer
+I		Northwest Antonica Explorer
+I		Northeast Antonica Explorer
+I		Southwest Antonica Explorer
+I		Southeast Antonica Explorer
+C		The Planes Explorer
+I		Guild Locals Explorer
+I		Housing Explorer
+I		Special Events Explorer
+EverQuest: Progression
+I	Arcane Scientists
+I		Arcane Scientists
+I	Ashen Order
+I		Ashen Order
+I	Bloodsabers
+I		Bloodsabers
+I	Carson McCabe
+I		Carson McCabe
+I	Circle of Unseen Hands
+I		Circle of Unseen Hands
+I	Clerics of Tunare
+I		Clerics of Tunare
+I	Clerics of Underfoot
+I		Clerics of Underfoot
+I	Clurg
+I		Clurg
+I	Coalition of Tradefolk
+I		Coalition of Tradefolk
+I	Coalition of Tradefolk Underground
+I		Coalition of Tradefolk Underground
+I	Corrupt Qeynos Guards
+I		Corrupt Qeynos Guards
+I	Craftkeepers
+I		Craftkeepers
+I	Craknek Warriors
+I		Craknek Warriors
+I	Crimson Hands
+I		Crimson Hands
+I	DaBashers
+I		DaBashers
+I	Dark Bargainers
+I		Dark Bargainers
+I	Dark Ones
+I		Dark Ones
+I	Dark Reflection
+I		Dark Reflection
+I	Deepmuses
+I		Deepmuses
+I	Deeppockets
+I		Deeppockets
+I	Deepwater Knights
+I		Deepwater Knights
+I	Dismal Rage
+I		Dismal Rage
+I	Dreadguard Inner
+I		Dreadguard Inner
+I	Dreadguard Outer
+I		Dreadguard Outer
+I	Ebon Mask
+I		Ebon Mask
+I	Eldritch Collective
+I		Eldritch Collective
+I	Emerald Warriors
+I		Emerald Warriors
+I	Faydarks Champions
+I		Faydarks Champions
+I	Gate Callers
+I		Gate Callers
+I	Gem Choppers
+I		Gem Choppers
+I	Green Blood Knights
+I		Green Blood Knights
+I	Grobb Merchants
+I		Grobb Merchants
+I	Guardians of the Vale
+I		Guardians of the Vale
+I	Guards of Qeynos
+I		Guards of Qeynos
+I	Guktan Elders
+I		Guktan Elders
+I	Guktan Suppliers
+I		Guktan Suppliers
+I	Heretics
+I		Heretics
+I	High Council of Erudin
+I		High Council of Erudin
+I	High Council of Gukta
+I		High Council of Gukta
+I	High Guard of Erudin
+I		High Guard of Erudin
+I	Indigo Brotherhood
+I		Indigo Brotherhood
+I	Kazon Stormhammer
+I		Kazon Stormhammer
+I	Keepers of the Art
+I		Keepers of the Art
+I	Kelethin Merchants
+I		Kelethin Merchants
+C	Kerra Isle
+C		Kerra Isle
+I	King Ak`Anon
+I		King Ak`Anon
+I	King Tearis Thex
+I		King Tearis Thex
+I	Knights of Thunder
+I		Knights of Thunder
+I	Knights of Truth
+I		Knights of Truth
+I	Lorekeepers of Gukta
+I		Lorekeepers of Gukta
+I	Merchants of Ak`Anon
+I		Merchants of Ak`Anon
+I	Merchants of Erudin
+I		Merchants of Erudin
+I	Merchants of Felwithe
+I		Merchants of Felwithe
+I	Merchants of Halas
+I		Merchants of Halas
+I	Merchants of Kaladim
+I		Merchants of Kaladim
+I	Merchants of Oggok
+I		Merchants of Oggok
+I	Merchants of Qeynos
+I		Merchants of Qeynos
+I	Merchants of Rivervale
+I		Merchants of Rivervale
+I	Miners Guild 249
+I		Miners Guild 249
+I	Miners Guild 628
+I		Miners Guild 628
+I	New Sebilis Expedition
+I		New Sebilis Expedition
+I	Oggok Guards
+I		Oggok Guards
+I	Paladins of Underfoot
+I		Paladins of Underfoot
+I	Priests of Innoruuk
+I		Priests of Innoruuk
+I	Priests of Life
+I		Priests of Life
+I	Priests of Marr
+I		Priests of Marr
+I	Priests of Mischief
+I		Priests of Mischief
+I	Protectors of Gukta
+I		Protectors of Gukta
+I	Rogues of the White Rose
+I		Rogues of the White Rose
+I	Shadowknights of Night Keep
+I		Shadowknights of Night Keep
+I	Shamen of Justice
+I		Shamen of Justice
+I	Shamen of War
+I		Shamen of War
+I	Silent Fist Clan
+I		Silent Fist
+I	Soldiers of Tunare
+I		Soldiers of Tunare
+I	Song Weavers
+I		Song Weavers
+I	Steel Warriors
+I		Steel Warriors
+I	Storm Guard
+I		Storm Guard
+I	Storm Reapers
+I		Storm Reapers
+I	The Dead
+I		The Dead
+I	The Freeport Militia
+I		The Freeport Militia
+I	The Spurned
+I		The Spurned
+I	Tunare's Scouts
+I		Tunare's Scouts
+I	Wolves of the North
+I		Wolves of the North
+EverQuest: Exploration
+I	Faydwer Explorer
+I		Northern Felwithe Traveler
+I		Southern Felwithe Traveler
+C		The Greater Faydark Traveler
+I		Crushbone Traveler
+C		The Lesser Faydark Traveler
+C		The Castle of Mistmoore Traveler
+I		The Steamfont Mountains Traveler
+I		Ak'Anon Traveler
+C		Butcherblock Mountains Traveler
+I		South Kaladim Traveler
+I		North Kaladim Traveler
+C		Dagnor's Cauldron Traveler
+C		The Estate of Unrest Traveler
+C		Kedge Keep Traveler
+I		The Ocean of Tears Traveler
+I	Northeast Antonica Explorer
+C		East Freeport Traveler
+I		West Freeport Traveler
+I		Freeport Sewers Traveler
+C		The Commonlands Traveler
+C		Befallen Traveler
+I		Kithicor Forest Traveler
+I		Rivervale Traveler
+I		The Misty Thicket Traveler
+C		The Liberated Citadel of Runnyeye Traveler
+C		The Gorge of King Xorbb Traveler
+I		Highpass Hold Traveler
+I		High Keep Traveler
+C		The Nektulos Forest Traveler
+C		Neriak - Foreign Quarter Traveler
+C		Neriak - Commons Traveler
+C		Neriak - Third Gate Traveler
+C		The Lavastorm Mountains Traveler
+I		The Temple of Solusek Ro Traveler
+C		Najena Traveler
+C		Solusek's Eye Traveler
+C		Nagafen's Lair Traveler
+I		The Caverns of Exile Traveler
+I	Northwest Antonica Explorer
+I		South Qeynos Traveler
+I		North Qeynos Traveler
+I		The Qeynos Aqueduct System Traveler
+C		The Qeynos Hills Traveler
+C		The Surefall Glade Traveler
+C		Blackburrow Traveler
+I		Jaggedpine Forest Traveler
+I		Nedaria's Landing Traveler
+C		Everfrost Peaks Traveler
+I		Halas Traveler
+C		The Permafrost Caverns Traveler
+C		The Western Plains of Karana Traveler
+C		The Northern Plains of Karana Traveler
+C		Eastern Plains of Karana Traveler
+I	Odus Explorer
+I		Erud's Crossing Traveler
+I		Erudin Traveler
+I		The Erudin Palace Traveler
+C		Toxxulia Forest Traveler
+C		Paineel Traveler
+C		The Ruins of Old Paineel Traveler
+I		The Warrens Traveler
+I		The Stonebrunt Mountains Traveler
+I	Southeast Antonica Explorer
+C		The Northern Desert of Ro Traveler
+C		The Southern Desert of Ro Traveler
+C		The Innothule Swamp Traveler
+I		Grobb Traveler
+C		The City of Guk Traveler
+C		The Ruins of Old Guk Traveler
+I	Southwest Antonica Explorer
+C		The Southern Plains of Karana Traveler
+C		The Lair of the Splitpaw Traveler
+I		Lake Rathetear Traveler
+I		The Arena Traveler
+I		The Rathe Mountains Traveler
+C		The Feerrott Traveler
+I		Oggok Traveler
+C		Temple of Cazic-Thule Traveler
+C	The Planes Explorer
+C		The Plane of Fear Traveler
+C		The Plane of Hate Traveler
+C		The Plane of Sky Traveler
+I	Special Events Explorer
+I		Shadowrest Traveler
+I		Dragoncrypt Traveler
+I		Wedding Chapel (Light) Traveler
+I		Wedding Chapel (Dark) Traveler
+I	Housing Explorer
+I		House (One Room Stucco Interior) Traveler
+I		House (One Room Wood Interior) Traveler
+I		House (One Room Stone Interior) Traveler
+I		House (Three Room Stucco Interior) Traveler
+I		House (Three Room Wood Interior) Traveler
+I		House (Three Room Stone Interior) Traveler
+I		House (Hermit's Hideaway) Traveler
+I		House (Evantil's Abode) Traveler
+I		House (Bixie Hive) Traveler
+I	Guild Locals Explorer
+I		Guild Lobby Traveler
+I		Guild Hall Traveler
+I		Guild Hall (Modest) Traveler
+I		Guild Hall (Grand) Traveler
+I		Guild Hall (Palatial) Traveler
+I	Ak'Anon Traveler
+I		Visit Ak'Anon
+C	Befallen Traveler
+C		Visit Befallen
+C	Blackburrow Traveler
+C		Visit Blackburrow
+C	Butcherblock Mountains Traveler
+C		Visit Butcherblock Mountains
+I	Crushbone Traveler
+I		Visit Crushbone
+C	Dagnor's Cauldron Traveler
+C		Visit Dagnor's Cauldron
+I	Dragoncrypt Traveler
+I		Visit Dragoncrypt
+C	East Freeport Traveler
+C		Visit East Freeport
+C	Eastern Plains of Karana Traveler
+C		Visit Eastern Plains of Karana
+I	Erud's Crossing Traveler
+I		Visit Erud's Crossing
+I	Erudin Traveler
+I		Visit Erudin
+C	Everfrost Peaks Traveler
+C		Visit Everfrost Peaks
+I	Grobb Traveler
+I		Visit Grobb
+I	Guild Hall (Grand) Traveler
+I		Visit a Grand Guild Hall
+I	Guild Hall (Modest) Traveler
+I		Visit a Modest Guild Hall
+I	Guild Hall (Palatial) Traveler
+I		Visit a Palatial Guild Hall
+I	Guild Hall Traveler
+I		Visit your Guild Hall
+I	Guild Lobby Traveler
+I		Visit the Guild Lobby
+I	Halas Traveler
+I		Visit Halas
+I	High Keep Traveler
+I		Visit High Keep
+I	Highpass Hold Traveler
+I		Visit Highpass Hold
+I	House (Bixie Hive) Traveler
+I		Visit a Bixie Hive House
+I	House (Evantil's Abode) Traveler
+I		Visit an Evantil's Abode House
+I	House (Hermit's Hideaway) Traveler
+I		Visit a Hermit's Hideaway House
+I	House (One Room Stone Interior) Traveler
+I		Visit a One Room House with Stone Interior
+I	House (One Room Stucco Interior) Traveler
+I		Visit a One Room House with Stucco Interior
+I	House (One Room Wood Interior) Traveler
+I		Visit a One Room House with Wood Interior
+I	House (Three Room Stone Interior) Traveler
+I		Visit a Three Room House with Stone Interior
+I	House (Three Room Stucco Interior) Traveler
+I		Visit a Three Room House with Stucco Interior
+I	House (Three Room Wood Interior) Traveler
+I		Visit a Three Room House with Wood Interior
+C	Kedge Keep Traveler
+C		Visit Kedge Keep
+I	Kithicor Forest Traveler
+I		Visit Kithicor Forest
+I	Lake Rathetear Traveler
+I		Visit Lake Rathetear
+C	Nagafen's Lair Traveler
+C		Visit Nagafen's Lair
+C	Najena Traveler
+C		Visit Najena
+I	Nedaria's Landing Traveler
+I		Visit Nedaria's Landing
+C	Neriak - Commons Traveler
+C		Visit Neriak - Commons
+C	Neriak - Foreign Quarter Traveler
+C		Visit Neriak - Foreign Quarter
+C	Neriak - Third Gate Traveler
+C		Visit Neriak - Third Gate
+I	North Kaladim Traveler
+I		Visit North Kaladim
+I	North Qeynos Traveler
+I		Visit North Qeynos
+I	Northern Felwithe Traveler
+I		Visit Northern Felwithe
+I	Oggok Traveler
+I		Visit Oggok
+C	Paineel Traveler
+C		Visit Paineel
+I	Rivervale Traveler
+I		Visit Rivervale
+I	Shadowrest Traveler
+I		Visit Shadowrest
+C	Solusek's Eye Traveler
+C		Visit Solusek's Eye
+I	South Kaladim Traveler
+I		Visit South Kaladim
+I	South Qeynos Traveler
+I		Visit South Qeynos
+I	Southern Felwithe Traveler
+I		Visit Southern Felwithe
+C	Temple of Cazic-Thule Traveler
+C		Visit Temple of Cazic-Thule
+I	The Arena Traveler
+I		Visit The Arena
+C	The Castle of Mistmoore Traveler
+C		Visit The Castle of Mistmoore
+C	The City of Guk Traveler
+C		Visit The City of Guk
+C	The Commonlands Traveler
+C		Visit The Commonlands
+I	The Erudin Palace Traveler
+I		Visit The Erudin Palace
+C	The Estate of Unrest Traveler
+C		Visit The Estate of Unrest
+C	The Feerrott Traveler
+C		Visit The Feerrott
+C	The Gorge of King Xorbb Traveler
+C		Visit The Gorge of King Xorbb
+C	The Greater Faydark Traveler
+C		Visit The Greater Faydark
+C	The Innothule Swamp Traveler
+C		Visit The Innothule Swamp
+C	The Lair of the Splitpaw Traveler
+C		Visit The Lair of the Splitpaw
+C	The Lavastorm Mountains Traveler
+C		Visit The Lavastorm Mountains
+C	The Lesser Faydark Traveler
+C		Visit The Lesser Faydark
+C	The Liberated Citadel of Runnyeye Traveler
+C		Visit The Liberated Citadel of Runnyeye
+I	The Misty Thicket Traveler
+I		Visit The Misty Thicket
+C	The Nektulos Forest Traveler
+C		Visit The Nektulos Forest
+C	The Northern Desert of Ro Traveler
+C		Visit The Northern Desert of Ro
+C	The Northern Plains of Karana Traveler
+C		Visit The Northern Plains of Karana
+C	The Oasis of Marr Traveler
+C		Visit The Oasis of Marr
+I	The Ocean of Tears Traveler
+I		Visit The Ocean of Tears
+C	The Permafrost Caverns Traveler
+C		Visit The Permafrost Caverns
+C	The Plane of Fear Traveler
+C		Visit The Plane of Fear
+C	The Plane of Hate Traveler
+C		Visit The Plane of Hate
+C	The Plane of Sky Traveler
+C		Visit The Plane of Sky
+I	The Qeynos Aqueduct System Traveler
+I		Visit The Qeynos Aqueduct System
+C	The Qeynos Hills Traveler
+C		Visit The Qeynos Hills
+I	The Rathe Mountains Traveler
+I		Visit The Rathe Mountains
+C	The Ruins of Old Guk Traveler
+C		Visit The Ruins of Old Guk
+C	The Ruins of Old Paineel Traveler
+C		Visit The Ruins of Old Paineel
+C	The Southern Desert of Ro Traveler
+C		Visit The Southern Desert of Ro
+C	The Southern Plains of Karana Traveler
+C		Visit The Southern Plains of Karana
+I	The Steamfont Mountains Traveler
+I		Visit The Steamfont Mountains
+I	The Stonebrunt Mountains Traveler
+I		Visit The Stonebrunt Mountains
+C	The Surefall Glade Traveler
+C		Visit The Surefall Glade
+I	The Temple of Solusek Ro Traveler
+I		Visit The Temple of Solusek Ro
+I	The Warrens Traveler
+I		Visit The Warrens
+C	The Western Plains of Karana Traveler
+C		Visit The Western Plains of Karana
+C	Toxxulia Forest Traveler
+C		Visit Toxxulia Forest
+I	Wedding Chapel (Dark) Traveler
+I		Visit the Dark Wedding Chapel
+I	Wedding Chapel (Light) Traveler
+I		Visit the Light Wedding Chapel
+I	West Freeport Traveler
+I		Visit West Freeport
+EverQuest: Keys
+I	Bone Crafted Key
+I		Bone Crafted Key
+I	Hole Key
+I		Hole Key
+C	Islands of Sky Keys
+C		Key of Swords
+C		Key of the Misplaced
+C		Key of Misfortune
+C		Key of Beasts
+C		Avian Key
+C		Key of the Swarm
+C		Key of Scale
+C		Veeshan's Key
+C	Efreeti's Key
+C		Efreeti's Key
+EverQuest: Raids
+I	Conqueror of Kedge Keep
+I		Phinigel Autropos
+I	Conqueror of Nagafen's Lair
+I		Lord Nagafen
+I	Conqueror of The Permafrost Caverns
+I		Lady Vox
+I	Conqueror of The Plane of Fear
+I		Cazic-Thule
+I		Dread
+I		Fright
+I		Terror
+I		a dracoliche
+I	Conqueror of The Plane of Hate
+I		Innoruuk
+I		Maestro of Rancor
+I	Conqueror of The Plane of Sky
+I		Eye of Veeshan
+I		a thunder spirit princess
+I		Noble Dojorn
+I		Overseer of Air
+I		Protector of Sky
+I		Gorgalosk
+I		Keeper of Souls
+I		The Spiroc Lord
+I		Bazzt Zzzt
+I		Sister of the Spire
+I		Hand of Veeshan
+EverQuest: Hunter
+I	Hunter of Faydwer
+I		Hunter of Crushbone
+I		Hunter of The Lesser Faydark
+I		Hunter of The Castle of Mistmoore
+I		Hunter of The Steamfont Mountains
+I		Hunter of Butcherblock Mountains
+I		Hunter of Dagnor's Cauldron
+I		Hunter of The Estate of Unrest
+C		Hunter of Kedge Keep
+I		Hunter of The Ocean of Tears
+I	Hunter of Northeast Antonica
+I		Hunter of Freeport Sewers
+C		Hunter of Befallen
+I		Hunter of The Liberated Citadel of Runnyeye
+I		Hunter of The Caverns of Exile
+I		Hunter of The Misty Thicket
+I		Hunter of The Gorge of King Xorbb
+I		Hunter of Highpass Hold
+I		Hunter of The Lavastorm Mountains
+C		Hunter of Najena
+I		Hunter of Solusek's Eye
+I		Hunter of Nagafen's Lair
+I	Hunter of Northwest Antonica
+I		Hunter of Jaggedpine Forest
+I		Hunter of Nedaria's Landing
+I		Hunter of The Qeynos Aqueduct System
+I		Hunter of The Qeynos Hills
+I		Hunter of Everfrost Peaks
+I		Hunter of The Permafrost Caverns
+I		Hunter of The Western Plains of Karana
+I		Hunter of The Northern Plains of Karana
+I	Hunter of Odus
+I		Hunter of Toxxulia Forest
+I		Hunter of The Ruins of Old Paineel or The Hole
+I		Hunter of The Stonebrunt Mountains
+I		Hunter of The Warrens
+I	Hunter of Southeast Antonica
+I		Hunter of North Desert of Ro
+I		Hunter of South Desert of Ro
+I		Hunter of The City of Guk
+I		Hunter of The Ruins of Old Guk
+I	Hunter of Southwest Antonica
+I		Hunter of The Southern Plains of Karana
+C		Hunter of The Lair of the Splitpaw or The Invaded Lair of the Splitpaw
+I		Hunter of The Rathe Mountains
+I		Hunter of The Feerrott
+I		Hunter of Temple of Cazic-Thule or Accursed Temple of Cazic-Thule
+I	Hunter of The Planes
+I		Hunter of The Plane of Hate
+C	Hunter of Befallen
+C		Priest Amiaz
+C		the thaumaturgist
+I	Hunter of Butcherblock Mountains
+I		Glubbsink
+I	Hunter of The Castle of Mistmoore
+C		a glyphed ghoul
+I		Garton Viswin
+C		a cloaked dhampyre
+C		Lasna Cheroon
+C		an avenging caitiff
+I		Mynthi Davissi or a werewolf gypsy
+C		Maid Issis
+C		Butler Syncall
+I	Hunter of The City of Guk
+I		a froglok realist
+I		a froglok gaz squire
+I		a giant heart spider
+I		a froglok scryer
+I		the froglok warden
+I		the froglok shin lord
+I		an ancient croc
+I		a froglok summoner
+I	Hunter of Crushbone
+I		orc warlord
+I		orc taskmaster
+I	Hunter of Dagnor's Cauldron
+I		Flotsam
+I		Jetsam
+I		Squallslither
+I		Barnacle Bones
+I		Bilge Farfathom
+I	Hunter of The Estate of Unrest
+C		Garanel Rucksif
+C		a reanimated hand
+C		reclusive ghoul magus
+C		an undead knight of Unrest
+C		an undead barkeep
+I		lesser blade fiend
+I	Hunter of Everfrost Peaks
+I		Dark Assassin
+I	Hunter of The Feerrott
+I		a Silverflank guardian
+I		Tae Ew Templar
+I		Tae Ew Diviner
+I		Tae Ew Archon
+I		Thul Tae Ew Cenobite
+I		a Tae Ew Spiritualist
+I	Hunter of The Gorge of King Xorbb
+I		Spinflint
+I		Brahhm
+I		Yymp the infernal
+I		King Xorbb
+I	Hunter of Highpass Hold
+I		Vopuk Shralok
+I		Recfek Shralok
+I		Hagnis Shralok
+I		Vexven Mucktail
+I		Grenix Mucktail
+C	Hunter of Kedge Keep
+C		a frenzied cauldron shark
+C		a ferocious hammerhead
+C		a fierce impaler
+C		a seahorse matriarch
+C		a seahorse patriarch
+C		Shellara Ebbhunter
+C		Coralyn Kelpmaiden
+C		Cauldronboil
+C		Undertow
+C	Hunter of The Lair of the Splitpaw
+C		Tesch Val Deval`Nmak
+C		Tesch Val Kadvem
+C		Rosch Val L`Vlor
+C		Nisch Val Torash Mashk
+I	Hunter of Lake Rathetear
+I		a gnoll embalmer
+I	Hunter of The Lavastorm Mountains
+I		Scorchwing
+I		Scorchfist
+I		Swirlstone
+I		Flamebite
+I		Brognot
+I		Flameclaw
+I		Cinder Goblin Overseer
+I		Molgo
+I		Solusek Goblin Commander
+I		Solusek Goblin Lookout
+I		Shadowsoul
+I		Lavaspinner Protector
+I		Burnt Overlord
+I		Shadowhand
+I		Solusek Goblin Assassin
+I		Tisella
+I		a lesser nightmare
+I		a warbone monk
+I		a warbone spearman
+I	Hunter of The Lesser Faydark
+I		Crookstinger
+I		Queen Nasheeji
+I		Old Dimshimmer
+I		Whimsy Larktwitter
+I		Mina Glimmerwing
+I	Hunter of The Liberated Citadel of Runnyeye
+I		The Sporali Moldmaster
+I		a goblin janitor
+I	Hunter of The Misty Thicket
+I		a goblin alchemist
+I	Hunter of Nagafen's Lair
+I		a guano harvester
+C		a death beetle
+C		a kobold noble
+C		a kobold priest
+C		a kobold champion
+C		a kobold king
+C		a noxious spider
+C		a stone spider
+C		Efreeti Lord Djarn
+I		King Tranix
+I		Warlord Skarlon
+I		Magus Rokyl
+C	Hunter of Najena
+C		Drelzna
+C		Rathyl
+C		Najena
+C		Ekeros
+C		Trazdon
+C		Officer Grush
+C		The Widowmistress
+I	Hunter of Nedaria's Landing
+I		a magnificent grizzly
+I	Hunter of North Desert of Ro
+I		Dunedigger
+I		Rahotep
+I	Hunter of The Northern Plains of Karana
+I		Ashenpaw
+I		Callowwing
+I		Grimtooth
+I		Korvik the Cursed
+I		Lieutenant Midraim
+I		Swiftclaw
+I		Timbur the tiny
+I		Bristletoe
+I	Hunter of The Ocean of Tears
+I		Mojo the Tainted
+I		an ancient cyclops
+I	Hunter of The Permafrost Caverns
+I		an elite honor guard
+I		High Priest Zaharn
+I		King Thex`Ka IV
+I		an injured polar bear
+I		a goblin scryer
+I		a goblin jailmaster
+I		a goblin preacher
+I		a goblin alchemist
+I		a goblin archaeologist
+I	Hunter of The Qeynos Aqueduct System
+I		an injured rat
+I		an undead knight
+I		a shady mercenary
+I		a nesting rat
+I	Hunter of The Qeynos Hills
+I		Pyzjn
+I		Varsoon
+I	Hunter of The Rathe Mountains
+I		Petrifin
+I		Oculys Ogrefiend
+I		Shardwing
+I		Yun Jerahk the Poisoned
+I		Bloodneedle
+I		Quid Rilstone
+I		Mortificator Syythrak
+I	Hunter of The Ruins of Old Guk
+C		a reanimated hand
+C		a ghoul ritualist
+C		a ghoul supplier
+C		a ghoul savant
+C		a ghoul assassin
+C		a ghoul cavalier
+C		a ghoul sage
+C		a ghoul executioner
+C		a frenzied ghoul
+C		a ghoul sentinel
+C		the ghoul arch magus
+C		the ghoul lord
+I		a minotaur patriarch
+I		a minotaur elder
+I		a froglok crusader
+I		a froglok noble
+I		a froglok yun priest
+I		the froglok king
+I		a froglok tactician
+I		a froglok herbalist
+I	Hunter of The Ruins of Old Paineel
+C		Stonegrinder Minion
+C		Gibartik
+C		Stonesoul the Unmoving
+C		muck covered elemental
+C		Rocksoul
+C		bejeweled elemental
+I		Irslak the Wretched
+I		Niltoth the Unholy
+I		Initiate Sirlis
+I		Commander Yarik
+I		Ulrik the Devout
+I		Slizik the Mighty
+I		Retseth Tretse
+I	Hunter of Solusek's Eye
+I		flame goblin foreman
+I		Singe
+I		Kindle
+I		inferno goblin captain
+I		reckless efreeti
+I		fire goblin bartender
+I		goblin high shaman
+I		inferno goblin torturer
+I		Solusek goblin king
+I		kobold predator
+I		Gabbie Mardoddle
+I		Captain Bipnubble
+I		CWG Model EXG
+I		lava elemental
+I	Hunter of South Desert of Ro
+I		an ancient cyclops
+I		Lockjaw
+I		Hatar
+I		Erg Bluntbruiser
+I	Hunter of The Southern Plains of Karana
+I		Marik Clubthorn
+I		Knari Morawk
+I		Kroldir Thunderhoof
+I		Mroon
+I		Narra Tanith
+I		Grizzleknot
+I		Quillmane
+I		Lord Grimrot
+C		Tesch Val Deval`Nmak
+C		Tesch Val Kadvem
+C		Rosch Val L`Vlor
+C		Nisch Val Torash Mashk
+I		Synger Foxfyre
+I	Hunter of The Steamfont Mountains
+I		Minotaur Lord
+I		Minotaur Hero
+I	Hunter of The Stonebrunt Mountains
+I		Rognarog the Infuriated
+I		Slyder the Ancient
+I		Giang Yin
+I		Snowbeast
+I		Jelquar the Soulslayer
+I		Girgak the Bloody
+I		Rendolr the Maimer
+I		Arglar the Tormentor
+I		Hurglak the Destroyer
+I	Hunter of Temple of Cazic-Thule
+I		a clay golem
+I		a stone golem
+I		a steel golem
+I		Tae Ew Templar
+I		Tae Ew Diviner
+I		Tae Ew Archon
+I		Cazic Cenobite
+I		Avatar of Fear
+I		a lizard ritualist
+I	Hunter of Toxxulia Forest
+I		Alrik Pasdar
+I		Lord Gongo
+I		Jo Jo
+I		The Kerran Sha`rr
+I		Khonza Mitty of Kerra
+I		Hamed Grarr
+I	Hunter of The Warrens
+I		Warlord Drrig
+I		Packmaster Dledsh
+I	Hunter of The Western Plains of Karana
+I		a werewolf bandit

--- a/tests/fixtures/factions/hateborne.txt
+++ b/tests/fixtures/factions/hateborne.txt
@@ -1,0 +1,186 @@
+ID	Name	StandingValue	PointsToMax
+65	Brownies of Faydwer	0	2000
+106	Pixies of Faydwer	0	2000
+121	Qeynos Citizens	0	2000
+128	Erudin Citizens	0	2000
+138	Clockworks of Ak`Anon	0	2000
+144	Kaladim Citizens	0	2000
+217	Allize Volew	45	1955
+1717	Lorekeepers of Gukta	0	2000
+218	Allize Taeew	-192	2192
+1718	Guktan Elders	0	2000
+219	Antonius Bayle	0	2000
+1719	Citizens of Gukta	0	2000
+220	Arcane Scientists	0	2000
+1720	Guktan Suppliers	0	2000
+221	Bloodsabers	0	2000
+222	Broken Skull Clan	0	2000
+722	New Sebilisian Expedition	0	2000
+1722	Exiled Frogloks	0	2000
+223	Circle of Unseen Hands	0	2000
+225	Clan Runnyeye	-5	2005
+226	Clerics of Tunare	6	1994
+227	Clerics of Underfoot	0	2000
+228	Clurg	0	2000
+229	Coalition of Tradefolk	0	2000
+230	Corrupt Qeynos Guards	0	2000
+231	Craftkeepers	800	1200
+232	Craknek Warriors	0	2000
+1732	Tribe Vrodak	541	1459
+233	Crimson Hands	800	1200
+234	Crushbone Orcs	0	2000
+235	DaBashers	0	2000
+236	Dark Bargainers	0	2000
+237	Dark Ones	0	2000
+238	Dark Reflection	0	2000
+239	The Dead	220	1780
+240	Deepmuses	0	2000
+241	Deeppockets	0	2000
+242	Deepwater Knights	800	1200
+243	Drafling	0	2000
+244	Ebon Mask	0	2000
+245	Eldritch Collective	0	2000
+246	Faydarks Champions	-140	2140
+249	Nagafen	-1861	3861
+251	Frogloks of Guk	2000	0
+254	Gate Callers	800	1200
+255	Gem Choppers	5	1995
+258	Goblins of Fire Peak	-490	2490
+261	Green Blood Knights	0	2000
+262	Guards of Qeynos	1535	465
+263	Guardians of the Vale	20	1980
+264	Whistling Fist Brotherhood	0	2000
+265	Heretics	-420	2420
+266	High Council of Erudin	0	2000
+267	High Guard of Erudin	0	2000
+269	Kithicor Residents	0	2000
+270	Indigo Brotherhood	0	2000
+271	Dismal Rage	0	2000
+272	Jaggedpine Treefolk	1510	490
+273	Kane Bayle	0	2000
+274	Kazon Stormhammer	0	2000
+275	Keepers of the Art	-950	2950
+276	Kelethin Merchants	0	2000
+277	Kerra of Barren Coast	0	2000
+278	King Naythox Thex	-3	2003
+279	King Tearis Thex	1525	475
+280	Knights of Thunder	0	2000
+281	Knights of Truth	25	1975
+282	Kobolds of Fire Pit	-457	2457
+284	League of Antonican Bards	1760	240
+285	Mayong Mistmoore	-1947	3947
+286	Mayor Gubbin	-3	2003
+287	Meldrath	0	2000
+288	Merchants of Ak`Anon	0	2000
+289	Merchants of Erudin	0	2000
+290	Merchants of Kaladim	0	2000
+291	Merchants of Qeynos	1510	490
+292	Merchants of Rivervale	-4	2004
+293	Miners Guild 249	0	2000
+296	Opal Darkbriar	0	2000
+297	Paladins of Underfoot	0	2000
+298	Peace Keepers	0	2000
+299	Phinigel Autropos	-2000	4000
+300	Priests of Mischief	0	2000
+302	Protectors of Pine	0	2000
+303	Queen Cristanos Thex	0	2000
+304	Ring of Scale	1700	300
+305	Rogues of the White Rose	-3	2003
+306	Sabertooths of Blackburrow	-2000	4000
+308	Shadowknights of Night Keep	0	2000
+309	Silent Fist Clan	1510	490
+310	Soldiers of Tunare	0	2000
+311	Steel Warriors	-1	2001
+312	Storm Guard	10	1990
+316	Tunare's Scouts	0	2000
+317	Undead Frogloks of Guk	-2000	4000
+319	Vox	-817	2817
+320	Wolves of the North	-15	2015
+321	Split Paw Clan	-100	2100
+322	Miners Guild 628	0	2000
+323	Solusek Mining Co.	1170	830
+324	Unkempt Druids	5	1995
+325	Merchants of Felwithe	0	2000
+326	Emerald Warriors	5	1995
+327	Shamen of Justice	-3	2003
+328	Merchants of Halas	-3	2003
+329	Carson McCabe	0	2000
+330	The Freeport Militia	0	2000
+331	Merchants of Highpass	0	2000
+332	Highpass Guards	0	2000
+333	King Ak`Anon	0	2000
+334	Dreadguard Outer	5	1995
+336	Coalition of Tradefolk Underground	0	2000
+337	Oggok Guards	0	2000
+338	Merchants of Oggok	0	2000
+340	Priests of Innoruuk	-25	2025
+341	Priests of Life	5	1995
+342	Order of Three	0	2000
+343	Surefall Protected Animals	0	2000
+345	Karana Residents	25	1975
+346	Commons Residents	25	1975
+353	Neriak Ogre	0	2000
+354	Neriak Troll	0	2000
+355	Storm Reapers	-16	2016
+361	Ashen Order	25	1975
+362	Priests of Marr	8	1992
+363	The Spurned	100	1900
+364	Shralok Orcs	0	2000
+365	Pickclaw Goblins	0	2000
+366	Karana Bandits	0	2000
+367	Donovon	0	2000
+368	Dervish Cutthroats	-4	2004
+370	Dreadguard Inner	0	2000
+371	Neriak Ghoul	0	2000
+372	Najena	-958	2958
+373	Mucktail Gnolls	0	2000
+374	Oggok Resident	0	2000
+375	Death Fist Orcs	-7	2007
+376	Grobb Merchants	0	2000
+377	Grobb Guard	0	2000
+378	Stone Hive Bixies	0	2000
+379	Butcherblock Bandits	0	2000
+382	Kerra Isle	2000	0
+385	Defective Clockwork	0	2000
+387	Befallen Inhabitants	-1284	3284
+388	Faerie	0	2000
+394	Shamen of War	0	2000
+397	Sky Talons	0	2000
+398	Riptide Goblins	-1	2001
+401	Song Weavers	0	2000
+402	Oracle of K`Arnon	0	2000
+412	Krag	0	2000
+415	Temple of Solusek Ro	0	2000
+416	Shadowed Men	4	1996
+417	Ankhefenmut	0	2000
+418	Zazamoukh	0	2000
+420	Fallen of Bloody Kithicor	0	2000
+421	Aggressors of Kithicor	0	2000
+422	Defenders of Kithicor	0	2000
+423	Verish Mal	-300	2300
+425	Inhabitants of Hate	-2000	4000
+426	Agents of Mistmoore	-1947	3947
+428	Minions of Underfoot	-720	2720
+471	Clan Kolbok	0	2000
+473	Kejek Village	0	2000
+474	Sporali	0	2000
+475	King Xorbb	5	1995
+1005	Qeynos Elite Watch	0	2000
+1522	Primordial Malice	100	1900
+1597	Residents of Jaggedpine	0	2000
+1598	Anchorites of Brell Serilis	0	2000
+1599	Darkpaws of Jaggedpine	0	2000
+1600	Guardians of the Hatchling	0	2000
+1601	Pirates of the Pine	0	2000
+1603	Dryads of the Grove	0	2000
+1620	Treants of Jaggedpine	0	2000
+1622	Arboreans of the Faydark	0	2000
+1630	Burning Dead	-573	2573
+1704	Cursed Frogloks of Gukta	0	2000
+1709	Protectors of Gukta	0	2000
+1711	Clerics of Gutka	0	2000
+1712	Warriors of Gukta	0	2000
+1713	Paladins of Gukta	0	2000
+1714	Wizards of Gukta	0	2000
+1715	Shaman of Gukta	0	2000
+1716	High Council of Gukta	0	2000

--- a/tests/fixtures/inventory/hateborne.txt
+++ b/tests/fixtures/inventory/hateborne.txt
@@ -1,0 +1,690 @@
+Location	Name	ID	Count	Slots
+Any Slot	Insidious Robe +2	1247	1	10
+Any Slot-Slot2	Empty	0	0	0
+Any Slot-Slot7	Shining Metallic Robes (Exaltation)	1360	1	10
+Any Slot-Slot8	Empty	0	0	0
+Ear	Onyx Earring +5	10354	1	10
+Ear-Slot7	Empty	0	0	0
+Ear-Slot8	Empty	0	0	0
+Ear-Slot9	Empty	0	0	0
+Ear-Slot10	Empty	0	0	0
+Head	Ethereal Mist Helm +1	4881	1	10
+Head-Slot2	Empty	0	0	0
+Head-Slot7	Empty	0	0	0
+Face	Polished Mithril Mask +3	4505	1	10
+Face-Slot7	Polished Mithril Mask (Exaltation)	4505	1	10
+Face-Slot8	Empty	0	0	0
+Face-Slot9	Empty	0	0	0
+Ear	Drop of Crystallized Flame +5	177839	1	10
+Ear-Slot7	Empty	0	0	0
+Ear-Slot8	Empty	0	0	0
+Ear-Slot9	Empty	0	0	0
+Ear-Slot10	Empty	0	0	0
+Neck	Bloodstar Pendant +1	1536	1	10
+Neck-Slot7	Empty	0	0	0
+Shoulders	Pauldrons of Power	1542	1	10
+Arms	Pristine Studded Leather Sleeves +6	1884	1	10
+Arms-Slot2	Empty	0	0	0
+Arms-Slot7	Empty	0	0	0
+Arms-Slot8	Empty	0	0	0
+Arms-Slot9	Empty	0	0	0
+Arms-Slot10	Empty	0	0	0
+Back	Loam Encrusted Cloak +3	1646	1	10
+Back-Slot7	Empty	0	0	0
+Back-Slot8	Empty	0	0	0
+Back-Slot9	Empty	0	0	0
+Wrist	Pristine Studded Leather Bracer +4	1881	1	10
+Wrist-Slot2	Empty	0	0	0
+Wrist-Slot7	Empty	0	0	0
+Wrist-Slot8	Empty	0	0	0
+Wrist-Slot9	Empty	0	0	0
+Wrist-Slot10	Empty	0	0	0
+Wrist	Verishe Bracer of Dominance +1	177919	1	10
+Wrist-Slot1	Empty	0	0	0
+Wrist-Slot7	Empty	0	0	0
+Range	The Artist's Brush +4	177843	1	10
+Range-Slot1	Empty	0	0	0
+Range-Slot7	The Artist's Brush (Exaltation)	177843	1	10
+Range-Slot8	Empty	0	0	0
+Range-Slot9	Empty	0	0	0
+Range-Slot10	Empty	0	0	0
+Hands	Gauntlets of Fiery Might +3	11624	1	10
+Hands-Slot2	Empty	0	0	0
+Hands-Slot7	Empty	0	0	0
+Hands-Slot8	Empty	0	0	0
+Hands-Slot9	Empty	0	0	0
+Primary	Blade of Abrogation +3	5430	1	10
+Primary-Slot2	Empty	0	0	0
+Primary-Slot7	Empty	0	0	0
+Primary-Slot8	Golem Metal Wand (Exaltation)	14313	1	10
+Primary-Slot9	Empty	0	0	0
+Secondary	Nisch Mas Ilkvel +5	177914	1	10
+Secondary-Slot1	Empty	0	0	0
+Secondary-Slot7	Nisch Mas Ilkvel (Exaltation)	177914	1	10
+Secondary-Slot8	Empty	0	0	0
+Secondary-Slot9	Empty	0	0	0
+Secondary-Slot10	Empty	0	0	0
+Fingers	Crimson Ring of the Djinni +1	27706	1	10
+Fingers-Slot7	Empty	0	0	0
+Fingers	Hamed's Ring of Tears +5	16840	1	10
+Fingers-Slot7	Clawed Knuckle-Ring (Exaltation)	10403	1	10
+Fingers-Slot8	Empty	0	0	0
+Fingers-Slot9	Empty	0	0	0
+Fingers-Slot10	Empty	0	0	0
+Chest	Umbral Platemail Breastplate +1	4842	1	10
+Chest-Slot2	Empty	0	0	0
+Chest-Slot7	Empty	0	0	0
+Legs	Pristine Studded Leather Leggings +7	1882	1	10
+Legs-Slot2	Empty	0	0	0
+Legs-Slot7	Empty	0	0	0
+Legs-Slot8	Empty	0	0	0
+Legs-Slot9	Empty	0	0	0
+Legs-Slot10	Empty	0	0	0
+Feet	Midnight Clad Footwraps +2	177800	1	10
+Feet-Slot1	Empty	0	0	0
+Feet-Slot7	Empty	0	0	0
+Feet-Slot8	Empty	0	0	0
+Waist	Belt of Iniquity +3	2918	1	10
+Waist-Slot7	Empty	0	0	0
+Waist-Slot8	Empty	0	0	0
+Waist-Slot9	Empty	0	0	0
+Any Slot	Midnight Clad Straps	177795	1	10
+Any Slot-Slot1	Empty	0	0	0
+Ammo	Empty	0	0	0
+General 1	Treasure Hunter`s Satchel	17702	1	10
+General 1-Slot1	Iron Ration	13005	32	10
+General 1-Slot2	Spiroc Wingblade	20679	1	10
+General 1-Slot2-Slot2	Empty	0	0	0
+General 1-Slot3	Bone Chips	13073	164	10
+General 1-Slot4	Tiny Dagger	13080	23	10
+General 1-Slot5	Journeyman's Boots +1	2300	1	10
+General 1-Slot5-Slot2	Empty	0	0	0
+General 1-Slot5-Slot7	Empty	0	0	0
+General 1-Slot6	Rod of Infinite Thought	11574	1	10
+General 1-Slot6-Slot2	Empty	0	0	0
+General 1-Slot7	Prayers of Life	11631	1	10
+General 1-Slot8	Fish Scales	13076	100	10
+General 1-Slot9	Guise of the Deceived	177948	1	10
+General 1-Slot10	Fish Scales	13076	84	10
+General 2	Treasure Hunter`s Satchel	17702	1	10
+General 2-Slot1	Void-Touched Potential	148600	1	10
+General 2-Slot2	Void-Touched Potential	148600	1	10
+General 2-Slot3	Shield of the Stalwart Seas	11552	1	10
+General 2-Slot3-Slot2	Empty	0	0	0
+General 2-Slot4	Turmoil Warts	8331	1	10
+General 2-Slot5	Gnoll Fang	13915	23	10
+General 2-Slot6	Efreeti Zweihander +1	20725	1	10
+General 2-Slot6-Slot2	Empty	0	0	0
+General 2-Slot6-Slot7	Empty	0	0	0
+General 2-Slot7	Decrepit Hide	14371	1	10
+General 2-Slot8	Mithril Vambraces	4411	1	10
+General 2-Slot8-Slot2	Empty	0	0	0
+General 2-Slot9	Talisman of Kejaar Kerrath +4	177931	1	10
+General 2-Slot9-Slot1	Empty	0	0	0
+General 2-Slot9-Slot7	Empty	0	0	0
+General 2-Slot9-Slot8	Empty	0	0	0
+General 2-Slot9-Slot9	Empty	0	0	0
+General 2-Slot9-Slot10	Empty	0	0	0
+General 2-Slot10	Fae Pauldrons +2	20710	1	10
+General 2-Slot10-Slot7	Empty	0	0	0
+General 2-Slot10-Slot8	Empty	0	0	0
+General 3	Kavruul`s Mystic Pouch	17701	1	10
+General 3-Slot1	Obtenebrate Mithril Guard	11678	1	10
+General 3-Slot1-Slot2	Empty	0	0	0
+General 3-Slot2	Finely Woven Cloth Cord	20768	1	10
+General 3-Slot3	Silken Wrap	20800	1	10
+General 3-Slot4	Symbol of Marr +1	12800	1	10
+General 3-Slot4-Slot7	Empty	0	0	0
+General 3-Slot5	Djinni War Blade	20980	1	10
+General 3-Slot5-Slot2	Empty	0	0	0
+General 3-Slot6	Bracelet of Cessation +1	12804	1	10
+General 3-Slot6-Slot2	Empty	0	0	0
+General 3-Slot6-Slot7	Empty	0	0	0
+General 3-Slot7	Leather Cord	20835	1	10
+General 3-Slot8	Woven Skull Cap	20744	1	10
+General 3-Slot8-Slot2	Empty	0	0	0
+General 3-Slot9	Efreeti Zweihander	20725	1	10
+General 3-Slot9-Slot2	Empty	0	0	0
+General 3-Slot10	Mantle of Woven Grass +1	20731	1	10
+General 3-Slot10-Slot7	Empty	0	0	0
+General 4	Kavruul`s Mystic Pouch	17701	1	10
+General 4-Slot1	Cracked Leather Eyepatch	20796	1	10
+General 4-Slot2	Spiroc Elder's Totem	20867	1	10
+General 4-Slot3	Silver Hoop	20807	1	10
+General 4-Slot4	Treant Tear +1	12801	1	10
+General 4-Slot4-Slot7	Empty	0	0	0
+General 4-Slot5	Stein of Flowing Ichor	12802	1	10
+General 4-Slot6	Whitened Treant Fists +2	6502	1	10
+General 4-Slot6-Slot2	Empty	0	0	0
+General 4-Slot6-Slot7	Empty	0	0	0
+General 4-Slot6-Slot8	Empty	0	0	0
+General 4-Slot7	Bixie Sword Blade	20722	1	10
+General 4-Slot7-Slot2	Empty	0	0	0
+General 4-Slot8	Amethyst Amulet	20750	1	10
+General 4-Slot9	Bloodsky Sapphire	20996	1	10
+General 4-Slot10	White Satin Gloves +3	2923	1	10
+General 4-Slot10-Slot2	Empty	0	0	0
+General 4-Slot10-Slot7	Empty	0	0	0
+General 4-Slot10-Slot8	Empty	0	0	0
+General 4-Slot10-Slot9	Empty	0	0	0
+General 5	Light Burlap Sack	17353	1	8
+General 5-Slot1	Swirling Mist	22523	1	10
+General 5-Slot2	Efreeti Statuette	20951	1	10
+General 5-Slot3	Golden Efreeti Turban +1	4341	1	10
+General 5-Slot3-Slot2	Empty	0	0	0
+General 5-Slot3-Slot7	Empty	0	0	0
+General 5-Slot4	Golden Efreeti Bracers	4344	1	10
+General 5-Slot4-Slot2	Empty	0	0	0
+General 5-Slot5	Efreeti Belt +1	20976	1	10
+General 5-Slot5-Slot7	Empty	0	0	0
+General 5-Slot6	Efreeti Mace +1	20816	1	10
+General 5-Slot6-Slot2	Empty	0	0	0
+General 5-Slot6-Slot7	Empty	0	0	0
+General 5-Slot7	Bracelet of Exertion +1	12805	1	10
+General 5-Slot7-Slot2	Empty	0	0	0
+General 5-Slot7-Slot7	Empty	0	0	0
+General 5-Slot8	Efreeti Magi Staff	20870	1	10
+General 5-Slot8-Slot2	Empty	0	0	0
+General 6	Light Burlap Sack	17353	1	8
+General 6-Slot1	Efreeti War Axe	20711	1	10
+General 6-Slot1-Slot2	Empty	0	0	0
+General 6-Slot2	Efreeti Wind Staff	20779	1	10
+General 6-Slot2-Slot2	Empty	0	0	0
+General 6-Slot3	Efreeti War Horn	20830	1	10
+General 6-Slot4	Efreeti War Maul	20846	1	10
+General 6-Slot4-Slot2	Empty	0	0	0
+General 6-Slot5	Spiroc Air Totem	20975	1	10
+General 6-Slot6	Efreeti War Bow +1	20861	1	10
+General 6-Slot6-Slot2	Empty	0	0	0
+General 6-Slot6-Slot7	Empty	0	0	0
+General 6-Slot7	Efreeti Magi Staff	20870	1	10
+General 6-Slot7-Slot2	Empty	0	0	0
+General 6-Slot8	Fine Wool Cloak	20991	1	10
+General 7	Light Burlap Sack	17353	1	8
+General 7-Slot1	Bracelet of Distortion +2	12803	1	10
+General 7-Slot1-Slot2	Empty	0	0	0
+General 7-Slot1-Slot7	Empty	0	0	0
+General 7-Slot1-Slot8	Empty	0	0	0
+General 7-Slot2	Efreeti Scimitar	20739	1	10
+General 7-Slot2-Slot2	Empty	0	0	0
+General 7-Slot3	Glowing Necklace	20776	1	10
+General 7-Slot4	Tear of Quellious	20805	1	10
+General 7-Slot5	Polished Brass Key	20632	1	10
+General 7-Slot6	Scuffed Silver Key	20633	1	10
+General 7-Slot7	Small Stone Key	20631	1	10
+General 7-Slot8	Cracked Glass Key	20634	1	10
+General 8	Light Burlap Sack	17353	1	8
+General 8-Slot1	Guard's Keyring	20443	1	10
+General 8-Slot2	Bloodstained Key	20444	1	10
+General 8-Slot3	Golden Crescent Key	20445	1	10
+General 8-Slot4	Shiny Metal Key	20441	1	10
+General 8-Slot5	Smoked Glass Key	20363	1	10
+General 8-Slot6	Dull Bone Key	20442	1	10
+General 8-Slot7	Splintered Wooden Key	20361	1	10
+General 8-Slot8	Charred Bone Key	20362	1	10
+General 9	Empty	0	0	0
+General 10	Empty	0	0	0
+General 11	Empty	0	0	0
+General 12	Empty	0	0	0
+Held	Empty	0	0	0
+Bank1	Backpack	17005	1	8
+Bank1-Slot1	Throwing Boulder +7	8013	1	10
+Bank1-Slot1-Slot7	Empty	0	0	0
+Bank1-Slot1-Slot8	Empty	0	0	0
+Bank1-Slot1-Slot9	Empty	0	0	0
+Bank1-Slot1-Slot10	Empty	0	0	0
+Bank1-Slot2	Gloomwater Arrow +5	8716	1	10
+Bank1-Slot2-Slot7	Empty	0	0	0
+Bank1-Slot2-Slot8	Empty	0	0	0
+Bank1-Slot2-Slot9	Empty	0	0	0
+Bank1-Slot2-Slot10	Empty	0	0	0
+Bank1-Slot3	Turmoil Warts +2	8331	1	10
+Bank1-Slot3-Slot7	Empty	0	0	0
+Bank1-Slot3-Slot8	Empty	0	0	0
+Bank1-Slot4	Eye of Kor	10524	1	10
+Bank1-Slot5	Prickly Pear	10195	4	10
+Bank1-Slot6	Empty	0	0	0
+Bank1-Slot7	Mermaid Scale	16542	7	10
+Bank1-Slot8	Kedge Cave Crystals	20691	1	10
+Bank2	Backpack	17005	1	8
+Bank2-Slot1	Empty	0	0	0
+Bank2-Slot2	Crystalline Orb +1	10218	1	10
+Bank2-Slot2-Slot7	Empty	0	0	0
+Bank2-Slot3	Empty	0	0	0
+Bank2-Slot4	Empty	0	0	0
+Bank2-Slot5	Empty	0	0	0
+Bank2-Slot6	Hierophant`s Crook +3	11629	1	10
+Bank2-Slot6-Slot2	Empty	0	0	0
+Bank2-Slot6-Slot7	Empty	0	0	0
+Bank2-Slot6-Slot8	Empty	0	0	0
+Bank2-Slot6-Slot9	Empty	0	0	0
+Bank2-Slot7	Tarnished Ancient Tiara +6	177945	1	10
+Bank2-Slot7-Slot1	Empty	0	0	0
+Bank2-Slot7-Slot7	Tarnished Ancient Tiara (Exaltation)	177945	1	10
+Bank2-Slot7-Slot8	Empty	0	0	0
+Bank2-Slot7-Slot9	Empty	0	0	0
+Bank2-Slot7-Slot10	Empty	0	0	0
+Bank2-Slot8	Vexthorne	11557	1	10
+Bank2-Slot8-Slot2	Empty	0	0	0
+Bank3	Backpack*	32601	1	8
+Bank3-Slot1	Empty	0	0	0
+Bank3-Slot2	Robe of the Keeper +2	1345	1	10
+Bank3-Slot2-Slot2	Empty	0	0	0
+Bank3-Slot2-Slot7	Empty	0	0	0
+Bank3-Slot2-Slot8	Empty	0	0	0
+Bank3-Slot3	Green Silken Drape +2	1412	1	10
+Bank3-Slot3-Slot2	Empty	0	0	0
+Bank3-Slot3-Slot7	Green Silken Drape (Exaltation)	1412	1	10
+Bank3-Slot3-Slot8	Empty	0	0	0
+Bank3-Slot4	Short Sword of the Ykesha	5500	1	10
+Bank3-Slot4-Slot2	Empty	0	0	0
+Bank3-Slot5	Noble's Robes +4	1891	1	10
+Bank3-Slot5-Slot2	Empty	0	0	0
+Bank3-Slot5-Slot7	Empty	0	0	0
+Bank3-Slot5-Slot8	Empty	0	0	0
+Bank3-Slot5-Slot9	Empty	0	0	0
+Bank3-Slot5-Slot10	Empty	0	0	0
+Bank3-Slot6	Shining Metallic Robes +2	1360	1	10
+Bank3-Slot6-Slot2	Empty	0	0	0
+Bank3-Slot6-Slot7	Empty	0	0	0
+Bank3-Slot6-Slot8	Empty	0	0	0
+Bank3-Slot7	Flowing Black Robe +1	1320	1	10
+Bank3-Slot7-Slot2	Empty	0	0	0
+Bank3-Slot7-Slot7	Flowing Black Robe (Exaltation)	1320	1	10
+Bank3-Slot8	Cape of Midnight Mist +4	1407	1	10
+Bank3-Slot8-Slot7	Cape of Midnight Mist (Exaltation)	1407	1	10
+Bank3-Slot8-Slot8	Empty	0	0	0
+Bank3-Slot8-Slot9	Empty	0	0	0
+Bank3-Slot8-Slot10	Empty	0	0	0
+Bank4	Bag of Sewn Evil-Eye	17354	1	8
+Bank4-Slot1	Crystalline Spear	11610	1	10
+Bank4-Slot1-Slot2	Empty	0	0	0
+Bank4-Slot2	Empty	0	0	0
+Bank4-Slot3	Empty	0	0	0
+Bank4-Slot4	Empty	0	0	0
+Bank4-Slot5	Empty	0	0	0
+Bank4-Slot6	Empty	0	0	0
+Bank4-Slot7	Empty	0	0	0
+Bank4-Slot8	Empty	0	0	0
+Bank5	Backpack	17005	1	8
+Bank5-Slot1	Desecrated Kejaar Totem	177929	1	10
+Bank5-Slot2	The Idol	12317	1	10
+Bank5-Slot3	Rod	14354	1	10
+Bank5-Slot4	Scepter	14364	1	10
+Bank5-Slot5	Torn Brown Shirt* +1	13570	1	10
+Bank5-Slot5-Slot2	Empty	0	0	0
+Bank5-Slot5-Slot7	Empty	0	0	0
+Bank5-Slot6	Painbringer +2	5410	1	10
+Bank5-Slot6-Slot2	Empty	0	0	0
+Bank5-Slot6-Slot7	Empty	0	0	0
+Bank5-Slot6-Slot8	Empty	0	0	0
+Bank5-Slot7	Parchment of Flayed Skin	18110	1	10
+Bank5-Slot8	Spiroc Wingblade	20679	1	10
+Bank5-Slot8-Slot2	Empty	0	0	0
+Bank6	Backpack	17005	1	8
+Bank6-Slot1	Fleshripper +2	5411	1	10
+Bank6-Slot1-Slot2	Empty	0	0	0
+Bank6-Slot1-Slot7	Empty	0	0	0
+Bank6-Slot1-Slot8	Empty	0	0	0
+Bank6-Slot2	Verishe Mal Greataxe +2	177918	1	10
+Bank6-Slot2-Slot1	Empty	0	0	0
+Bank6-Slot2-Slot7	Empty	0	0	0
+Bank6-Slot2-Slot8	Empty	0	0	0
+Bank6-Slot3	Executioner's Axe +1	5407	1	10
+Bank6-Slot3-Slot2	Empty	0	0	0
+Bank6-Slot3-Slot7	Empty	0	0	0
+Bank6-Slot4	Lamentation Blade +2	5424	1	10
+Bank6-Slot4-Slot2	Empty	0	0	0
+Bank6-Slot4-Slot7	Empty	0	0	0
+Bank6-Slot4-Slot8	Empty	0	0	0
+Bank6-Slot5	Dark Reaver	5404	1	10
+Bank6-Slot5-Slot2	Empty	0	0	0
+Bank6-Slot6	Silver Plated War Sword +5	1876	1	10
+Bank6-Slot6-Slot2	Empty	0	0	0
+Bank6-Slot6-Slot7	Empty	0	0	0
+Bank6-Slot6-Slot8	Empty	0	0	0
+Bank6-Slot6-Slot9	Empty	0	0	0
+Bank6-Slot6-Slot10	Empty	0	0	0
+Bank6-Slot7	Ebon Scythe +5	1871	1	10
+Bank6-Slot7-Slot2	Empty	0	0	0
+Bank6-Slot7-Slot7	Empty	0	0	0
+Bank6-Slot7-Slot8	Empty	0	0	0
+Bank6-Slot7-Slot9	Empty	0	0	0
+Bank6-Slot7-Slot10	Empty	0	0	0
+Bank6-Slot8	Empty	0	0	0
+Bank7	Backpack*	32601	1	8
+Bank7-Slot1	Thick Banded Belt +1	2406	1	10
+Bank7-Slot1-Slot7	Empty	0	0	0
+Bank7-Slot2	Golden Chitin Bracer	4408	1	10
+Bank7-Slot2-Slot2	Empty	0	0	0
+Bank7-Slot3	Mithril Vambraces +2	4411	1	10
+Bank7-Slot3-Slot2	Empty	0	0	0
+Bank7-Slot3-Slot7	Empty	0	0	0
+Bank7-Slot3-Slot8	Empty	0	0	0
+Bank7-Slot4	Cloak of Spiroc Feathers	1278	1	10
+Bank7-Slot5	Empty	0	0	0
+Bank7-Slot6	McVaxius` Horn of War	11607	1	10
+Bank7-Slot7	Sharpshooter's Bandana +4	177819	1	10
+Bank7-Slot7-Slot1	Empty	0	0	0
+Bank7-Slot7-Slot7	Empty	0	0	0
+Bank7-Slot7-Slot8	Empty	0	0	0
+Bank7-Slot7-Slot9	Empty	0	0	0
+Bank7-Slot7-Slot10	Empty	0	0	0
+Bank7-Slot8	Efreeti War Horn	20830	1	10
+Bank8	Bag of Sewn Evil-Eye	17354	1	8
+Bank8-Slot1	Empty	0	0	0
+Bank8-Slot2	Empty	0	0	0
+Bank8-Slot3	Empty	0	0	0
+Bank8-Slot4	Empty	0	0	0
+Bank8-Slot5	Empty	0	0	0
+Bank8-Slot6	Empty	0	0	0
+Bank8-Slot7	Woven Shadow Vambraces +1	4903	1	10
+Bank8-Slot7-Slot2	Empty	0	0	0
+Bank8-Slot7-Slot7	Empty	0	0	0
+Bank8-Slot8	Empty	0	0	0
+Bank9	Backpack	17005	1	8
+Bank9-Slot1	Torn, Burnt Book	19071	1	10
+Bank9-Slot2	Whitened Treant Fists +2	6502	1	10
+Bank9-Slot2-Slot2	Empty	0	0	0
+Bank9-Slot2-Slot7	Empty	0	0	0
+Bank9-Slot2-Slot8	Empty	0	0	0
+Bank9-Slot3	Staff of Writhing +3	6404	1	10
+Bank9-Slot3-Slot2	Empty	0	0	0
+Bank9-Slot3-Slot7	Empty	0	0	0
+Bank9-Slot3-Slot8	Empty	0	0	0
+Bank9-Slot3-Slot9	Empty	0	0	0
+Bank9-Slot4	Ashenwood Short Spear +4	7308	1	10
+Bank9-Slot4-Slot2	Empty	0	0	0
+Bank9-Slot4-Slot7	Empty	0	0	0
+Bank9-Slot4-Slot8	Empty	0	0	0
+Bank9-Slot4-Slot9	Empty	0	0	0
+Bank9-Slot4-Slot10	Ashenwood Short Spear (Exaltation)	7308	1	10
+Bank9-Slot5	Gold Plated Koshigatana +2	11630	1	10
+Bank9-Slot5-Slot2	Empty	0	0	0
+Bank9-Slot5-Slot7	Empty	0	0	0
+Bank9-Slot5-Slot8	Empty	0	0	0
+Bank9-Slot6	Eyerazzia +2	7508	1	10
+Bank9-Slot6-Slot2	Empty	0	0	0
+Bank9-Slot6-Slot7	Empty	0	0	0
+Bank9-Slot6-Slot8	Empty	0	0	0
+Bank9-Slot7	Stiletto of the Bloodclaw +6	7312	1	10
+Bank9-Slot7-Slot2	Empty	0	0	0
+Bank9-Slot7-Slot7	Empty	0	0	0
+Bank9-Slot7-Slot8	Empty	0	0	0
+Bank9-Slot7-Slot9	Empty	0	0	0
+Bank9-Slot7-Slot10	Stiletto of the Bloodclaw (Exaltation)	7312	1	10
+Bank9-Slot8	Nautilus Shield +1	9404	1	10
+Bank9-Slot8-Slot2	Empty	0	0	0
+Bank9-Slot8-Slot7	Empty	0	0	0
+Bank10	Backpack*	32601	1	8
+Bank10-Slot1	Empty	0	0	0
+Bank10-Slot2	Efreeti Great Staff +1	20792	1	10
+Bank10-Slot2-Slot2	Empty	0	0	0
+Bank10-Slot2-Slot7	Empty	0	0	0
+Bank10-Slot3	Efreeti Mace	20816	1	10
+Bank10-Slot3-Slot2	Empty	0	0	0
+Bank10-Slot4	Efreeti War Staff	20753	1	10
+Bank10-Slot4-Slot2	Empty	0	0	0
+Bank10-Slot5	Efreeti Magi Staff	20870	1	10
+Bank10-Slot5-Slot2	Empty	0	0	0
+Bank10-Slot6	Empty	0	0	0
+Bank10-Slot7	Efreeti War Axe	20711	1	10
+Bank10-Slot7-Slot2	Empty	0	0	0
+Bank10-Slot8	Empty	0	0	0
+Bank11	Bag of Sewn Evil-Eye	17354	1	8
+Bank11-Slot1	Corrosive Venom	20842	1	10
+Bank11-Slot2	Silken Wrap	20800	1	10
+Bank11-Slot3	Wind Tablet	20978	1	10
+Bank11-Slot4	Nebulous Sapphire	20802	1	10
+Bank11-Slot5	Efreeti Statuette	20951	1	10
+Bank11-Slot6	Corrosive Venom	20842	1	10
+Bank11-Slot7	Griffon Talon	20850	1	10
+Bank11-Slot8	Griffon's Beak	20781	1	10
+Bank12	Bag of Sewn Evil-Eye	17354	1	8
+Bank12-Slot1	Golden Efreeti Chestplate	4342	1	10
+Bank12-Slot1-Slot2	Empty	0	0	0
+Bank12-Slot2	Efreeti Magi Staff	20870	1	10
+Bank12-Slot2-Slot2	Empty	0	0	0
+Bank12-Slot3	Empty	0	0	0
+Bank12-Slot4	Empty	0	0	0
+Bank12-Slot5	Empty	0	0	0
+Bank12-Slot6	Empty	0	0	0
+Bank12-Slot7	Empty	0	0	0
+Bank12-Slot8	Empty	0	0	0
+Bank13	Backpack	17005	1	8
+Bank13-Slot1	Symbol of Marr +3	12800	1	10
+Bank13-Slot1-Slot7	Empty	0	0	0
+Bank13-Slot1-Slot8	Empty	0	0	0
+Bank13-Slot1-Slot9	Empty	0	0	0
+Bank13-Slot2	Circlet of Brambles +1	20860	1	10
+Bank13-Slot2-Slot2	Empty	0	0	0
+Bank13-Slot2-Slot7	Empty	0	0	0
+Bank13-Slot3	Stein of Flowing Ichor +2	12802	1	10
+Bank13-Slot3-Slot7	Empty	0	0	0
+Bank13-Slot3-Slot8	Empty	0	0	0
+Bank13-Slot4	Treant Tear +3	12801	1	10
+Bank13-Slot4-Slot7	Empty	0	0	0
+Bank13-Slot4-Slot8	Empty	0	0	0
+Bank13-Slot4-Slot9	Empty	0	0	0
+Bank13-Slot5	Bracelet of Exertion +3	12805	1	10
+Bank13-Slot5-Slot2	Empty	0	0	0
+Bank13-Slot5-Slot7	Empty	0	0	0
+Bank13-Slot5-Slot8	Empty	0	0	0
+Bank13-Slot5-Slot9	Empty	0	0	0
+Bank13-Slot6	Bracelet of Cessation +2	12804	1	10
+Bank13-Slot6-Slot2	Empty	0	0	0
+Bank13-Slot6-Slot7	Empty	0	0	0
+Bank13-Slot6-Slot8	Empty	0	0	0
+Bank13-Slot7	Bracelet of Distortion +1	12803	1	10
+Bank13-Slot7-Slot2	Empty	0	0	0
+Bank13-Slot7-Slot7	Empty	0	0	0
+Bank13-Slot8	White Satin Gloves +3	2923	1	10
+Bank13-Slot8-Slot2	Empty	0	0	0
+Bank13-Slot8-Slot7	Empty	0	0	0
+Bank13-Slot8-Slot8	Empty	0	0	0
+Bank13-Slot8-Slot9	Empty	0	0	0
+Bank14	Backpack	17005	1	8
+Bank14-Slot1	Cracked Leather Eyepatch +1	20796	1	10
+Bank14-Slot1-Slot7	Empty	0	0	0
+Bank14-Slot2	Djinni Stave	20765	1	10
+Bank14-Slot2-Slot2	Empty	0	0	0
+Bank14-Slot3	Small Shield	20809	1	10
+Bank14-Slot3-Slot2	Empty	0	0	0
+Bank14-Slot4	Mithril Bands	20819	1	10
+Bank14-Slot5	Ring of Veeshan	20789	1	10
+Bank14-Slot6	Empty	0	0	0
+Bank14-Slot7	Grey Damask Cloak	20742	1	10
+Bank14-Slot8	Brass Knuckles +1	20803	1	10
+Bank14-Slot8-Slot2	Empty	0	0	0
+Bank14-Slot8-Slot7	Empty	0	0	0
+Bank15	Bag of Sewn Evil-Eye	17354	1	8
+Bank15-Slot1	Efreeti Scimitar	20739	1	10
+Bank15-Slot1-Slot2	Empty	0	0	0
+Bank15-Slot2	Efreeti Wind Staff	20779	1	10
+Bank15-Slot2-Slot2	Empty	0	0	0
+Bank15-Slot3	Efreeti Scimitar	20739	1	10
+Bank15-Slot3-Slot2	Empty	0	0	0
+Bank15-Slot4	Efreeti Mace +1	20816	1	10
+Bank15-Slot4-Slot2	Empty	0	0	0
+Bank15-Slot4-Slot7	Empty	0	0	0
+Bank15-Slot5	Efreeti Battle Axe	20983	1	10
+Bank15-Slot5-Slot2	Empty	0	0	0
+Bank15-Slot6	Efreeti War Maul	20846	1	10
+Bank15-Slot6-Slot2	Empty	0	0	0
+Bank15-Slot7	Efreeti Battle Axe	20983	1	10
+Bank15-Slot7-Slot2	Empty	0	0	0
+Bank15-Slot8	Efreeti Standard	20817	1	10
+Bank15-Slot8-Slot2	Empty	0	0	0
+Bank16	Bag of Sewn Evil-Eye	17354	1	8
+Bank16-Slot1	Light Burlap Sack	17353	1	8
+Bank16-Slot1-Slot1	Empty	0	0	0
+Bank16-Slot1-Slot2	Empty	0	0	0
+Bank16-Slot1-Slot3	Empty	0	0	0
+Bank16-Slot1-Slot4	Empty	0	0	0
+Bank16-Slot1-Slot5	Empty	0	0	0
+Bank16-Slot1-Slot6	Empty	0	0	0
+Bank16-Slot1-Slot7	Empty	0	0	0
+Bank16-Slot1-Slot8	Empty	0	0	0
+Bank16-Slot2	Light Burlap Sack	17353	1	8
+Bank16-Slot2-Slot1	Empty	0	0	0
+Bank16-Slot2-Slot2	Empty	0	0	0
+Bank16-Slot2-Slot3	Empty	0	0	0
+Bank16-Slot2-Slot4	Empty	0	0	0
+Bank16-Slot2-Slot5	Empty	0	0	0
+Bank16-Slot2-Slot6	Empty	0	0	0
+Bank16-Slot2-Slot7	Empty	0	0	0
+Bank16-Slot2-Slot8	Empty	0	0	0
+Bank16-Slot3	Light Burlap Sack	17353	1	8
+Bank16-Slot3-Slot1	Empty	0	0	0
+Bank16-Slot3-Slot2	Empty	0	0	0
+Bank16-Slot3-Slot3	Empty	0	0	0
+Bank16-Slot3-Slot4	Empty	0	0	0
+Bank16-Slot3-Slot5	Empty	0	0	0
+Bank16-Slot3-Slot6	Empty	0	0	0
+Bank16-Slot3-Slot7	Empty	0	0	0
+Bank16-Slot3-Slot8	Empty	0	0	0
+Bank16-Slot4	Shattered Emerald of Corruption	20484	1	10
+Bank16-Slot5	Empty	0	0	0
+Bank16-Slot6	Fleshless Skull	31427	1	10
+Bank16-Slot7	Empty	0	0	0
+Bank16-Slot8	Book of Souls	28016	1	10
+Bank17	Empty	0	0	0
+Bank18	Empty	0	0	0
+Bank19	Empty	0	0	0
+Bank20	Empty	0	0	0
+Bank21	Empty	0	0	0
+Bank22	Empty	0	0	0
+Bank23	Empty	0	0	0
+Bank24	Empty	0	0	0
+SharedBank1	Empty	0	0	0
+SharedBank2	Empty	0	0	0
+SharedBank3	Empty	0	0	0
+SharedBank4	Empty	0	0	0
+SharedBank5	Empty	0	0	0
+SharedBank6	Empty	0	0	0
+
+KeyRing	Name	ID	
+Augmentation	Sharkskin Drum (Exaltation)	10373
+Augmentation	Minotaur Horn (Exaltation)	13077
+Augmentation	Golem Metal Wand (Exaltation)	14313
+Augmentation	Moonstone Ring (Exaltation)	10150
+Augmentation	Cat o' Nine Tails (Exaltation)	5058
+Augmentation	Guise of the Deceiver (Exaltation)	2469
+Equipment	Gnoll Hide Tome +1	13500
+Equipment	Carmine Robe	1226
+Equipment	Crown of King Tranix +1	4504
+Equipment	Splitpaw Keepsake Ring +4	177920
+Equipment	Unholy Steed	77443
+Equipment	The Baron's Blade +6	177773
+Equipment	Sleeves of the Spurned Necromancer +4	177841
+Equipment	Bracelet of Quiescence +2	12806
+Equipment	Insidious Gloves +2	1250
+Equipment	Enchanted Fine Steel Morning Star +5	5214
+Equipment	Signet Ring of the Lost Crusader +6	177838
+Equipment	Swirlspine Belt	2471
+Equipment	Silken Mask +1	20772
+Equipment	Gloomwater Harpoon +5	7407
+Equipment	Golden Efreeti Boots +4	4407
+Equipment	Sword of the Lost +4	177837
+Equipment	Truewind Earring	14563
+Equipment	Girdle of the Diligent	2500
+Equipment	Weight of the Gods +3	2924
+Equipment	Clawed Knuckle-Ring +5	10403
+Equipment	Belt of Concordance +3	2920
+Equipment	Rune Etched Greaves +1	4876
+Equipment	Carnal Pauldrons +2	4405
+Equipment	Hooded Black Cloak +4	1409
+Equipment	Woven Shadow Greaves +2	4906
+Equipment	Imbrued Platemail Greaves +1	4866
+Equipment	Tunarian Scimitar	11563
+Equipment	Vermiculated Leggings	3806
+Equipment	Cryosilk Lined Shoes +2	1222
+Equipment	Neriak Ceremonial Robe +3	1527
+Equipment	Cryosilk Amice +1	1215
+Equipment	Rune Etched Helm +2	4871
+Equipment	Imbrued Platemail Vambraces +2	4863
+Equipment	Rune Etched Boots	4877
+Equipment	Imbrued Platemail Bracer	4864
+Equipment	Apothic Kilt +2	1244
+Equipment	Indicolite Vambraces +2	4913
+Equipment	Lustrous Russet Vambraces +1	4833
+Equipment	Carmine Turban	1225
+Equipment	Belt of the Pine +4	2916
+Equipment	Lustrous Russet Gauntlets	4835
+Equipment	Indicolite Boots +1	4917
+Equipment	Cryosilk Veil	1212
+Equipment	Insidious Manacle +1	1249
+Equipment	Ethereal Mist Boots	4887
+Equipment	Executioners Hood +2	2468
+Equipment	Belt of Virtue +3	2919
+Equipment	Indicolite Gauntlets +2	4915
+Equipment	Rune Etched Gauntlets +2	4875
+Equipment	Imbrued Platemail Gauntlets +1	4865
+Equipment	Rune Etched Chestplate +2	4872
+Equipment	Woven Shadow Chestplate	4902
+Equipment	Woven Shadow Boots +2	4907
+Equipment	Shadow Rage Gloves	55605
+Equipment	Woven Shadow Bracer +1	4904
+Equipment	Umbral Platemail Bracer +1	4844
+Equipment	Thorny Vine Gauntlets	4895
+Equipment	Imbrued Platemail Breastplate +1	4862
+Equipment	Umbral Platemail Gauntlets +2	4845
+Equipment	Cryosilk Choker +1	1213
+Equipment	Insidious Sleeves +2	1248
+Equipment	Shiverback-Hide Wristbands +1	1203
+Equipment	Midnight Clad Wristbands +2	177797
+Equipment	Carmine Boots	1231
+Equipment	Apothic Robe	1240
+Equipment	Shiverback-Hide Jerkin	1201
+Equipment	Carmine Gloves	1229
+Equipment	Vermiculated Gloves	3805
+Equipment	Shiverback-Hide Gloves +2	1204
+Equipment	Vermiculated Tunic	3802
+Equipment	Belt of Tranquility +4	2917
+Equipment	Carmine Trinket +2	1228
+Equipment	Prismatic Shield	9405
+Equipment	Thorny Vine Vambraces +1	4893
+Equipment	Spitestone Shield	9407
+Equipment	Shadow Rage Helm +1	55601
+Equipment	Blighted Armband +1	1235
+Equipment	Midnight Clad Armbands	177796
+Equipment	Indicolite Bracer +2	4914
+Equipment	Umbral Platemail Vambraces +1	4843
+Equipment	Rune Etched Vambraces +1	4873
+Equipment	Runed Mithril Bracer +1	4406
+Equipment	Ethereal Mist Greaves +1	4886
+Equipment	Seahorse Scale Cloak +1	3403
+Equipment	Flayed Turmoilskin Belt	2502
+Equipment	Pristine Studded Leather Tunic +8	1880
+Equipment	Pristine Studded Leather Gloves +5	1885
+Equipment	Valorium Boots	4857
+Equipment	Apothic Warband +1	1242
+Equipment	Apothic Sleeves	1241
+Equipment	Imbrued Platemail Helm +2	4861
+Equipment	Adamantite Epaulets +1	4402
+Equipment	Encyclopedia Necrotheurgia +1	11571
+Equipment	Leatherfoot Sandals	1534
+Equipment	Lustrous Russet Greaves	4836
+Equipment	Indicolite Greaves +1	4916
+Equipment	Imbrued Platemail Boots +1	4867
+Equipment	Carmine Pants +1	1230
+Equipment	Valorium Greaves	4856
+Equipment	Valorium Vambraces	4853
+Equipment	Anthemion Skullcap +1	7835
+Equipment	Shadow Rage Wristguard +1	55604
+Equipment	Midnight Clad Headband	177801
+Equipment	Vermiculated Bracelet	3804
+Equipment	Eye of Innoruuk +2	20656
+Equipment	Vermiculated Armplates +1	3803
+Equipment	Ethereal Mist Vambraces +1	4883
+Equipment	Truesight Hammer	11565
+Equipment	Blighted Sleeves	1234
+Equipment	Insidious Halo	1246
+Equipment	Theologian Claymore	5519
+Equipment	Sunderfury	11550
+Equipment	Shrieking Ahlspiess +1	7507
+Equipment	Evensong	11554
+Equipment	Anthemion Armbands +2	7834
+Equipment	Apothic Gloves	1243
+Equipment	Kelin`s Seven Stringed Lute	11573
+Equipment	Staff of Elemental Mastery: Earth	11567


### PR DESCRIPTION
Five asks, three of which turned out to be something other than they looked. Branched from `main` at 5c4866c; `check.ps1` green — build, 2,599 unit, 281 Avalonia.

Two of these were already built and needed finding rather than writing, so the diff is smaller than the list suggests.

## 1. Shadow Knight Sky rewards were being dropped silently

The dump writes `Primary Class Unlock - Shadowknight`; every catalog here writes `Shadow Knight`. `AchievementsImport.SkyRewards` compared them exactly, found no rows, and hit `if (rewards.Count == 0) continue` — dropping all sixteen Shadow Knight rewards **before** the #101 auto-grant guard, before the matcher, and before `unmatched`, whose whole job is that nothing is swallowed. Fifteen classes spell identically, so only a Shadow Knight could ever see it.

`QuestClassFilter.Canonical` is the resolver, on the type that already owns the class names and their codes. It is a rule — compare ignoring non-alphanumerics — not an alias list, so `Shadow-Knight` is covered before anyone reports it. `GearLocker`'s private code map, which carried **both** spellings while the code doing the comparing had neither, is retired to it (trap 4).

Two more on the same route:

- **A ticked Sky reward did not tick its Sky Test quest.** The Sky tab reads `SkyQuestCompleted`; the Quests tab read the per-character ledger keyed on quest name, and nothing joined them. `SkyTestSplit` now owns both directions of the mapping and folds turn-ins in on **read**; the write side goes to `SkyCompleteToggle`, so the fact keeps one store and un-marking is not undone by the next render. Both desktops and the phone.
- **The Sky tab named no way to produce the dump that feeds it.** A hand-in never appears in the log, so that dump is the only thing that can say a reward was turned in before EQBuddy existed. Copy button added above the rows (trap 44), with its rows in `GameCommandsTests.SurfacesNeedingACommand`.

Both tests fail on the pre-fix tree. Fixtures are a real three-dump set (achievements, inventory, faction) from one character.

## 2. The pop-out resize feature was inert

`CanResize` creates no non-client area on a `WindowStyle=None` + `AllowsTransparency` window. Every window that gained resize on 08-21 and 08-25 had `CanResize`, called `AllowResize`, persisted a height on close, and **could not be dragged by hand** — confirmed directly, then measured before and after.

`ResizableWindowTests` asserts a window does not say `NoResize` and that it calls `AllowResize`. Both true throughout: trap 34, a guard that checks for the wrong thing being present cannot see the right thing being absent. A screenshot cannot see it either.

The mechanism was already here. `BreakoutWindow` has had a `WM_NCHITTEST` hook since 2026-08-06, when the same complaint arrived about the loot window, and it was never lifted out. `FramelessResize` is that hook, called from `AllowResize` itself so a window cannot join the feature and miss the affordance. Zone math stays in `ResizeZones`.

Three things that followed:

- **A visible grip**, same accent bar and resource keys as the widget's own `HeightGrip`, shown exactly when a bottom drag would engage.
- **Pop-outs stop opening full-screen.** Each derived its body from the monitor, so a tall display gave the Quest Tracker a 944-unit body — measured at 1822 px. Bevel had already ruled *"386 lu was a cap, not a fill target"* and the code never used a constant. `WindowSizing.BodyCap` is that constant, shared by all seven pop-outs instead of seven copies, still clamped by a small screen, and following the window once dragged. 1822 px → 1006 px.
- **Only a height the player dragged to is stored.** `AllowResize` persisted `ActualHeight` unconditionally, so a close recorded whatever the window happened to measure. One real profile carried four such entries, none of them chosen: `drops` 1224, `gearloot` 200 (the minimum floor, from an empty first frame), `quests` 425, `progress` 493. `WM_EXITSIZEMOVE` after a resize hit code is the native size loop and nothing else — the exact signal trap 49's reverted follower could not get. `MigrateWindowHeights` discards the old values once.

`drag-verify.ps1` takes `-Window` now (it was hardcoded to Progress, which is why six windows shipped unchecked) and phase D drags with a real mouse rather than `SetWindowPos`.

**The `ContentRendered` pin itself is untouched** — still the V2 in flight. This changes only what is persisted, not when the natural height is sampled.

## 3. Unlocks: a fourth Quest Tracker tab

Race and class unlocks from `/outputfile achievements` and `/outputfile faction`. Deity is deliberately absent: sixteen of its seventeen entries in a real dump read *"Future Placeholder for &lt;God&gt; Requirements"*.

**`/outputfile faction` is new to EQBuddy**, and neither the command nor the file it writes is documented anywhere public. Both come from the game's own log:

```
usage: /outputfile [achievements | faction | guild | ... | spellbook ]
Outputfile Complete: Hateborne_neriak-ENC-Factions.txt
```

Singular command, plural file, class code spliced into the middle — so the filename rule is a suffix and never a segment count (trap 48 on a different file).

**No catalog is curated.** The achievements dump states its own requirements, so `UnlockRequirements` reads them. Writing that table out would create a second source of truth competing with eqlwiki, and one somebody maintains forever.

Three things the real data forced:

- **`Bypass` and `Derived` both begin "This achievement will autocomplete"** and mean opposite things — one is a way the unlock can be handed to you, the other a real consequence of real work. Counting either puts "3 of 5" on a race with three. Half Elf, whose only rows are `Derived`, scores null rather than 0/0.
- **A granted unlock's ticks are not evidence, and the pair proves it.** `Race Unlock - Dark Elf` is complete with all three faction criteria flagged complete, while the faction dump written three minutes later reads 0/2000, 5/1995 and 0/2000 for those three. #101/#193 generalised from classes to races.
- **Four of the forty-two race requirement lines name a faction the other dump spells differently** (`Coalition of Tradesfolk`/`Tradefolk`, `Freeport Militia`/`The Freeport Militia`, `Corrupt Qeynos Guard`/`Guards`, `Da Bashers`/`DaBashers`). A rule reaches one; `NamesMatch` reaches none, and loosening it trades four known misses for unknown wrong matches. Rule first, curated list for the rest, unresolved names reported.

**Also fixed, found while wiring it:** both widgets routed the dump announcement with `if (kind == Inventory) … else …`, so adding `OutputfileKind.Factions` fed faction rows to the achievements importer — which finds nothing and then **writes that nothing**, wiping the character's unlocked-class list. Both switch exhaustively now.

The tab strip is a `WrapPanel` on both lanes (trap 25 — a `StackPanel` clips a fourth chip with no ellipsis and no test signal), the class picker is replaced by an All/Races/Classes lens since a class filter would silently hide every race, and both commands sit on the populated surface rather than only in an empty state (#217's rule).

## 4. Alt+Tab, opt-in

`WS_EX_TOOLWINDOW`, off by default, Options → Behavior. The recipe was already in `NoActivate` and `WinClickThrough.SetOverlay`, but both set it **with** `WS_EX_NOACTIVATE` — right for a chip, wrong for any window a player types in.

Two things that are not obvious: it takes the taskbar button with it (one flag, both effects, not separable — so the row names the tray icon), and a live flip needs a hide/show because Windows samples switcher membership at show time. Without that the style changes and nothing visible does, which reads as a dead tick-box (trap 42).

## 5. Hide when the game is not focused — already shipped

`FocusHide` + `HideWhenGameUnfocused` / `HideWhenGameNotRunning` already do exactly this, on both builds, covering every window. **No code.** Left opt-in.

## Flagged rather than fixed here

- **Issue #50 carries a table saying eight windows resize**, posted to the one contributor who cannot run Windows to check — and points him at `AllowResize` as the helper to mirror, which is the half that did not work. He would have reproduced an inert feature on Avalonia. Deliberately left until there is a shipped version to point at.
- **The v1.99.11 Fable review request** discloses the hit-testing risk as unverified. It is now measured, and it materialised.
- **Avalonia pop-outs still do not resize at all** (`CanResize = false`, no `AllowResize`). `BeginResizeDrag` is the proven mechanism there; this PR does not widen that gap but does not close it.
- **Aero Snap does not count as a player resize** — only a border drag sets the flag. Small exposure on frameless windows with no title bar, but real.
- **The Unlocks tab has no screenshot.** `shoot.ps1` has no shot for it yet.

## Housekeeping

- No `WhatsNew.json` entry or version bump — proposed text below, renumber to whatever ships it:
  > **PLANE OF SKY: SHADOW KNIGHT REWARDS NOW IMPORT.** If you play a Shadow Knight, the achievements dump was being read but every one of your Sky rewards was silently skipped — the game spells the class one way and EQBuddy spelled it another. Re-run `/outputfile achievements` and they will fill in. Turning a reward in also marks its Sky Test quest complete on the Quests tab, which it never did before.
  > **QUEST TRACKER: A NEW UNLOCKS TAB.** Race and class unlocks, read from `/outputfile achievements` and `/outputfile faction`, with how far along each race's factions are and a note when an unlock was handed to you rather than earned. Both commands are one click to copy from the tab itself.
  > **POP-OUT WINDOWS CAN BE RESIZED AGAIN.** Progress, Quests, Gear & Loot, Kills & Drops, Spawns, Travel, Session history and the fight timeline had resize turned on but no edge you could actually grab. Drag any edge or corner; a hint appears along the bottom when you are on it. They also stop opening tall enough to fill the screen, and only a size you chose yourself is remembered.
- `docs/TestPlan.md` rows not added — say if you want them in this PR rather than the release that ships it.

— Hateborne, with Claude Code
